### PR TITLE
Use secure crypto RNG for dice rolls

### DIFF
--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -2,7 +2,15 @@ export const rollDie = (sides) => {
   if (!Number.isInteger(sides) || sides <= 0) {
     throw new Error('sides must be a positive integer');
   }
-  return Math.floor(Math.random() * sides) + 1;
+  if (typeof crypto?.randomInt === 'function') {
+    return crypto.randomInt(1, sides + 1);
+  }
+  if (typeof crypto?.getRandomValues === 'function') {
+    const array = new Uint32Array(1);
+    crypto.getRandomValues(array);
+    return (array[0] % sides) + 1;
+  }
+  throw new Error('Secure random number generation is not supported');
 };
 
 export const rollDice = (formula) => {

--- a/src/utils/dice.test.js
+++ b/src/utils/dice.test.js
@@ -1,9 +1,14 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 import { rollDie, rollDice } from './dice.js';
 
 describe('rollDie', () => {
   it('returns a value within 1..sides', () => {
-    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const spy = vi.spyOn(crypto, 'getRandomValues').mockImplementation((arr) => {
+      // force rollDie to return 4
+      arr[0] = 3; // (3 % 6) + 1 => 4
+      return arr;
+    });
     expect(rollDie(6)).toBe(4);
     spy.mockRestore();
   });
@@ -11,21 +16,44 @@ describe('rollDie', () => {
 
 describe('rollDice', () => {
   it('handles multi-die formulas', () => {
-    const spy = vi.spyOn(Math, 'random');
-    spy.mockReturnValueOnce(0.2).mockReturnValueOnce(0.8).mockReturnValueOnce(0.4);
+    const spy = vi.spyOn(crypto, 'getRandomValues');
+    spy
+      .mockImplementationOnce((arr) => {
+        arr[0] = 1; // (1 % 6) + 1 => 2
+        return arr;
+      })
+      .mockImplementationOnce((arr) => {
+        arr[0] = 4; // -> 5
+        return arr;
+      })
+      .mockImplementationOnce((arr) => {
+        arr[0] = 2; // -> 3
+        return arr;
+      });
     expect(rollDice('3d6+2')).toBe(12);
     spy.mockRestore();
   });
 
   it('handles single die formulas', () => {
-    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.2);
+    const spy = vi.spyOn(crypto, 'getRandomValues').mockImplementation((arr) => {
+      arr[0] = 1; // (1 % 8) + 1 => 2
+      return arr;
+    });
     expect(rollDice('d8+2')).toBe(4);
     spy.mockRestore();
   });
 
   it('handles negative modifiers', () => {
-    const spy = vi.spyOn(Math, 'random');
-    spy.mockReturnValueOnce(0.75).mockReturnValueOnce(0.25);
+    const spy = vi.spyOn(crypto, 'getRandomValues');
+    spy
+      .mockImplementationOnce((arr) => {
+        arr[0] = 3; // (3 % 4) + 1 => 4
+        return arr;
+      })
+      .mockImplementationOnce((arr) => {
+        arr[0] = 1; // -> 2
+        return arr;
+      });
     expect(rollDice('2d4-3')).toBe(3);
     spy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- replace Math.random with crypto.randomInt or crypto.getRandomValues to roll dice securely
- mock crypto.getRandomValues in dice tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899143363ec8332bf787ed3827175c2