### PR TITLE
feat: add flexible dice parser and case-insensitive context

### DIFF
--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -1,0 +1,15 @@
+export function parseDiceNotation(formula, rollDie) {
+  const match = formula.trim().match(/^(\d*)d(\d+)([+-]\d+)?$/i);
+  if (!match) {
+    return { error: `Cannot parse dice formula: ${formula}` };
+  }
+  const count = parseInt(match[1] || '1', 10);
+  const sides = parseInt(match[2], 10);
+  const modifier = match[3] ? parseInt(match[3], 10) : 0;
+  if (count <= 0 || sides <= 0) {
+    return { error: `Invalid dice formula: ${formula}` };
+  }
+  const rolls = Array.from({ length: count }, () => rollDie(sides));
+  const total = rolls.reduce((sum, val) => sum + val, 0) + modifier;
+  return { rolls, sides, modifier, total };
+}


### PR DESCRIPTION
## Summary
- add parser for NdM(+/-K) dice formulas with multiple dice and negative modifiers
- normalize roll descriptions to lower case for consistent context checks
- return explicit error when a roll formula cannot be parsed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897f997e4648332b02938182995d1dc