### PR TITLE
Remove duplicate LevelUpModal import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
-import LevelUpModal from './components/LevelUpModal.jsx';
 import LevelUpModal from './components/LevelUpModal';
 import InventoryModal from './components/InventoryModal';
 import StatusModal from './components/StatusModal';


### PR DESCRIPTION
## Summary
- Remove redundant LevelUpModal import in `App.jsx`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898de945bf48332b62af419e2c83186