### PR TITLE
Enforce second stat threshold during level up

### DIFF
--- a/src/components/BondsModal.jsx
+++ b/src/components/BondsModal.jsx
@@ -9,7 +9,7 @@ const buttonStyle = {
   cursor: 'pointer',
   fontWeight: 'bold',
   transition: 'all 0.3s ease',
-  margin: '5px'
+  margin: '5px',
 };
 
 export default function BondsModal({ isOpen, onClose }) {
@@ -26,7 +26,7 @@ export default function BondsModal({ isOpen, onClose }) {
         zIndex: 1000,
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center'
+        justifyContent: 'center',
       }}
     >
       <div
@@ -35,12 +35,14 @@ export default function BondsModal({ isOpen, onClose }) {
           border: '2px solid #00ff88',
           borderRadius: '15px',
           padding: '30px',
-          textAlign: 'center'
+          textAlign: 'center',
         }}
       >
         <h2 style={{ color: '#00ff88' }}>👥 Character Bonds</h2>
         <p style={{ color: '#aaa', margin: '20px 0' }}>Component coming soon...</p>
-        <button onClick={onClose} style={buttonStyle}>Close</button>
+        <button onClick={onClose} style={buttonStyle}>
+          Close
+        </button>
       </div>
     </div>
   );

--- a/src/components/LevelUpModal.js
+++ b/src/components/LevelUpModal.js
@@ -78,13 +78,19 @@ const LevelUpModal = ({ character, setCharacter, levelUpState, setLevelUpState, 
       if (alreadySelected) {
         return { ...prev, selectedStats: prev.selectedStats.filter(s => s !== stat) };
       }
-      
+
       // Can't select more than 2 stats
       if (prev.selectedStats.length >= 2) return prev;
-      
-      // If already selected 1 stat, can only select another if both would be under 16
-      if (prev.selectedStats.length === 1 && !canIncreaseTwo()) return prev;
-      
+
+      // If selecting a second stat, ensure its current score is below 16
+      if (prev.selectedStats.length === 1) {
+        if (currentScore >= 16) {
+          alert('Cannot select a second stat with a score of 16 or higher.');
+          return prev;
+        }
+        if (!canIncreaseTwo()) return prev;
+      }
+
       return { ...prev, selectedStats: [...prev.selectedStats, stat] };
     });
   };

--- a/src/components/RollModal.jsx
+++ b/src/components/RollModal.jsx
@@ -9,7 +9,7 @@ const buttonStyle = {
   cursor: 'pointer',
   fontWeight: 'bold',
   transition: 'all 0.3s ease',
-  margin: '5px'
+  margin: '5px',
 };
 
 export default function RollModal({ isOpen, data, onClose }) {
@@ -28,7 +28,7 @@ export default function RollModal({ isOpen, data, onClose }) {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        padding: '20px'
+        padding: '20px',
       }}
     >
       <div
@@ -38,7 +38,7 @@ export default function RollModal({ isOpen, data, onClose }) {
           borderRadius: '15px',
           maxWidth: '500px',
           width: '100%',
-          boxShadow: '0 0 30px rgba(0, 255, 136, 0.5)'
+          boxShadow: '0 0 30px rgba(0, 255, 136, 0.5)',
         }}
       >
         <div
@@ -46,7 +46,7 @@ export default function RollModal({ isOpen, data, onClose }) {
             textAlign: 'center',
             padding: '20px',
             background: 'linear-gradient(45deg, #0f3460, #533483)',
-            borderRadius: '13px 13px 0 0'
+            borderRadius: '13px 13px 0 0',
           }}
         >
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -60,7 +60,7 @@ export default function RollModal({ isOpen, data, onClose }) {
                 fontSize: '1.2rem',
                 cursor: 'pointer',
                 padding: '5px 10px',
-                borderRadius: '8px'
+                borderRadius: '8px',
               }}
             >
               ×
