### PR TITLE
Simplify XP needed calculation

### DIFF
--- a/codex.md
+++ b/codex.md
@@ -49,7 +49,7 @@ When asking Codex to implement a new feature or component, provide a concise des
 > • Allow the user to increase one or two attribute scores and automatically recalculate their modifiers.  
 > • Present a list of available advanced moves (from `advancedMoves`) and let the user select one.  
 > • Roll new hit points (1d10 + CON modifier); update both `maxHp` and current `hp` accordingly.  
-> • Increment `level`, reset `xp` to 0 and recalc `xpNeeded` using `(level + 1) * 7`.  
+> • Increment `level`, reset `xp` to 0 and recalc `xpNeeded` using `level + 7`.
 > • Include Save and Cancel buttons; update the main character state on save and close the modal on either action.  
 > **Acceptance Criteria:** The modal opens when triggered, performs all calculations correctly, updates the state immutably, provides clear feedback for invalid selections (e.g. no stat chosen), and closes gracefully.
 

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -18,8 +18,8 @@ const LevelUpModal = ({
   // Helper functions
   const canIncreaseTwo = () => {
     const validStats = Object.entries(character.stats)
-      .filter(([_, data]) => data.score < 16)
-      .map(([stat, _]) => stat);
+      .filter(([, data]) => data.score < 16)
+      .map(([stat]) => stat);
     return validStats.length >= 2;
   };
 
@@ -103,7 +103,7 @@ const LevelUpModal = ({
       maxHp: prev.maxHp + levelUpState.hpIncrease,
       hp: prev.maxHp + levelUpState.hpIncrease, // Heal to full when leveling
       xp: prev.xp - prev.xpNeeded,
-      xpNeeded: (levelUpState.newLevel + 1) * 7,
+      xpNeeded: levelUpState.newLevel + 7,
       selectedMoves: [...prev.selectedMoves, levelUpState.selectedMove],
       actionHistory: [
         ...prev.actionHistory.slice(-4), // Keep last 4 actions
@@ -172,7 +172,14 @@ const LevelUpModal = ({
   };
 
   return (
-    <div className="levelup-overlay" onClick={handleOverlayClick}>
+    <div
+      className="levelup-overlay"
+      onClick={handleOverlayClick}
+      role="button"
+      tabIndex={0}
+      aria-label="Close"
+      onKeyDown={(e) => e.key === 'Enter' && handleOverlayClick(e)}
+    >
       <div className="levelup-modal">
         {/* Header */}
         <div className="levelup-header">
@@ -256,12 +263,18 @@ const LevelUpModal = ({
             <h3 className="levelup-step-title">⚔️ Step 2: Choose Advanced Move</h3>
             <div className="levelup-move-list">
               {Object.entries(advancedMoves)
-                .filter(([id, move]) => !character.selectedMoves.includes(id))
+                .filter(([id]) => !character.selectedMoves.includes(id))
                 .map(([id, move]) => (
                   <div key={id} className="levelup-move-wrapper">
                     <div
                       onClick={() => setLevelUpState((prev) => ({ ...prev, selectedMove: id }))}
                       className={moveButtonClass(id)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) =>
+                        e.key === 'Enter' &&
+                        setLevelUpState((prev) => ({ ...prev, selectedMove: id }))
+                      }
                     >
                       <div className="levelup-move-header">
                         <div className="levelup-move-text">
@@ -269,6 +282,7 @@ const LevelUpModal = ({
                           <p className="levelup-move-desc">{move.desc}</p>
                         </div>
                         <button
+                          type="button"
                           onClick={(e) => {
                             e.stopPropagation();
                             setShowMoveDetails(showMoveDetails === id ? '' : id);

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -1,3 +1,4 @@
+import { render, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
@@ -41,5 +42,57 @@ describe('LevelUpModal advanced moves', () => {
     );
 
     expect(html).toContain(advancedMoves.appetite.name);
+  });
+});
+
+describe('LevelUpModal XP calculation', () => {
+  it('sets xpNeeded to level + 7 after leveling', () => {
+    let character = {
+      name: 'Test',
+      level: 1,
+      stats: {
+        STR: { score: 10, mod: 0 },
+        DEX: { score: 10, mod: 0 },
+        CON: { score: 10, mod: 0 },
+        INT: { score: 10, mod: 0 },
+        WIS: { score: 10, mod: 0 },
+        CHA: { score: 10, mod: 0 },
+      },
+      maxHp: 10,
+      hp: 10,
+      xp: 8,
+      xpNeeded: 8,
+      selectedMoves: [],
+      actionHistory: [],
+    };
+
+    const levelUpState = {
+      selectedStats: ['STR'],
+      selectedMove: 'appetite',
+      hpIncrease: 1,
+      newLevel: 2,
+      expandedMove: '',
+    };
+
+    const setCharacter = (fn) => {
+      character = fn(character);
+    };
+
+    render(
+      <LevelUpModal
+        character={character}
+        setCharacter={setCharacter}
+        levelUpState={levelUpState}
+        setLevelUpState={() => {}}
+        onClose={() => {}}
+        rollDie={() => 1}
+        setRollResult={() => {}}
+      />,
+    );
+
+    const completeButton = screen.getByRole('button', { name: /Complete Level Up/i });
+    fireEvent.click(completeButton);
+
+    expect(character.xpNeeded).toBe(levelUpState.newLevel + 7);
   });
 });

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -4,7 +4,7 @@ export const INITIAL_CHARACTER_DATA = {
   hp: 15,
   maxHp: 25,
   xp: 4,
-  xpNeeded: 12, // Formula: (level + 1) * 7
+  xpNeeded: 11, // Formula: level + 7
   armor: 0,
 
   // Attributes


### PR DESCRIPTION
## Summary
- Compute xpNeeded as level + 7 in default character data and on level up
- Update docs and add regression test for new XP rule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990e2f78948332a98d4997e9b6395a