### PR TITLE
Implement bonds and damage modals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
-import LevelUpModal from './components/LevelUpModal.jsx';
 import LevelUpModal from './components/LevelUpModal';
 import InventoryModal from './components/InventoryModal';
 import StatusModal from './components/StatusModal';
 import RollModal from './components/RollModal';
 import BondsModal from './components/BondsModal';
+import DamageModal from './components/DamageModal';
 import { useCharacter } from './state/CharacterContext';
 import { statusEffectTypes, debilityTypes } from './state/character';
 import useModal from './hooks/useModal';
@@ -30,7 +30,6 @@ function App() {
   const [showExportModal, setShowExportModal] = useState(false);
   
   // Additional UI State
-  const [damageInput, setDamageInput] = useState('');
   const [compactMode, setCompactMode] = useState(false);
 
   // Level Up State
@@ -961,32 +960,7 @@ function App() {
         />
       )}
 
-      {showDamageModal && (
-        <div style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          background: 'rgba(0, 0, 0, 0.8)',
-          zIndex: 1000,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center'
-        }}>
-          <div style={{
-            background: '#1a1a2e',
-            border: '2px solid #00ff88',
-            borderRadius: '15px',
-            padding: '30px',
-            textAlign: 'center'
-          }}>
-            <h2 style={{ color: '#00ff88' }}>💔 Damage Calculator</h2>
-            <p style={{ color: '#aaa', margin: '20px 0' }}>Component coming soon...</p>
-            <button onClick={() => setShowDamageModal(false)} style={buttonStyle}>Close</button>
-          </div>
-        </div>
-      )}
+      <DamageModal isOpen={showDamageModal} onClose={() => setShowDamageModal(false)} />
 
       {showInventoryModal && (
         <InventoryModal

--- a/src/components/BondsModal.jsx
+++ b/src/components/BondsModal.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useCharacter } from '../state/CharacterContext';
 
 const buttonStyle = {
   background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
@@ -9,11 +10,55 @@ const buttonStyle = {
   cursor: 'pointer',
   fontWeight: 'bold',
   transition: 'all 0.3s ease',
-  margin: '5px',
+  margin: '5px'
+};
+
+const inputStyle = {
+  background: '#0f0f1f',
+  border: '1px solid #00ff88',
+  borderRadius: '6px',
+  color: 'white',
+  padding: '8px',
+  width: '100%'
 };
 
 export default function BondsModal({ isOpen, onClose }) {
+  const { character, setCharacter } = useCharacter();
+  const [name, setName] = useState('');
+  const [relationship, setRelationship] = useState('');
+
   if (!isOpen) return null;
+
+  const addBond = () => {
+    if (name.trim() && relationship.trim()) {
+      setCharacter(prev => ({
+        ...prev,
+        bonds: [
+          ...prev.bonds,
+          { name: name.trim(), relationship: relationship.trim(), resolved: false }
+        ]
+      }));
+      setName('');
+      setRelationship('');
+    }
+  };
+
+  const removeBond = index => {
+    setCharacter(prev => ({
+      ...prev,
+      bonds: prev.bonds.filter((_, i) => i !== index)
+    }));
+  };
+
+  const toggleResolved = index => {
+    setCharacter(prev => ({
+      ...prev,
+      bonds: prev.bonds.map((bond, i) =>
+        i === index ? { ...bond, resolved: !bond.resolved } : bond
+      )
+    }));
+  };
+
   return (
     <div
       style={{
@@ -26,7 +71,7 @@ export default function BondsModal({ isOpen, onClose }) {
         zIndex: 1000,
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        justifyContent: 'center'
       }}
     >
       <div
@@ -36,11 +81,72 @@ export default function BondsModal({ isOpen, onClose }) {
           borderRadius: '15px',
           padding: '30px',
           textAlign: 'center',
+          width: '400px',
+          maxHeight: '80%',
+          overflowY: 'auto'
         }}
       >
         <h2 style={{ color: '#00ff88' }}>👥 Character Bonds</h2>
-        <p style={{ color: '#aaa', margin: '20px 0' }}>Component coming soon...</p>
-        <button onClick={onClose} style={buttonStyle}>
+        {character.bonds.length === 0 ? (
+          <p style={{ color: '#aaa', margin: '20px 0' }}>No bonds yet.</p>
+        ) : (
+          <ul style={{ listStyle: 'none', padding: 0, margin: '20px 0' }}>
+            {character.bonds.map((bond, index) => (
+              <li key={index} style={{ marginBottom: '15px', textAlign: 'left' }}>
+                <div style={{
+                  textDecoration: bond.resolved ? 'line-through' : 'none',
+                  color: '#fff'
+                }}>
+                  <strong>{bond.name}</strong>: {bond.relationship}
+                </div>
+                <div style={{ marginTop: '5px' }}>
+                  <button
+                    onClick={() => toggleResolved(index)}
+                    style={{
+                      ...buttonStyle,
+                      background: bond.resolved
+                        ? 'linear-gradient(45deg, #6366f1, #4f46e5)'
+                        : 'linear-gradient(45deg, #10b981, #059669)'
+                    }}
+                  >
+                    {bond.resolved ? 'Unresolve' : 'Resolve'}
+                  </button>
+                  <button
+                    onClick={() => removeBond(index)}
+                    style={{
+                      ...buttonStyle,
+                      background: 'linear-gradient(45deg, #ef4444, #dc2626)'
+                    }}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div style={{ textAlign: 'left' }}>
+          <input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            style={{ ...inputStyle, marginBottom: '10px' }}
+          />
+          <input
+            type="text"
+            placeholder="Relationship"
+            value={relationship}
+            onChange={e => setRelationship(e.target.value)}
+            style={{ ...inputStyle, marginBottom: '10px' }}
+          />
+          <button onClick={addBond} style={buttonStyle}>
+            Add Bond
+          </button>
+        </div>
+
+        <button onClick={onClose} style={{ ...buttonStyle, marginTop: '20px' }}>
           Close
         </button>
       </div>

--- a/src/components/DamageModal.jsx
+++ b/src/components/DamageModal.jsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+import { useCharacter } from '../state/CharacterContext';
+
+const buttonStyle = {
+  background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
+  border: 'none',
+  borderRadius: '6px',
+  color: 'white',
+  padding: '8px 15px',
+  cursor: 'pointer',
+  fontWeight: 'bold',
+  transition: 'all 0.3s ease',
+  margin: '5px'
+};
+
+const inputStyle = {
+  background: '#0f0f1f',
+  border: '1px solid #00ff88',
+  borderRadius: '6px',
+  color: 'white',
+  padding: '8px',
+  width: '100%'
+};
+
+export default function DamageModal({ isOpen, onClose }) {
+  const { character, setCharacter } = useCharacter();
+  const [damage, setDamage] = useState('');
+
+  if (!isOpen) return null;
+
+  const getTotalArmor = () => {
+    const baseArmor = character.armor || 0;
+    const equippedArmor = character.inventory
+      .filter(item => item.equipped && item.armor)
+      .reduce((total, item) => total + (item.armor || 0), 0);
+    return baseArmor + equippedArmor;
+  };
+
+  const effectiveDamage = () => {
+    const dmg = parseInt(damage, 10);
+    return isNaN(dmg) ? 0 : Math.max(0, dmg - getTotalArmor());
+  };
+
+  const applyDamage = () => {
+    const dmg = parseInt(damage, 10);
+    if (isNaN(dmg)) return;
+    setCharacter(prev => {
+      const armor = prev.armor || 0;
+      const equippedArmor = prev.inventory
+        .filter(item => item.equipped && item.armor)
+        .reduce((total, item) => total + (item.armor || 0), 0);
+      const totalArmor = armor + equippedArmor;
+      const finalDamage = Math.max(0, dmg - totalArmor);
+      return {
+        ...prev,
+        actionHistory: [
+          { action: 'HP Change', state: prev, timestamp: Date.now() },
+          ...prev.actionHistory.slice(0, 4)
+        ],
+        hp: Math.max(0, prev.hp - finalDamage)
+      };
+    });
+    setDamage('');
+    onClose();
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        background: 'rgba(0, 0, 0, 0.8)',
+        zIndex: 1000,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+    >
+      <div
+        style={{
+          background: '#1a1a2e',
+          border: '2px solid #00ff88',
+          borderRadius: '15px',
+          padding: '30px',
+          textAlign: 'center',
+          width: '300px'
+        }}
+      >
+        <h2 style={{ color: '#00ff88' }}>💔 Damage Calculator</h2>
+        <div style={{ margin: '15px 0', color: '#fff' }}>Armor: {getTotalArmor()}</div>
+        <input
+          type="number"
+          placeholder="Incoming damage"
+          value={damage}
+          onChange={e => setDamage(e.target.value)}
+          style={{ ...inputStyle, marginBottom: '10px' }}
+        />
+        <div style={{ color: '#aaa', marginBottom: '20px' }}>
+          After armor: {effectiveDamage()}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <button
+            onClick={applyDamage}
+            style={{
+              ...buttonStyle,
+              background: 'linear-gradient(45deg, #ef4444, #dc2626)'
+            }}
+          >
+            Apply
+          </button>
+          <button onClick={onClose} style={buttonStyle}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add full bonds management UI
- add damage calculator modal and integrate
- remove placeholder damage content

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run lint`
- `npm run format:check` *(fails: SyntaxError in .github/workflows/test.yml)*

------
https://chatgpt.com/codex/tasks/task_e_6898de9d5eb883328abdda8a8888fa0d