### PR TITLE
fix LevelUpModal JSX syntax error

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -260,12 +260,11 @@ const LevelUpModal = ({ character, setCharacter, levelUpState, setLevelUpState, 
         {/* Header */}
         <div style={headerStyle}>
           <h2 style={{ margin: 0, fontSize: '1.5rem', color: 'white' }}>
-  LEVEL UP!
-</h2>
+            LEVEL UP!
+          </h2>
           <p style={{ margin: '5px 0 0', color: '#e0f2fe' }}>
-<p style={{ margin: '5px 0 0', color: '#e0f2fe' }}>
-  Zimbo advances to Level {levelUpState.newLevel}
-</p>          </p>
+            {character.name} advances to Level {levelUpState.newLevel}
+          </p>
           <button
             onClick={onClose}
             style={{


### PR DESCRIPTION
## Summary
- rename LevelUpModal to .jsx and fix header markup
- ensure character level-up message renders properly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689766e16cf48332831c6e44fe87a0cf