### PR TITLE
Add inventory and status modals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 import LevelUpModal from './components/LevelUpModal';
+import InventoryModal from './components/InventoryModal';
+import StatusModal from './components/StatusModal';
 
 // Initial character data based on Zimbo's character sheet
 const INITIAL_CHARACTER_DATA = {
@@ -377,6 +379,56 @@ function App() {
     if (character.statusEffects.includes('frozen')) return 'frozen-overlay';
     if (character.statusEffects.includes('blessed')) return 'blessed-overlay';
     return '';
+  };
+
+  const handleEquipItem = (id) => {
+    setCharacter(prev => ({
+      ...prev,
+      inventory: prev.inventory.map(item =>
+        item.id === id ? { ...item, equipped: !item.equipped } : item
+      )
+    }));
+  };
+
+  const handleConsumeItem = (id) => {
+    setCharacter(prev => ({
+      ...prev,
+      inventory: prev.inventory.reduce((acc, item) => {
+        if (item.id === id) {
+          if (item.quantity && item.quantity > 1) {
+            acc.push({ ...item, quantity: item.quantity - 1 });
+          }
+        } else {
+          acc.push(item);
+        }
+        return acc;
+      }, [])
+    }));
+  };
+
+  const handleDropItem = (id) => {
+    setCharacter(prev => ({
+      ...prev,
+      inventory: prev.inventory.filter(item => item.id !== id)
+    }));
+  };
+
+  const handleToggleStatusEffect = (effect) => {
+    setCharacter(prev => ({
+      ...prev,
+      statusEffects: prev.statusEffects.includes(effect)
+        ? prev.statusEffects.filter(e => e !== effect)
+        : [...prev.statusEffects, effect]
+    }));
+  };
+
+  const handleToggleDebility = (debility) => {
+    setCharacter(prev => ({
+      ...prev,
+      debilities: prev.debilities.includes(debility)
+        ? prev.debilities.filter(d => d !== debility)
+        : [...prev.debilities, debility]
+    }));
   };
 
   const getHeaderColor = () => {
@@ -1086,32 +1138,16 @@ function App() {
   />
 )}
 
-      {/* Other Modal Placeholders */}
       {showStatusModal && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          background: 'rgba(0, 0, 0, 0.8)',
-          zIndex: 1000,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center'
-        }}>
-          <div style={{
-            background: '#1a1a2e',
-            border: '2px solid #00ff88',
-            borderRadius: '15px',
-            padding: '30px',
-            textAlign: 'center'
-          }}>
-            <h2 style={{ color: '#00ff88' }}>💀 Status Effects & Debilities</h2>
-            <p style={{ color: '#aaa', margin: '20px 0' }}>Component coming soon...</p>
-            <button onClick={() => setShowStatusModal(false)} style={buttonStyle}>Close</button>
-          </div>
-        </div>
+        <StatusModal
+          statusEffects={character.statusEffects}
+          debilities={character.debilities}
+          statusEffectTypes={statusEffectTypes}
+          debilityTypes={debilityTypes}
+          onToggleStatusEffect={handleToggleStatusEffect}
+          onToggleDebility={handleToggleDebility}
+          onClose={() => setShowStatusModal(false)}
+        />
       )}
 
       {showDamageModal && (
@@ -1142,30 +1178,13 @@ function App() {
       )}
 
       {showInventoryModal && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          background: 'rgba(0, 0, 0, 0.8)',
-          zIndex: 1000,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center'
-        }}>
-          <div style={{
-            background: '#1a1a2e',
-            border: '2px solid #00ff88',
-            borderRadius: '15px',
-            padding: '30px',
-            textAlign: 'center'
-          }}>
-            <h2 style={{ color: '#00ff88' }}>🎒 Inventory Management</h2>
-            <p style={{ color: '#aaa', margin: '20px 0' }}>Component coming soon...</p>
-            <button onClick={() => setShowInventoryModal(false)} style={buttonStyle}>Close</button>
-          </div>
-        </div>
+        <InventoryModal
+          inventory={character.inventory}
+          onEquip={handleEquipItem}
+          onConsume={handleConsumeItem}
+          onDrop={handleDropItem}
+          onClose={() => setShowInventoryModal(false)}
+        />
       )}
 
       {showBondsModal && (

--- a/src/components/InventoryModal.jsx
+++ b/src/components/InventoryModal.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
+  const overlayStyle = {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    background: 'rgba(0, 0, 0, 0.8)',
+    zIndex: 1000,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  };
+
+  const modalStyle = {
+    background: '#1a1a2e',
+    border: '2px solid #00ff88',
+    borderRadius: '15px',
+    padding: '20px',
+    maxWidth: '500px',
+    width: '100%',
+    maxHeight: '80vh',
+    overflowY: 'auto'
+  };
+
+  const buttonStyle = {
+    background: 'linear-gradient(45deg, #8b5cf6, #7c3aed)',
+    border: 'none',
+    borderRadius: '6px',
+    color: 'white',
+    padding: '5px 10px',
+    cursor: 'pointer',
+    margin: '3px'
+  };
+
+  return (
+    <div style={overlayStyle}>
+      <div style={modalStyle}>
+        <h2 style={{ color: '#00ff88', textAlign: 'center' }}>🎒 Inventory</h2>
+        {inventory.length === 0 ? (
+          <p style={{ color: '#aaa' }}>No items</p>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            {inventory.map(item => (
+              <li key={item.id} style={{ marginBottom: '10px', borderBottom: '1px solid #333', paddingBottom: '10px' }}>
+                <div style={{ color: '#fff', fontWeight: 'bold' }}>
+                  {item.name}{item.quantity ? ` x${item.quantity}` : ''}
+                </div>
+                <div style={{ marginTop: '5px' }}>
+                  {'equipped' in item && (
+                    <button style={buttonStyle} onClick={() => onEquip(item.id)}>
+                      {item.equipped ? 'Unequip' : 'Equip'}
+                    </button>
+                  )}
+                  {item.type === 'consumable' && (
+                    <button style={buttonStyle} onClick={() => onConsume(item.id)}>
+                      Consume
+                    </button>
+                  )}
+                  <button style={buttonStyle} onClick={() => onDrop(item.id)}>
+                    Drop
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div style={{ textAlign: 'center', marginTop: '15px' }}>
+          <button style={buttonStyle} onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InventoryModal;

--- a/src/components/StatusModal.jsx
+++ b/src/components/StatusModal.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+
+const StatusModal = ({
+  statusEffects,
+  debilities,
+  statusEffectTypes,
+  debilityTypes,
+  onToggleStatusEffect,
+  onToggleDebility,
+  onClose
+}) => {
+  const overlayStyle = {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    background: 'rgba(0, 0, 0, 0.8)',
+    zIndex: 1000,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
+  };
+
+  const modalStyle = {
+    background: '#1a1a2e',
+    border: '2px solid #00ff88',
+    borderRadius: '15px',
+    padding: '20px',
+    maxWidth: '500px',
+    width: '100%',
+    maxHeight: '80vh',
+    overflowY: 'auto'
+  };
+
+  const listStyle = { listStyle: 'none', padding: 0 };
+  const itemStyle = { marginBottom: '8px' };
+  const buttonStyle = {
+    background: 'linear-gradient(45deg, #f97316, #ea580c)',
+    border: 'none',
+    borderRadius: '6px',
+    color: 'white',
+    padding: '5px 10px',
+    cursor: 'pointer',
+    marginTop: '10px'
+  };
+
+  return (
+    <div style={overlayStyle}>
+      <div style={modalStyle}>
+        <h2 style={{ color: '#00ff88', textAlign: 'center' }}>💀 Status & Debilities</h2>
+        <div>
+          <h3 style={{ color: '#00ff88' }}>Status Effects</h3>
+          <ul style={listStyle}>
+            {Object.keys(statusEffectTypes).map(key => (
+              <li key={key} style={itemStyle}>
+                <label style={{ color: '#fff' }}>
+                  <input
+                    type="checkbox"
+                    checked={statusEffects.includes(key)}
+                    onChange={() => onToggleStatusEffect(key)}
+                  />{' '}
+                  {statusEffectTypes[key].name}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 style={{ color: '#00ff88' }}>Debilities</h3>
+          <ul style={listStyle}>
+            {Object.keys(debilityTypes).map(key => (
+              <li key={key} style={itemStyle}>
+                <label style={{ color: '#fff' }}>
+                  <input
+                    type="checkbox"
+                    checked={debilities.includes(key)}
+                    onChange={() => onToggleDebility(key)}
+                  />{' '}
+                  {debilityTypes[key].name}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div style={{ textAlign: 'center' }}>
+          <button style={buttonStyle} onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StatusModal;


### PR DESCRIPTION
## Summary
- add modal components for inventory management and status effects
- wire inventory and status modals into App state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: src/components/LevelUpModal.js (258:4): Expression expected)*

------
https://chatgpt.com/codex/tasks/task_e_6897f991499c833287dfa846b58e8722