### PR TITLE
feat: add restrictive csp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "zimbo-panel",
   "private": true,
   "version": "0.1.0",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- add restrictive content security policy for Tauri app
- normalize package.json to ensure lint-staged runs

## Testing
- `tauri dev` *(fails: Failed to initialize GTK backend)*
- `tauri build` *(fails: LevelUpModal has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6898dec0d2dc83328b96046540096f34