### PR TITLE
feat: limit dice count

### DIFF
--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -1,3 +1,5 @@
+const MAX_COUNT = 1000;
+
 export const rollDie = (sides) => {
   if (!Number.isInteger(sides) || sides <= 0) {
     throw new Error('sides must be a positive integer');
@@ -11,6 +13,9 @@ export const rollDice = (formula) => {
     throw new Error('Unsupported formula');
   }
   const count = parseInt(match[1] || '1', 10);
+  if (count > MAX_COUNT) {
+    throw new Error(`count must not exceed ${MAX_COUNT}`);
+  }
   const sides = parseInt(match[2], 10);
   const modifier = parseInt(match[3] || '0', 10);
   let total = 0;

--- a/src/utils/dice.test.js
+++ b/src/utils/dice.test.js
@@ -33,4 +33,8 @@ describe('rollDice', () => {
   it('throws on unsupported formulas', () => {
     expect(() => rollDice('2d')).toThrow('Unsupported formula');
   });
+
+  it('throws when count exceeds the limit', () => {
+    expect(() => rollDice('1001d6')).toThrow('count must not exceed 1000');
+  });
 });


### PR DESCRIPTION
## Summary
- cap number of dice rolled in `rollDice` to avoid excessive loops
- add test ensuring rolls with more than 1000 dice throw an error

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899143796508332b2ebdf15ea3561d1