@@ -68,20 +68,27 @@ export default function RollModal({ isOpen, data, onClose }) {
           </div>
         </div>
         <div style={{ padding: '30px', textAlign: 'center' }}>
-          <div style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#00ff88', marginBottom: '15px' }}>
+          <div
+            style={{
+              fontSize: '1.5rem',
+              fontWeight: 'bold',
+              color: '#00ff88',
+              marginBottom: '15px',
+            }}
+          >
             {data.result}
           </div>
           {data.description && (
-            <div style={{ color: '#e0e0e0', marginBottom: '15px' }}>
-              {data.description}
-            </div>
+            <div style={{ color: '#e0e0e0', marginBottom: '15px' }}>{data.description}</div>
           )}
           {data.context && (
             <div style={{ color: '#aaa', fontSize: '0.9rem', marginBottom: '20px' }}>
               {data.context}
             </div>
           )}
-          <button onClick={onClose} style={buttonStyle}>Close</button>
+          <button onClick={onClose} style={buttonStyle}>
+            Close
+          </button>
         </div>
       </div>
     </div>

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -9,73 +9,115 @@ export const INITIAL_CHARACTER_DATA = {
 
   // Attributes
   stats: {
-    STR: { score: 18, mod: 3 },  // mod = Math.floor((score - 10) / 2)
+    STR: { score: 18, mod: 3 }, // mod = Math.floor((score - 10) / 2)
     DEX: { score: 15, mod: 1 },
     CON: { score: 16, mod: 2 },
     INT: { score: 9, mod: 0 },
     WIS: { score: 13, mod: 1 },
-    CHA: { score: 8, mod: -1 }
+    CHA: { score: 8, mod: -1 },
   },
 
   // Resources & Abilities
   resources: {
-    chronoUses: 2,        // Ring of Smooshed Chronologies
-    paradoxPoints: 0,     // 0-3, 3 = reality unstable
-    bandages: 3,          // Heal 4 HP slowly
-    rations: 5,           // Satisfy hunger at camp
-    advGear: 5            // Rope, torches, chalk, etc.
+    chronoUses: 2, // Ring of Smooshed Chronologies
+    paradoxPoints: 0, // 0-3, 3 = reality unstable
+    bandages: 3, // Heal 4 HP slowly
+    rations: 5, // Satisfy hunger at camp
+    advGear: 5, // Rope, torches, chalk, etc.
   },
 
   // Character Relationships
   bonds: [
-    { name: "Sar", relationship: "I will teach Sar about the future", resolved: false },
-    { name: "Kael", relationship: "Kael reminds me of someone I lost", resolved: false }
+    { name: 'Sar', relationship: 'I will teach Sar about the future', resolved: false },
+    { name: 'Kael', relationship: 'Kael reminds me of someone I lost', resolved: false },
   ],
 
   // Status Conditions
   statusEffects: [], // Keys: poisoned, shocked, burning, frozen, confused, weakened, blessed, invisible
-  debilities: [],    // Keys: weak, shaky, sick, stunned, confused, scarred
+  debilities: [], // Keys: weak, shaky, sick, stunned, confused, scarred
 
   // Equipment & Items
   inventory: [
-    { id: 1, name: "Entropic Cyber-Warhammer", type: "weapon", damage: "d10+3", equipped: true,
-      description: "Phases through time occasionally", tags: ["melee", "forceful", "messy"] },
-    { id: 2, name: "Ring of Smooshed Chronologies", type: "magic", equipped: true,
-      description: "Grants Chrono-Retcon ability" },
-    { id: 3, name: "Gravity Beetle Shell", type: "material", quantity: 1,
-      description: "Crafting material for Sar's companion Kumquat" },
-    { id: 4, name: "Healing Potion", type: "consumable", quantity: 2,
-      description: "Restore 1d8 HP" },
-    { id: 5, name: "Cyber-Plated Vest", type: "armor", armor: 1, equipped: false,
-      description: "Light armor with energy dispersal" }
+    {
+      id: 1,
+      name: 'Entropic Cyber-Warhammer',
+      type: 'weapon',
+      damage: 'd10+3',
+      equipped: true,
+      description: 'Phases through time occasionally',
+      tags: ['melee', 'forceful', 'messy'],
+    },
+    {
+      id: 2,
+      name: 'Ring of Smooshed Chronologies',
+      type: 'magic',
+      equipped: true,
+      description: 'Grants Chrono-Retcon ability',
+    },
+    {
+      id: 3,
+      name: 'Gravity Beetle Shell',
+      type: 'material',
+      quantity: 1,
+      description: "Crafting material for Sar's companion Kumquat",
+    },
+    {
+      id: 4,
+      name: 'Healing Potion',
+      type: 'consumable',
+      quantity: 2,
+      description: 'Restore 1d8 HP',
+    },
+    {
+      id: 5,
+      name: 'Cyber-Plated Vest',
+      type: 'armor',
+      armor: 1,
+      equipped: false,
+      description: 'Light armor with energy dispersal',
+    },
   ],
 
   // Character Progression
-  selectedMoves: [],     // Advanced moves acquired through leveling
-  actionHistory: [],     // For undo functionality (last 5 actions)
+  selectedMoves: [], // Advanced moves acquired through leveling
+  actionHistory: [], // For undo functionality (last 5 actions)
 
   // Session Data
-  sessionNotes: "",      // Campaign notes and events
-  rollHistory: []        // Recent dice rolls (last 10)
+  sessionNotes: '', // Campaign notes and events
+  rollHistory: [], // Recent dice rolls (last 10)
 };
 
 export const statusEffectTypes = {
-  poisoned: { name: "Poisoned", description: "-1 to all rolls", color: "green", icon: "🤢" },
-  shocked: { name: "Shocked", description: "-2 to DEX rolls", color: "blue-yellow", icon: "⚡" },
-  burning: { name: "Burning", description: "Fire damage each turn", color: "red-orange", icon: "🔥" },
-  frozen: { name: "Frozen", description: "-1 to physical actions", color: "cyan-blue", icon: "🧊" },
-  confused: { name: "Confused", description: "GM controls one action", color: "purple", icon: "😵" },
-  weakened: { name: "Weakened", description: "-1 to damage rolls", color: "gray", icon: "💔" },
-  blessed: { name: "Blessed", description: "+1 to all rolls", color: "yellow", icon: "✨" },
-  invisible: { name: "Invisible", description: "Cannot be targeted", color: "transparent", icon: "👻" }
+  poisoned: { name: 'Poisoned', description: '-1 to all rolls', color: 'green', icon: '🤢' },
+  shocked: { name: 'Shocked', description: '-2 to DEX rolls', color: 'blue-yellow', icon: '⚡' },
+  burning: {
+    name: 'Burning',
+    description: 'Fire damage each turn',
+    color: 'red-orange',
+    icon: '🔥',
+  },
+  frozen: { name: 'Frozen', description: '-1 to physical actions', color: 'cyan-blue', icon: '🧊' },
+  confused: {
+    name: 'Confused',
+    description: 'GM controls one action',
+    color: 'purple',
+    icon: '😵',
+  },
+  weakened: { name: 'Weakened', description: '-1 to damage rolls', color: 'gray', icon: '💔' },
+  blessed: { name: 'Blessed', description: '+1 to all rolls', color: 'yellow', icon: '✨' },
+  invisible: {
+    name: 'Invisible',
+    description: 'Cannot be targeted',
+    color: 'transparent',
+    icon: '👻',
+  },
 };
 
 export const debilityTypes = {
-  weak: { name: "Weak", description: "-1 to STR rolls", icon: "💪" },
-  shaky: { name: "Shaky", description: "-1 to DEX rolls", icon: "🫨" },
-  sick: { name: "Sick", description: "-1 to CON rolls", icon: "🤒" },
-  stunned: { name: "Stunned", description: "-1 to INT rolls", icon: "😵‍💫" },
-  confused: { name: "Confused", description: "-1 to WIS rolls", icon: "🤯" },
-  scarred: { name: "Scarred", description: "-1 to CHA rolls", icon: "😰" }
+  weak: { name: 'Weak', description: '-1 to STR rolls', icon: '💪' },
+  shaky: { name: 'Shaky', description: '-1 to DEX rolls', icon: '🫨' },
+  sick: { name: 'Sick', description: '-1 to CON rolls', icon: '🤒' },
+  stunned: { name: 'Stunned', description: '-1 to INT rolls', icon: '😵‍💫' },
+  confused: { name: 'Confused', description: '-1 to WIS rolls', icon: '🤯' },
+  scarred: { name: 'Scarred', description: '-1 to CHA rolls', icon: '😰' },
 };
-


### PR DESCRIPTION
## Summary
- validate second stat selection to ensure its current score is below 16
- alert players when attempting to pick a second stat at 16 or higher

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689767e01b5483329e44e369b4b47fa1