### PR TITLE
feat: implement regex-based dice parser

### DIFF
--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -6,18 +6,16 @@ export const rollDie = (sides) => {
 };
 
 export const rollDice = (formula) => {
-  if (formula.includes('2d6')) {
-    const modifier = parseInt(formula.replace('2d6', '').replace('+', ''), 10) || 0;
-    const die1 = rollDie(6);
-    const die2 = rollDie(6);
-    return die1 + die2 + modifier;
+  const match = formula.match(/^(\d*)d(\d+)([+-]\d+)?$/);
+  if (!match) {
+    throw new Error('Unsupported formula');
   }
-  if (formula.startsWith('d')) {
-    const [sidesPart, modPart] = formula.split('+');
-    const sides = parseInt(sidesPart.slice(1), 10);
-    const modifier = parseInt(modPart || '0', 10);
-    const roll = rollDie(sides);
-    return roll + modifier;
+  const count = parseInt(match[1] || '1', 10);
+  const sides = parseInt(match[2], 10);
+  const modifier = parseInt(match[3] || '0', 10);
+  let total = 0;
+  for (let i = 0; i < count; i += 1) {
+    total += rollDie(sides);
   }
-  throw new Error('Unsupported formula');
+  return total + modifier;
 };

--- a/src/utils/dice.test.js
+++ b/src/utils/dice.test.js
@@ -10,10 +10,10 @@ describe('rollDie', () => {
 });
 
 describe('rollDice', () => {
-  it('handles 2d6 formulas', () => {
+  it('handles multi-die formulas', () => {
     const spy = vi.spyOn(Math, 'random');
-    spy.mockReturnValueOnce(0.1).mockReturnValueOnce(0.6);
-    expect(rollDice('2d6+1')).toBe(6);
+    spy.mockReturnValueOnce(0.2).mockReturnValueOnce(0.8).mockReturnValueOnce(0.4);
+    expect(rollDice('3d6+2')).toBe(12);
     spy.mockRestore();
   });
 
@@ -23,7 +23,14 @@ describe('rollDice', () => {
     spy.mockRestore();
   });
 
+  it('handles negative modifiers', () => {
+    const spy = vi.spyOn(Math, 'random');
+    spy.mockReturnValueOnce(0.75).mockReturnValueOnce(0.25);
+    expect(rollDice('2d4-3')).toBe(3);
+    spy.mockRestore();
+  });
+
   it('throws on unsupported formulas', () => {
-    expect(() => rollDice('3d6')).toThrow('Unsupported formula');
+    expect(() => rollDice('2d')).toThrow('Unsupported formula');
   });
 });


### PR DESCRIPTION
## Summary
- replace ad-hoc dice parsing with regex handling NdX±M patterns
- roll multiple dice and apply optional modifiers
- cover multi-die and negative modifier formulas with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980f4296c083329eff494b13e7c27e