### PR TITLE
Add interaction tests for MoveList and modals

### DIFF
--- a/src/components/BondsModal.test.jsx
+++ b/src/components/BondsModal.test.jsx
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import CharacterContext from '../state/CharacterContext.jsx';
+import BondsModal from './BondsModal.jsx';
+
+function renderWithCharacter(ui) {
+  const Wrapper = ({ children }) => {
+    const [character, setCharacter] = React.useState({ bonds: [] });
+    return (
+      <CharacterContext.Provider value={{ character, setCharacter }}>
+        {children}
+      </CharacterContext.Provider>
+    );
+  };
+  return render(ui, { wrapper: Wrapper });
+}
+
+describe('BondsModal', () => {
+  it('adds, resolves, and removes bonds', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderWithCharacter(<BondsModal isOpen onClose={onClose} />);
+
+    await user.type(screen.getByPlaceholderText('Name'), 'Alice');
+    await user.type(screen.getByPlaceholderText('Relationship'), 'Friend');
+    await user.click(screen.getByText('Add Bond'));
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Resolve'));
+    expect(screen.getByText('Unresolve')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Remove'));
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/DamageModal.test.jsx
+++ b/src/components/DamageModal.test.jsx
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import CharacterContext from '../state/CharacterContext.jsx';
+import DamageModal from './DamageModal.jsx';
+
+function renderWithCharacter(ui, { character }) {
+  const Wrapper = ({ children }) => {
+    const [charState, setCharState] = React.useState(character);
+    return (
+      <CharacterContext.Provider value={{ character: charState, setCharacter: setCharState }}>
+        {children}
+        <div data-testid="hp">{charState.hp}</div>
+      </CharacterContext.Provider>
+    );
+  };
+  return render(ui, { wrapper: Wrapper });
+}
+
+describe('DamageModal', () => {
+  it('applies damage accounting for armor', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const initial = {
+      hp: 10,
+      armor: 1,
+      inventory: [{ id: 1, armor: 1, equipped: true }],
+      actionHistory: [],
+    };
+    renderWithCharacter(<DamageModal isOpen onClose={onClose} />, { character: initial });
+
+    await user.type(screen.getByPlaceholderText('Incoming damage'), '5');
+    await user.click(screen.getByText('Apply'));
+
+    await waitFor(() => expect(screen.getByTestId('hp')).toHaveTextContent('7'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('cancels without changing hp', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const initial = { hp: 10, armor: 0, inventory: [], actionHistory: [] };
+    renderWithCharacter(<DamageModal isOpen onClose={onClose} />, { character: initial });
+
+    await user.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalled();
+    expect(screen.getByTestId('hp')).toHaveTextContent('10');
+  });
+});

--- a/src/components/MoveList.test.jsx
+++ b/src/components/MoveList.test.jsx
@@ -1,0 +1,53 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import MoveList from './MoveList.jsx';
+
+const minimalCharacter = {
+  stats: {
+    STR: { score: 10, mod: 1 },
+    DEX: { score: 10, mod: 0 },
+  },
+};
+
+const rollHistory = [{ timestamp: '10:00', result: '2d6: 7' }];
+
+describe('MoveList', () => {
+  it('calls rollDice for stat checks and basic dice', async () => {
+    const user = userEvent.setup();
+    const rollDice = vi.fn();
+    render(
+      <MoveList
+        character={minimalCharacter}
+        rollDice={rollDice}
+        getEquippedWeaponDamage={() => 'd8'}
+        rollResult="Result: 9"
+        rollHistory={rollHistory}
+      />,
+    );
+
+    await user.click(screen.getByText('STR (+1)'));
+    expect(rollDice).toHaveBeenCalledWith('2d6+1', 'STR Check');
+
+    await user.click(screen.getByText('d6'));
+    expect(rollDice).toHaveBeenCalledWith('d6');
+  });
+
+  it('shows roll result and history', () => {
+    const rollDice = vi.fn();
+    render(
+      <MoveList
+        character={minimalCharacter}
+        rollDice={rollDice}
+        getEquippedWeaponDamage={() => 'd8'}
+        rollResult="Result: 9"
+        rollHistory={rollHistory}
+      />,
+    );
+    expect(screen.getByText('Result: 9')).toBeInTheDocument();
+    expect(screen.getByText('Recent Rolls:')).toBeInTheDocument();
+    expect(screen.getByText(/2d6: 7/)).toBeInTheDocument();
+  });
+});

--- a/src/components/RollModal.test.jsx
+++ b/src/components/RollModal.test.jsx
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import RollModal from './RollModal.jsx';
+
+describe('RollModal', () => {
+  it('shows roll data and handles closing', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const data = { result: '12', description: 'Great roll', context: 'STR Check' };
+
+    render(<RollModal isOpen data={data} onClose={onClose} />);
+
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('Great roll')).toBeInTheDocument();
+    expect(screen.getByText('STR Check')).toBeInTheDocument();
+
+    await user.click(screen.getByText('×'));
+    await user.click(screen.getByText('Close'));
+
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/StatusModal.test.jsx
+++ b/src/components/StatusModal.test.jsx
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import StatusModal from './StatusModal.jsx';
+
+describe('StatusModal', () => {
+  it('handles status and debility toggles', async () => {
+    const user = userEvent.setup();
+    const onToggleStatusEffect = vi.fn();
+    const onToggleDebility = vi.fn();
+    const onClose = vi.fn();
+
+    const statusEffectTypes = { poisoned: { name: 'Poisoned' } };
+    const debilityTypes = { weak: { name: 'Weak' } };
+
+    render(
+      <StatusModal
+        statusEffects={[]}
+        debilities={[]}
+        statusEffectTypes={statusEffectTypes}
+        debilityTypes={debilityTypes}
+        onToggleStatusEffect={onToggleStatusEffect}
+        onToggleDebility={onToggleDebility}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Poisoned'));
+    expect(onToggleStatusEffect).toHaveBeenCalledWith('poisoned');
+
+    await user.click(screen.getByLabelText('Weak'));
+    expect(onToggleDebility).toHaveBeenCalledWith('weak');
+
+    await user.click(screen.getByText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add MoveList tests for stat and dice rolls with history display
- cover DamageModal armor math and cancel behavior
- test BondsModal add/resolve/remove flows
- verify StatusModal toggles and RollModal close actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689905e2654c8332be8ad460ae39e27b