### PR TITLE
refactor: externalize modal styles

### DIFF
--- a/src/components/InventoryModal.css
+++ b/src/components/InventoryModal.css
@@ -1,0 +1,67 @@
+.inventory-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.inventory-modal {
+  background: #1a1a2e;
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  padding: 20px;
+  max-width: 500px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.inventory-title {
+  color: #00ff88;
+  text-align: center;
+}
+
+.inventory-empty {
+  color: #aaa;
+}
+
+.inventory-list {
+  list-style: none;
+  padding: 0;
+}
+
+.inventory-item {
+  margin-bottom: 10px;
+  border-bottom: 1px solid #333;
+  padding-bottom: 10px;
+}
+
+.inventory-item-name {
+  color: #fff;
+  font-weight: bold;
+}
+
+.inventory-item-actions {
+  margin-top: 5px;
+}
+
+.inventory-button {
+  background: linear-gradient(45deg, #8b5cf6, #7c3aed);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 5px 10px;
+  cursor: pointer;
+  margin: 3px;
+}
+
+.inventory-close {
+  text-align: center;
+  margin-top: 15px;
+}

--- a/src/components/InventoryModal.jsx
+++ b/src/components/InventoryModal.jsx
@@ -1,65 +1,32 @@
 import React from 'react';
+import './InventoryModal.css';
 
 const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
-  const overlayStyle = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    background: 'rgba(0, 0, 0, 0.8)',
-    zIndex: 1000,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center'
-  };
-
-  const modalStyle = {
-    background: '#1a1a2e',
-    border: '2px solid #00ff88',
-    borderRadius: '15px',
-    padding: '20px',
-    maxWidth: '500px',
-    width: '100%',
-    maxHeight: '80vh',
-    overflowY: 'auto'
-  };
-
-  const buttonStyle = {
-    background: 'linear-gradient(45deg, #8b5cf6, #7c3aed)',
-    border: 'none',
-    borderRadius: '6px',
-    color: 'white',
-    padding: '5px 10px',
-    cursor: 'pointer',
-    margin: '3px'
-  };
-
   return (
-    <div style={overlayStyle}>
-      <div style={modalStyle}>
-        <h2 style={{ color: '#00ff88', textAlign: 'center' }}>🎒 Inventory</h2>
+    <div className="inventory-overlay">
+      <div className="inventory-modal">
+        <h2 className="inventory-title">🎒 Inventory</h2>
         {inventory.length === 0 ? (
-          <p style={{ color: '#aaa' }}>No items</p>
+          <p className="inventory-empty">No items</p>
         ) : (
-          <ul style={{ listStyle: 'none', padding: 0 }}>
+          <ul className="inventory-list">
             {inventory.map(item => (
-              <li key={item.id} style={{ marginBottom: '10px', borderBottom: '1px solid #333', paddingBottom: '10px' }}>
-                <div style={{ color: '#fff', fontWeight: 'bold' }}>
+              <li key={item.id} className="inventory-item">
+                <div className="inventory-item-name">
                   {item.name}{item.quantity ? ` x${item.quantity}` : ''}
                 </div>
-                <div style={{ marginTop: '5px' }}>
+                <div className="inventory-item-actions">
                   {'equipped' in item && (
-                    <button style={buttonStyle} onClick={() => onEquip(item.id)}>
+                    <button className="inventory-button" onClick={() => onEquip(item.id)}>
                       {item.equipped ? 'Unequip' : 'Equip'}
                     </button>
                   )}
                   {item.type === 'consumable' && (
-                    <button style={buttonStyle} onClick={() => onConsume(item.id)}>
+                    <button className="inventory-button" onClick={() => onConsume(item.id)}>
                       Consume
                     </button>
                   )}
-                  <button style={buttonStyle} onClick={() => onDrop(item.id)}>
+                  <button className="inventory-button" onClick={() => onDrop(item.id)}>
                     Drop
                   </button>
                 </div>
@@ -67,8 +34,8 @@ const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
             ))}
           </ul>
         )}
-        <div style={{ textAlign: 'center', marginTop: '15px' }}>
-          <button style={buttonStyle} onClick={onClose}>Close</button>
+        <div className="inventory-close">
+          <button className="inventory-button" onClick={onClose}>Close</button>
         </div>
       </div>
     </div>

--- a/src/components/LevelUpModal.css
+++ b/src/components/LevelUpModal.css
@@ -1,0 +1,347 @@
+.levelup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.9);
+  backdrop-filter: blur(8px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.levelup-modal {
+  background: linear-gradient(135deg, #1a1a2e, #16213e);
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  max-width: 700px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 40px rgba(0, 255, 136, 0.3);
+}
+
+.levelup-header {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  padding: 20px;
+  border-radius: 13px 13px 0 0;
+  text-align: center;
+  position: relative;
+}
+
+.levelup-header-title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: white;
+}
+
+.levelup-header-text {
+  margin: 5px 0 0;
+  color: #e0f2fe;
+}
+
+.levelup-close-button {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  color: white;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.levelup-content {
+  padding: 20px;
+}
+
+.levelup-progress {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding: 10px;
+  background: rgba(0, 255, 136, 0.1);
+  border-radius: 8px;
+  border: 1px solid rgba(0, 255, 136, 0.3);
+}
+
+.levelup-progress-step {
+  text-align: center;
+  color: #666;
+}
+
+.levelup-progress-step.complete {
+  color: #00ff88;
+}
+
+.levelup-progress-icon {
+  font-size: 20px;
+}
+
+.levelup-progress-label {
+  font-size: 12px;
+}
+
+.levelup-step {
+  margin-bottom: 20px;
+}
+
+.levelup-step-title {
+  color: #00ff88;
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+}
+
+.levelup-step-desc {
+  color: #e0e0e0;
+  font-size: 14px;
+  margin-bottom: 15px;
+}
+
+.levelup-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.levelup-stat-button {
+  padding: 10px;
+  border: 2px solid #555;
+  border-radius: 8px;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.3s ease;
+  font-size: 14px;
+}
+
+.levelup-stat-button.selected {
+  border-color: #00ff88;
+  background: rgba(0, 255, 136, 0.2);
+  color: #00ff88;
+}
+
+.levelup-stat-button.maxed {
+  border-color: #666;
+  background: #333;
+  color: #666;
+  cursor: not-allowed;
+}
+
+.levelup-stat-button.disabled {
+  border-color: #333;
+  background: #222;
+  color: #555;
+  cursor: not-allowed;
+}
+
+.levelup-stat-name {
+  font-weight: bold;
+}
+
+.levelup-stat-score {
+  font-size: 12px;
+}
+
+.levelup-stat-mod {
+  font-size: 10px;
+  opacity: 0.8;
+}
+
+.levelup-selected-box {
+  padding: 8px 12px;
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.3);
+  border-radius: 6px;
+  font-size: 14px;
+  color: #00ff88;
+}
+
+.levelup-selected-move {
+  margin-top: 8px;
+}
+
+.levelup-move-list {
+  max-height: 250px;
+  overflow-y: auto;
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.levelup-move-wrapper {
+  margin-bottom: 8px;
+}
+
+.levelup-move-button {
+  padding: 12px;
+  border: 2px solid #555;
+  border-radius: 8px;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.3s ease;
+  margin-bottom: 8px;
+}
+
+.levelup-move-button.selected {
+  border-color: #00ff88;
+  background: rgba(0, 255, 136, 0.2);
+}
+
+.levelup-move-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.levelup-move-text {
+  flex: 1;
+}
+
+.levelup-move-name {
+  margin: 0;
+  color: #00ff88;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.levelup-move-desc {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #ccc;
+  line-height: 1.3;
+}
+
+.levelup-details-button {
+  background: none;
+  border: none;
+  color: #00ff88;
+  cursor: pointer;
+  font-size: 12px;
+  margin-left: 8px;
+}
+
+.levelup-move-details {
+  padding: 12px;
+  background: rgba(0, 255, 136, 0.05);
+  border: 1px solid rgba(0, 255, 136, 0.2);
+  border-radius: 6px;
+  margin-left: 10px;
+  font-size: 12px;
+}
+
+.levelup-move-expanded {
+  color: #e0e0e0;
+  margin-bottom: 8px;
+  line-height: 1.4;
+}
+
+.levelup-move-examples {
+  color: #aaa;
+}
+
+.levelup-hp-container {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 15px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  border: 1px solid #555;
+}
+
+.levelup-button {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  border: none;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  font-size: 14px;
+}
+
+.levelup-button-rolled {
+  background: linear-gradient(45deg, #00cc6a, #00aa55);
+}
+
+.levelup-button-cancel {
+  background: linear-gradient(45deg, #666, #555);
+}
+
+.levelup-button-complete {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  font-size: 16px;
+  padding: 12px 24px;
+}
+
+.levelup-button-disabled {
+  background: linear-gradient(45deg, #666, #555);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.levelup-hp-text {
+  color: #e0e0e0;
+  font-size: 14px;
+}
+
+.levelup-hp-result {
+  color: #00ff88;
+  font-weight: bold;
+  margin-top: 4px;
+}
+
+.levelup-summary {
+  padding: 15px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.levelup-summary.complete {
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.3);
+}
+
+.levelup-summary.incomplete {
+  background: rgba(255, 170, 68, 0.1);
+  border: 1px solid rgba(255, 170, 68, 0.3);
+}
+
+.levelup-summary-title {
+  color: #00ff88;
+  margin: 0 0 10px;
+  font-size: 1.1rem;
+}
+
+.levelup-summary-details {
+  color: #e0e0e0;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.levelup-actions {
+  margin-top: 15px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.levelup-warning {
+  color: #ffaa44;
+  font-size: 12px;
+  margin: 8px 0 0;
+  font-style: italic;
+}

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import './LevelUpModal.css';
 
 // Advanced moves available for selection
 const advancedMoves = {
@@ -164,231 +165,130 @@ const LevelUpModal = ({ character, setCharacter, levelUpState, setLevelUpState, 
     onClose();
   };
 
-  const isComplete = levelUpState.selectedStats.length > 0 && 
-                    levelUpState.selectedMove && 
+  const isComplete = levelUpState.selectedStats.length > 0 &&
+                    levelUpState.selectedMove &&
                     levelUpState.hpIncrease > 0;
 
-  // Modal styles
-  const modalOverlayStyle = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    background: 'rgba(0, 0, 0, 0.9)',
-    backdropFilter: 'blur(8px)',
-    zIndex: 1000,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '20px',
-    overflowY: 'auto'
-  };
-
-  const modalContentStyle = {
-    background: 'linear-gradient(135deg, #1a1a2e, #16213e)',
-    border: '2px solid #00ff88',
-    borderRadius: '15px',
-    maxWidth: '700px',
-    width: '100%',
-    maxHeight: '90vh',
-    overflowY: 'auto',
-    boxShadow: '0 20px 40px rgba(0, 255, 136, 0.3)'
-  };
-
-  const headerStyle = {
-    background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
-    padding: '20px',
-    borderRadius: '13px 13px 0 0',
-    textAlign: 'center',
-    position: 'relative'
-  };
-
-  const buttonStyle = {
-    background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
-    border: 'none',
-    color: 'white',
-    padding: '10px 20px',
-    borderRadius: '6px',
-    cursor: 'pointer',
-    fontWeight: 'bold',
-    transition: 'all 0.3s ease',
-    fontSize: '14px'
-  };
-
-  const statButtonStyle = (stat) => {
+  // Class helpers
+  const statButtonClass = (stat) => {
     const currentScore = character.stats[stat].score;
     const isSelected = levelUpState.selectedStats.includes(stat);
     const isMaxed = currentScore >= 18;
     const canSelect = !isMaxed && (
-      levelUpState.selectedStats.length === 0 || 
+      levelUpState.selectedStats.length === 0 ||
       (levelUpState.selectedStats.length === 1 && canIncreaseTwo()) ||
       isSelected
     );
 
-    return {
-      padding: '10px',
-      border: `2px solid ${isSelected ? '#00ff88' : isMaxed ? '#666' : canSelect ? '#555' : '#333'}`,
-      borderRadius: '8px',
-      background: isSelected ? 'rgba(0, 255, 136, 0.2)' : isMaxed ? '#333' : canSelect ? '#1a1a2e' : '#222',
-      color: isSelected ? '#00ff88' : isMaxed ? '#666' : canSelect ? '#e0e0e0' : '#555',
-      cursor: canSelect ? 'pointer' : 'not-allowed',
-      textAlign: 'center',
-      transition: 'all 0.3s ease',
-      fontSize: '14px'
-    };
+    return [
+      'levelup-stat-button',
+      isSelected && 'selected',
+      isMaxed && 'maxed',
+      !isSelected && !canSelect && 'disabled'
+    ].filter(Boolean).join(' ');
   };
 
-  const moveButtonStyle = (moveId) => {
+  const moveButtonClass = (moveId) => {
     const isSelected = levelUpState.selectedMove === moveId;
-    return {
-      padding: '12px',
-      border: `2px solid ${isSelected ? '#00ff88' : '#555'}`,
-      borderRadius: '8px',
-      background: isSelected ? 'rgba(0, 255, 136, 0.2)' : '#1a1a2e',
-      color: '#e0e0e0',
-      cursor: 'pointer',
-      textAlign: 'left',
-      transition: 'all 0.3s ease',
-      marginBottom: '8px'
-    };
+    return [
+      'levelup-move-button',
+      isSelected && 'selected'
+    ].filter(Boolean).join(' ');
+  };
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
   };
 
   return (
-    <div style={modalOverlayStyle} onClick={(e) => e.target === e.currentTarget && onClose()}>
-      <div style={modalContentStyle}>
+    <div className="levelup-overlay" onClick={handleOverlayClick}>
+      <div className="levelup-modal">
         {/* Header */}
-        <div style={headerStyle}>
-          <h2 style={{ margin: 0, fontSize: '1.5rem', color: 'white' }}>
+        <div className="levelup-header">
+          <h2 className="levelup-header-title">
             LEVEL UP!
           </h2>
-          <p style={{ margin: '5px 0 0', color: '#e0f2fe' }}>
+          <p className="levelup-header-text">
             {character.name} advances to Level {levelUpState.newLevel}
           </p>
-          <button
-            onClick={onClose}
-            style={{
-              position: 'absolute',
-              top: '15px',
-              right: '15px',
-              background: 'rgba(255, 255, 255, 0.2)',
-              border: 'none',
-              color: 'white',
-              width: '30px',
-              height: '30px',
-              borderRadius: '50%',
-              cursor: 'pointer',
-              fontSize: '18px'
-            }}
-          >
+          <button onClick={onClose} className="levelup-close-button">
             ×
           </button>
         </div>
 
-        <div style={{ padding: '20px' }}>
+        <div className="levelup-content">
           {/* Progress Indicator */}
-          <div style={{ 
-            display: 'flex', 
-            justifyContent: 'space-between', 
-            marginBottom: '20px',
-            padding: '10px',
-            background: 'rgba(0, 255, 136, 0.1)',
-            borderRadius: '8px',
-            border: '1px solid rgba(0, 255, 136, 0.3)'
-          }}>
-            <div style={{ textAlign: 'center', color: levelUpState.selectedStats.length > 0 ? '#00ff88' : '#666' }}>
-              <div style={{ fontSize: '20px' }}>{levelUpState.selectedStats.length > 0 ? '✅' : '1️⃣'}</div>
-              <div style={{ fontSize: '12px' }}>Stats</div>
+          <div className="levelup-progress">
+            <div className={`levelup-progress-step ${levelUpState.selectedStats.length > 0 ? 'complete' : ''}`}>
+              <div className="levelup-progress-icon">{levelUpState.selectedStats.length > 0 ? '✅' : '1️⃣'}</div>
+              <div className="levelup-progress-label">Stats</div>
             </div>
-            <div style={{ textAlign: 'center', color: levelUpState.selectedMove ? '#00ff88' : '#666' }}>
-              <div style={{ fontSize: '20px' }}>{levelUpState.selectedMove ? '✅' : '2️⃣'}</div>
-              <div style={{ fontSize: '12px' }}>Move</div>
+            <div className={`levelup-progress-step ${levelUpState.selectedMove ? 'complete' : ''}`}>
+              <div className="levelup-progress-icon">{levelUpState.selectedMove ? '✅' : '2️⃣'}</div>
+              <div className="levelup-progress-label">Move</div>
             </div>
-            <div style={{ textAlign: 'center', color: levelUpState.hpIncrease > 0 ? '#00ff88' : '#666' }}>
-              <div style={{ fontSize: '20px' }}>{levelUpState.hpIncrease > 0 ? '✅' : '3️⃣'}</div>
-              <div style={{ fontSize: '12px' }}>HP</div>
+            <div className={`levelup-progress-step ${levelUpState.hpIncrease > 0 ? 'complete' : ''}`}>
+              <div className="levelup-progress-icon">{levelUpState.hpIncrease > 0 ? '✅' : '3️⃣'}</div>
+              <div className="levelup-progress-label">HP</div>
             </div>
           </div>
 
           {/* Step 1: Stat Selection */}
-          <div style={{ marginBottom: '20px' }}>
-            <h3 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1.2rem' }}>
+          <div className="levelup-step">
+            <h3 className="levelup-step-title">
               📊 Step 1: Increase Ability Scores
             </h3>
-            <p style={{ color: '#e0e0e0', fontSize: '14px', marginBottom: '15px' }}>
+            <p className="levelup-step-desc">
               Choose 1 stat (max 18) or 2 stats if both are under 16:
             </p>
-            
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '10px', marginBottom: '10px' }}>
+
+            <div className="levelup-stat-grid">
               {Object.entries(character.stats).map(([stat, data]) => (
                 <button
                   key={stat}
                   onClick={() => handleStatSelection(stat)}
-                  style={statButtonStyle(stat)}
+                  className={statButtonClass(stat)}
                   disabled={data.score >= 18 || (!levelUpState.selectedStats.includes(stat) && levelUpState.selectedStats.length >= 2)}
                 >
-                  <div style={{ fontWeight: 'bold' }}>{stat}</div>
-                  <div style={{ fontSize: '12px' }}>
+                  <div className="levelup-stat-name">{stat}</div>
+                  <div className="levelup-stat-score">
                     {data.score} → {data.score >= 18 ? data.score : data.score + 1}
                     {data.score >= 18 && ' (MAX)'}
                   </div>
-                  <div style={{ fontSize: '10px', opacity: 0.8 }}>
+                  <div className="levelup-stat-mod">
                     ({data.mod >= 0 ? '+' : ''}{data.mod} → {Math.floor((Math.min(18, data.score + 1) - 10) / 2) >= 0 ? '+' : ''}{Math.floor((Math.min(18, data.score + 1) - 10) / 2)})
                   </div>
                 </button>
               ))}
             </div>
-            
+
             {levelUpState.selectedStats.length > 0 && (
-              <div style={{
-                padding: '8px 12px',
-                background: 'rgba(0, 255, 136, 0.1)',
-                border: '1px solid rgba(0, 255, 136, 0.3)',
-                borderRadius: '6px',
-                fontSize: '14px',
-                color: '#00ff88'
-              }}>
+              <div className="levelup-selected-box">
                 Selected: {levelUpState.selectedStats.join(', ')}
               </div>
             )}
           </div>
 
           {/* Step 2: Advanced Move Selection */}
-          <div style={{ marginBottom: '20px' }}>
-            <h3 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1.2rem' }}>
+          <div className="levelup-step">
+            <h3 className="levelup-step-title">
               ⚔️ Step 2: Choose Advanced Move
             </h3>
-            <div style={{ 
-              maxHeight: '250px', 
-              overflowY: 'auto',
-              border: '1px solid #555',
-              borderRadius: '8px',
-              padding: '8px'
-            }}>
+            <div className="levelup-move-list">
               {Object.entries(advancedMoves)
                 .filter(([id, move]) => !character.selectedMoves.includes(id))
                 .map(([id, move]) => (
-                <div key={id} style={{ marginBottom: '8px' }}>
+                <div key={id} className="levelup-move-wrapper">
                   <div
                     onClick={() => setLevelUpState(prev => ({ ...prev, selectedMove: id }))}
-                    style={moveButtonStyle(id)}
+                    className={moveButtonClass(id)}
                   >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start' }}>
-                      <div style={{ flex: 1 }}>
-                        <h4 style={{ 
-                          margin: 0, 
-                          color: '#00ff88', 
-                          fontSize: '14px', 
-                          fontWeight: 'bold' 
-                        }}>
+                    <div className="levelup-move-header">
+                      <div className="levelup-move-text">
+                        <h4 className="levelup-move-name">
                           {move.name}
                         </h4>
-                        <p style={{ 
-                          margin: '4px 0 0', 
-                          fontSize: '12px', 
-                          color: '#ccc',
-                          lineHeight: '1.3'
-                        }}>
+                        <p className="levelup-move-desc">
                           {move.desc}
                         </p>
                       </div>
@@ -397,34 +297,20 @@ const LevelUpModal = ({ character, setCharacter, levelUpState, setLevelUpState, 
                           e.stopPropagation();
                           setShowMoveDetails(showMoveDetails === id ? '' : id);
                         }}
-                        style={{
-                          background: 'none',
-                          border: 'none',
-                          color: '#00ff88',
-                          cursor: 'pointer',
-                          fontSize: '12px',
-                          marginLeft: '8px'
-                        }}
+                        className="levelup-details-button"
                       >
                         {showMoveDetails === id ? '▲' : '▼'}
                       </button>
                     </div>
                   </div>
-                  
+
                   {/* Expanded move details */}
                   {showMoveDetails === id && (
-                    <div style={{
-                      padding: '12px',
-                      background: 'rgba(0, 255, 136, 0.05)',
-                      border: '1px solid rgba(0, 255, 136, 0.2)',
-                      borderRadius: '6px',
-                      marginLeft: '10px',
-                      fontSize: '12px'
-                    }}>
-                      <p style={{ color: '#e0e0e0', marginBottom: '8px', lineHeight: '1.4' }}>
+                    <div className="levelup-move-details">
+                      <p className="levelup-move-expanded">
                         {move.expanded}
                       </p>
-                      <div style={{ color: '#aaa' }}>
+                      <div className="levelup-move-examples">
                         <strong>Examples:</strong><br />
                         {move.examples}
                       </div>
@@ -433,53 +319,32 @@ const LevelUpModal = ({ character, setCharacter, levelUpState, setLevelUpState, 
                 </div>
               ))}
             </div>
-            
+
             {levelUpState.selectedMove && (
-              <div style={{
-                padding: '8px 12px',
-                background: 'rgba(0, 255, 136, 0.1)',
-                border: '1px solid rgba(0, 255, 136, 0.3)',
-                borderRadius: '6px',
-                fontSize: '14px',
-                color: '#00ff88',
-                marginTop: '8px'
-              }}>
+              <div className="levelup-selected-box levelup-selected-move">
                 Selected: {advancedMoves[levelUpState.selectedMove].name}
               </div>
             )}
           </div>
 
           {/* Step 3: HP Rolling */}
-          <div style={{ marginBottom: '20px' }}>
-            <h3 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1.2rem' }}>
+          <div className="levelup-step">
+            <h3 className="levelup-step-title">
               ❤️ Step 3: Roll for Hit Points
             </h3>
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '15px',
-              padding: '15px',
-              background: 'rgba(255, 255, 255, 0.05)',
-              borderRadius: '8px',
-              border: '1px solid #555'
-            }}>
+            <div className="levelup-hp-container">
               <button
                 onClick={rollHPIncrease}
-                style={{
-                  ...buttonStyle,
-                  background: levelUpState.hpIncrease > 0 
-                    ? 'linear-gradient(45deg, #00cc6a, #00aa55)' 
-                    : 'linear-gradient(45deg, #00ff88, #00cc6a)'
-                }}
+                className={`levelup-button ${levelUpState.hpIncrease > 0 ? 'levelup-button-rolled' : ''}`}
                 disabled={levelUpState.hpIncrease > 0}
               >
                 {levelUpState.hpIncrease > 0 ? '✅ HP Rolled' : '🎲 Roll d10 + CON'}
               </button>
-              
-              <div style={{ color: '#e0e0e0', fontSize: '14px' }}>
+
+              <div className="levelup-hp-text">
                 Roll d10 + CON ({character.stats.CON.mod >= 0 ? '+' : ''}{character.stats.CON.mod}) for HP increase
                 {levelUpState.hpIncrease > 0 && (
-                  <div style={{ color: '#00ff88', fontWeight: 'bold', marginTop: '4px' }}>
+                  <div className="levelup-hp-result">
                     Result: +{levelUpState.hpIncrease} HP
                   </div>
                 )}
@@ -488,60 +353,36 @@ const LevelUpModal = ({ character, setCharacter, levelUpState, setLevelUpState, 
           </div>
 
           {/* Summary & Complete Button */}
-          <div style={{
-            padding: '15px',
-            background: isComplete ? 'rgba(0, 255, 136, 0.1)' : 'rgba(255, 170, 68, 0.1)',
-            border: `1px solid ${isComplete ? 'rgba(0, 255, 136, 0.3)' : 'rgba(255, 170, 68, 0.3)'}`,
-            borderRadius: '8px',
-            textAlign: 'center'
-          }}>
-            <h4 style={{ color: '#00ff88', margin: '0 0 10px', fontSize: '1.1rem' }}>
+          <div className={`levelup-summary ${isComplete ? 'complete' : 'incomplete'}`}>
+            <h4 className="levelup-summary-title">
               Level Up Summary
             </h4>
-            <div style={{ color: '#e0e0e0', fontSize: '14px', lineHeight: '1.4' }}>
+            <div className="levelup-summary-details">
               <div>Level: {character.level} → {levelUpState.newLevel}</div>
               <div>Stats: {levelUpState.selectedStats.length > 0 ? levelUpState.selectedStats.join(' & ') : 'None selected'}</div>
               <div>Move: {levelUpState.selectedMove ? advancedMoves[levelUpState.selectedMove].name : 'None selected'}</div>
               <div>HP: {levelUpState.hpIncrease > 0 ? `+${levelUpState.hpIncrease}` : 'Not rolled'}</div>
             </div>
-            
-            <div style={{ marginTop: '15px', display: 'flex', gap: '10px', justifyContent: 'center' }}>
+
+            <div className="levelup-actions">
               <button
                 onClick={onClose}
-                style={{
-                  ...buttonStyle,
-                  background: 'linear-gradient(45deg, #666, #555)',
-                  fontSize: '14px'
-                }}
+                className="levelup-button levelup-button-cancel"
               >
                 Cancel
               </button>
-              
+
               <button
                 onClick={completeLevelUp}
                 disabled={!isComplete}
-                style={{
-                  ...buttonStyle,
-                  background: isComplete 
-                    ? 'linear-gradient(45deg, #00ff88, #00cc6a)' 
-                    : 'linear-gradient(45deg, #666, #555)',
-                  opacity: isComplete ? 1 : 0.5,
-                  cursor: isComplete ? 'pointer' : 'not-allowed',
-                  fontSize: '16px',
-                  padding: '12px 24px'
-                }}
+                className={`levelup-button levelup-button-complete ${!isComplete ? 'levelup-button-disabled' : ''}`}
               >
                 🚀 Complete Level Up!
               </button>
             </div>
-            
+
             {!isComplete && (
-              <p style={{ 
-                color: '#ffaa44', 
-                fontSize: '12px', 
-                margin: '8px 0 0',
-                fontStyle: 'italic'
-              }}>
+              <p className="levelup-warning">
                 Complete all steps to finish leveling up
               </p>
             )}

--- a/src/components/StatusModal.css
+++ b/src/components/StatusModal.css
@@ -1,0 +1,59 @@
+.status-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.status-modal {
+  background: #1a1a2e;
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  padding: 20px;
+  max-width: 500px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.status-title {
+  color: #00ff88;
+  text-align: center;
+}
+
+.status-subtitle {
+  color: #00ff88;
+}
+
+.status-list {
+  list-style: none;
+  padding: 0;
+}
+
+.status-item {
+  margin-bottom: 8px;
+}
+
+.status-label {
+  color: #fff;
+}
+
+.status-button {
+  background: linear-gradient(45deg, #f97316, #ea580c);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 5px 10px;
+  cursor: pointer;
+  margin-top: 10px;
+}
+
+.status-footer {
+  text-align: center;
+}

--- a/src/components/StatusModal.jsx
+++ b/src/components/StatusModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './StatusModal.css';
 
 const StatusModal = ({
   statusEffects,
@@ -9,52 +10,16 @@ const StatusModal = ({
   onToggleDebility,
   onClose
 }) => {
-  const overlayStyle = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    width: '100%',
-    height: '100%',
-    background: 'rgba(0, 0, 0, 0.8)',
-    zIndex: 1000,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center'
-  };
-
-  const modalStyle = {
-    background: '#1a1a2e',
-    border: '2px solid #00ff88',
-    borderRadius: '15px',
-    padding: '20px',
-    maxWidth: '500px',
-    width: '100%',
-    maxHeight: '80vh',
-    overflowY: 'auto'
-  };
-
-  const listStyle = { listStyle: 'none', padding: 0 };
-  const itemStyle = { marginBottom: '8px' };
-  const buttonStyle = {
-    background: 'linear-gradient(45deg, #f97316, #ea580c)',
-    border: 'none',
-    borderRadius: '6px',
-    color: 'white',
-    padding: '5px 10px',
-    cursor: 'pointer',
-    marginTop: '10px'
-  };
-
   return (
-    <div style={overlayStyle}>
-      <div style={modalStyle}>
-        <h2 style={{ color: '#00ff88', textAlign: 'center' }}>💀 Status & Debilities</h2>
+    <div className="status-overlay">
+      <div className="status-modal">
+        <h2 className="status-title">💀 Status & Debilities</h2>
         <div>
-          <h3 style={{ color: '#00ff88' }}>Status Effects</h3>
-          <ul style={listStyle}>
+          <h3 className="status-subtitle">Status Effects</h3>
+          <ul className="status-list">
             {Object.keys(statusEffectTypes).map(key => (
-              <li key={key} style={itemStyle}>
-                <label style={{ color: '#fff' }}>
+              <li key={key} className="status-item">
+                <label className="status-label">
                   <input
                     type="checkbox"
                     checked={statusEffects.includes(key)}
@@ -67,11 +32,11 @@ const StatusModal = ({
           </ul>
         </div>
         <div>
-          <h3 style={{ color: '#00ff88' }}>Debilities</h3>
-          <ul style={listStyle}>
+          <h3 className="status-subtitle">Debilities</h3>
+          <ul className="status-list">
             {Object.keys(debilityTypes).map(key => (
-              <li key={key} style={itemStyle}>
-                <label style={{ color: '#fff' }}>
+              <li key={key} className="status-item">
+                <label className="status-label">
                   <input
                     type="checkbox"
                     checked={debilities.includes(key)}
@@ -83,8 +48,8 @@ const StatusModal = ({
             ))}
           </ul>
         </div>
-        <div style={{ textAlign: 'center' }}>
-          <button style={buttonStyle} onClick={onClose}>Close</button>
+        <div className="status-footer">
+          <button className="status-button" onClick={onClose}>Close</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move inline modal styling into dedicated CSS files
- apply class-based styling for InventoryModal, StatusModal, and LevelUpModal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980f4fa350833294e3af13d934c756