### PR TITLE
Grant XP on roll misses

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -154,6 +154,7 @@ function App() {
       } else {
         interpretation = ' ❌ Failure';
         context = getFailureContext(description);
+        setCharacter(prev => ({ ...prev, xp: prev.xp + 1 }));
       }
     } else if (formula.startsWith('d')) {
       const sides = parseInt(formula.replace('d', '').split('+')[0]);

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,6 +1,6 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import App from './App.jsx';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
 import CharacterContext from './state/CharacterContext.jsx';
@@ -33,5 +33,38 @@ describe('App level up auto-detection', () => {
     });
 
     expect(await screen.findByRole('heading', { name: /LEVEL UP!/i })).toBeInTheDocument();
+  });
+});
+
+describe('XP gain on miss', () => {
+  it('increments XP when roll total is less than 7', () => {
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const initialCharacter = { ...INITIAL_CHARACTER_DATA, xp: 0, xpNeeded: 5 };
+
+    const Wrapper = ({ children }) => {
+      const [character, setCharacter] = React.useState(initialCharacter);
+      return (
+        <CharacterContext.Provider value={{ character, setCharacter }}>
+          {children}
+        </CharacterContext.Provider>
+      );
+    };
+
+    render(
+      <Wrapper>
+        <App />
+      </Wrapper>,
+    );
+
+    const button = screen.getByRole('button', { name: 'INT (+0)' });
+
+    act(() => {
+      fireEvent.click(button);
+    });
+
+    expect(screen.getByText(/XP: 1\/5/i)).toBeInTheDocument();
+
+    Math.random.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Award XP for roll misses by incrementing character XP when 2d6 total is below 7 before showing results
- Add regression test ensuring XP increases after a mocked failed roll

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990e3168f4833292769b2fedf2bc50