### PR TITLE
feat: use DW score modifier lookup

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import './LevelUpModal.css';
 import { advancedMoves } from '../data/advancedMoves.js';
+import { scoreToMod } from '../utils/score.js';
 import Message from './Message.jsx';
 
 const LevelUpModal = ({
@@ -18,8 +19,8 @@ const LevelUpModal = ({
   // Helper functions
   const canIncreaseTwo = () => {
     const validStats = Object.entries(character.stats)
-      .filter(([_, data]) => data.score < 16)
-      .map(([stat, _]) => stat);
+      .filter(([, data]) => data.score < 16)
+      .map(([stat]) => stat);
     return validStats.length >= 2;
   };
 
@@ -91,7 +92,7 @@ const LevelUpModal = ({
     levelUpState.selectedStats.forEach((stat) => {
       newStats[stat] = {
         score: newStats[stat].score + 1,
-        mod: Math.floor((newStats[stat].score + 1 - 10) / 2),
+        mod: scoreToMod(newStats[stat].score + 1),
       };
     });
 
@@ -172,7 +173,13 @@ const LevelUpModal = ({
   };
 
   return (
-    <div className="levelup-overlay" onClick={handleOverlayClick}>
+    <div
+      className="levelup-overlay"
+      onClick={handleOverlayClick}
+      onKeyDown={(e) => e.key === 'Escape' && onClose()}
+      role="button"
+      tabIndex={0}
+    >
       <div className="levelup-modal">
         {/* Header */}
         <div className="levelup-header">
@@ -236,9 +243,8 @@ const LevelUpModal = ({
                   </div>
                   <div className="levelup-stat-mod">
                     ({data.mod >= 0 ? '+' : ''}
-                    {data.mod} →{' '}
-                    {Math.floor((Math.min(18, data.score + 1) - 10) / 2) >= 0 ? '+' : ''}
-                    {Math.floor((Math.min(18, data.score + 1) - 10) / 2)})
+                    {data.mod} → {scoreToMod(Math.min(18, data.score + 1)) >= 0 ? '+' : ''}
+                    {scoreToMod(Math.min(18, data.score + 1))})
                   </div>
                 </button>
               ))}
@@ -256,12 +262,18 @@ const LevelUpModal = ({
             <h3 className="levelup-step-title">⚔️ Step 2: Choose Advanced Move</h3>
             <div className="levelup-move-list">
               {Object.entries(advancedMoves)
-                .filter(([id, move]) => !character.selectedMoves.includes(id))
+                .filter(([id]) => !character.selectedMoves.includes(id))
                 .map(([id, move]) => (
                   <div key={id} className="levelup-move-wrapper">
                     <div
                       onClick={() => setLevelUpState((prev) => ({ ...prev, selectedMove: id }))}
+                      onKeyDown={(e) =>
+                        e.key === 'Enter' &&
+                        setLevelUpState((prev) => ({ ...prev, selectedMove: id }))
+                      }
                       className={moveButtonClass(id)}
+                      role="button"
+                      tabIndex={0}
                     >
                       <div className="levelup-move-header">
                         <div className="levelup-move-text">
@@ -274,6 +286,7 @@ const LevelUpModal = ({
                             setShowMoveDetails(showMoveDetails === id ? '' : id);
                           }}
                           className="levelup-details-button"
+                          type="button"
                         >
                           {showMoveDetails === id ? '▲' : '▼'}
                         </button>

--- a/src/utils/score.js
+++ b/src/utils/score.js
@@ -1,0 +1,24 @@
+export const scoreToMod = (score) => {
+  const table = {
+    3: -3,
+    4: -2,
+    5: -2,
+    6: -1,
+    7: -1,
+    8: -1,
+    9: 0,
+    10: 0,
+    11: 0,
+    12: 0,
+    13: 1,
+    14: 1,
+    15: 1,
+    16: 2,
+    17: 2,
+    18: 3,
+  };
+  if (!(score in table)) {
+    throw new Error('score must be between 3 and 18');
+  }
+  return table[score];
+};

--- a/src/utils/score.test.js
+++ b/src/utils/score.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { scoreToMod } from './score.js';
+
+describe('scoreToMod', () => {
+  it('changes from -1 to 0 between scores 8 and 9', () => {
+    expect(scoreToMod(8)).toBe(-1);
+    expect(scoreToMod(9)).toBe(0);
+  });
+
+  it('changes from 0 to 1 between scores 12 and 13', () => {
+    expect(scoreToMod(12)).toBe(0);
+    expect(scoreToMod(13)).toBe(1);
+  });
+
+  it('changes from 2 to 3 between scores 17 and 18', () => {
+    expect(scoreToMod(17)).toBe(2);
+    expect(scoreToMod(18)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add `scoreToMod` helper for Dungeon World ability scores
- replace direct math in `LevelUpModal` with lookup helper
- test score modifiers across key boundary values

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990e30b7b08332ad97ec0834ca0c95