### PR TITLE
Fix level-up newLevel and add auto-detection test

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,20 +1,19 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
-import LevelUpModal from './components/LevelUpModal';
-import InventoryModal from './components/InventoryModal';
-import StatusModal from './components/StatusModal';
-import RollModal from './components/RollModal';
-import BondsModal from './components/BondsModal';
-import DamageModal from './components/DamageModal';
-import { useCharacter } from './state/CharacterContext';
-import { statusEffectTypes, debilityTypes } from './state/character';
+import BondsModal from './components/BondsModal.jsx';
+import DamageModal from './components/DamageModal.jsx';
+import InventoryModal from './components/InventoryModal.jsx';
+import LevelUpModal from './components/LevelUpModal.jsx';
+import RollModal from './components/RollModal.jsx';
+import StatusModal from './components/StatusModal.jsx';
 import useModal from './hooks/useModal';
+import { statusEffectTypes, debilityTypes } from './state/character';
+import { useCharacter } from './state/CharacterContext.jsx';
 
 function App() {
   const { character, setCharacter } = useCharacter();
 
   // UI State Management
-  const [expandedMoves, setExpandedMoves] = useState({});
   const [rollResult, setRollResult] = useState('Ready to roll!');
   const rollModal = useModal();
   const bondsModal = useModal();
@@ -27,7 +26,6 @@ function App() {
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [showDamageModal, setShowDamageModal] = useState(false);
   const [showInventoryModal, setShowInventoryModal] = useState(false);
-  const [showExportModal, setShowExportModal] = useState(false);
   
   // Additional UI State
   const [compactMode, setCompactMode] = useState(false);
@@ -37,7 +35,7 @@ function App() {
     selectedStats: [],
     selectedMove: '',
     hpIncrease: 0,
-    newLevel: 5,
+    newLevel: character.level + 1,
     expandedMove: ''
   });
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import App from './App.jsx';
+import { INITIAL_CHARACTER_DATA } from './state/character.js';
+import CharacterContext from './state/CharacterContext.jsx';
+
+describe('App level up auto-detection', () => {
+  it('opens LevelUpModal when xp exceeds xpNeeded', async () => {
+    let setCharacter;
+    const initialCharacter = { ...INITIAL_CHARACTER_DATA, xp: 0, xpNeeded: 5 };
+
+    const Wrapper = ({ children }) => {
+      const [character, setChar] = React.useState(initialCharacter);
+      setCharacter = setChar;
+      return (
+        <CharacterContext.Provider value={{ character, setCharacter: setChar }}>
+          {children}
+        </CharacterContext.Provider>
+      );
+    };
+
+    render(
+      <Wrapper>
+        <App />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByRole('heading', { name: /LEVEL UP!/i })).toBeNull();
+
+    act(() => {
+      setCharacter((prev) => ({ ...prev, xp: 6 }));
+    });
+
+    expect(await screen.findByRole('heading', { name: /LEVEL UP!/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- derive the next level from the character's current level instead of hard-coding a value
- ensure import paths resolve and remove unused state
- test that LevelUpModal opens automatically when xp exceeds xpNeeded

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689905e34d288332872ae150bfa82032