### PR TITLE
Refactor App into modular components and hooks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
-import BondsModal from './components/BondsModal.jsx';
 import CharacterStats from './components/CharacterStats.jsx';
-import DamageModal from './components/DamageModal.jsx';
-import InventoryModal from './components/InventoryModal.jsx';
+import DiceRoller from './components/DiceRoller.jsx';
+import GameModals from './components/GameModals.jsx';
 import InventoryPanel from './components/InventoryPanel.jsx';
-import LevelUpModal from './components/LevelUpModal.jsx';
-import RollModal from './components/RollModal.jsx';
 import SessionNotes from './components/SessionNotes.jsx';
-import StatusModal from './components/StatusModal.jsx';
-import { panelStyle, buttonStyle } from './components/styles.js';
+import { buttonStyle } from './components/styles.js';
+import useDiceRoller from './hooks/useDiceRoller';
+import useInventory from './hooks/useInventory';
 import useModal from './hooks/useModal';
 import { statusEffectTypes, debilityTypes } from './state/character';
 import { useCharacter } from './state/CharacterContext.jsx';
@@ -18,12 +16,10 @@ function App() {
   const { character, setCharacter } = useCharacter();
 
   // UI State Management
-  const [rollResult, setRollResult] = useState('Ready to roll!');
-  const rollModal = useModal();
   const bondsModal = useModal();
-  const [rollModalData, setRollModalData] = useState({});
-  const [rollHistory, setRollHistory] = useState([]);
-  const [sessionNotes, setSessionNotes] = useState('');
+  const [sessionNotes, setSessionNotes] = useState(
+    () => localStorage.getItem('sessionNotes') || '',
+  );
 
   // Modal States
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
@@ -34,6 +30,25 @@ function App() {
   // Additional UI State
   const [compactMode, setCompactMode] = useState(false);
   const [autoXpOnMiss, setAutoXpOnMiss] = useState(true);
+
+  const {
+    rollResult,
+    setRollResult,
+    rollHistory,
+    rollDice,
+    rollModal,
+    rollModalData,
+    rollDie,
+    clearRollHistory,
+  } = useDiceRoller(character, setCharacter, autoXpOnMiss);
+
+  const {
+    getTotalArmor,
+    getEquippedWeaponDamage,
+    handleEquipItem,
+    handleConsumeItem,
+    handleDropItem,
+  } = useInventory(character, setCharacter);
 
   // Level Up State
   const [levelUpState, setLevelUpState] = useState({
@@ -52,200 +67,13 @@ function App() {
     }
   }, [character.xp, character.xpNeeded, character.level, showLevelUpModal]);
 
-  // Utility Functions
-  const rollDie = (sides) => Math.floor(Math.random() * sides) + 1;
-
-  const getTotalArmor = () => {
-    const baseArmor = character.armor || 0;
-    const equippedArmor = character.inventory
-      .filter((item) => item.equipped && item.armor)
-      .reduce((total, item) => total + (item.armor || 0), 0);
-    return baseArmor + equippedArmor;
-  };
-
-  const getEquippedWeaponDamage = () => {
-    const weapon = character.inventory.find((item) => item.equipped && item.type === 'weapon');
-    return weapon ? weapon.damage || 'd6' : 'd6';
-  };
-
-  // Get status effect modifiers
-  const getStatusModifiers = (rollType = 'general') => {
-    let modifier = 0;
-    let notes = [];
-
-    if (character.statusEffects.includes('poisoned')) {
-      modifier -= 1;
-      notes.push('Poisoned (-1)');
+  useEffect(() => {
+    if (sessionNotes) {
+      localStorage.setItem('sessionNotes', sessionNotes);
+    } else {
+      localStorage.removeItem('sessionNotes');
     }
-    if (character.statusEffects.includes('shocked') && rollType === 'dex') {
-      modifier -= 2;
-      notes.push('Shocked (-2 DEX)');
-    }
-    if (character.statusEffects.includes('weakened') && rollType === 'damage') {
-      modifier -= 1;
-      notes.push('Weakened (-1 damage)');
-    }
-    if (character.statusEffects.includes('frozen') && (rollType === 'str' || rollType === 'dex')) {
-      modifier -= 1;
-      notes.push('Frozen (-1 physical)');
-    }
-    if (character.statusEffects.includes('blessed')) {
-      modifier += 1;
-      notes.push('Blessed (+1)');
-    }
-
-    // Add debility modifiers
-    character.debilities.forEach((debility) => {
-      if (
-        (debility === 'weak' && rollType === 'str') ||
-        (debility === 'shaky' && rollType === 'dex') ||
-        (debility === 'sick' && rollType === 'con') ||
-        (debility === 'stunned' && rollType === 'int') ||
-        (debility === 'confused' && rollType === 'wis') ||
-        (debility === 'scarred' && rollType === 'cha')
-      ) {
-        modifier -= 1;
-        notes.push(`${debilityTypes[debility].name} (-1)`);
-      }
-    });
-
-    return { modifier, notes };
-  };
-
-  // Core Dice Rolling System
-  const rollDice = (formula, description = '') => {
-    let result = '';
-    let total = 0;
-    let interpretation = '';
-    let context = '';
-
-    if (formula.includes('2d6')) {
-      const die1 = rollDie(6);
-      const die2 = rollDie(6);
-      const baseModifier = parseInt(formula.replace('2d6', '').replace('+', '') || '0');
-
-      // Determine roll type for status effects
-      let rollType = 'general';
-      if (description.includes('STR') || description.includes('Hack')) rollType = 'str';
-      else if (description.includes('DEX')) rollType = 'dex';
-      else if (description.includes('CON')) rollType = 'con';
-      else if (description.includes('INT')) rollType = 'int';
-      else if (description.includes('WIS')) rollType = 'wis';
-      else if (description.includes('CHA')) rollType = 'cha';
-      else if (
-        description.includes('damage') ||
-        description.includes('Damage') ||
-        description.includes('Upper Hand') ||
-        description.includes('Bonus Damage')
-      )
-        rollType = 'damage';
-
-      const statusMods = getStatusModifiers(rollType);
-      const totalModifier = baseModifier + statusMods.modifier;
-      total = die1 + die2 + totalModifier;
-
-      result = `2d6: [${die1}, ${die2}]`;
-      if (baseModifier !== 0) {
-        result += ` ${baseModifier >= 0 ? '+' : ''}${baseModifier}`;
-      }
-      if (statusMods.modifier !== 0) {
-        result += ` ${statusMods.modifier >= 0 ? '+' : ''}${statusMods.modifier}`;
-      }
-      result += ` = ${total}`;
-
-      if (statusMods.notes.length > 0) {
-        result += ` (${statusMods.notes.join(', ')})`;
-      }
-
-      // Dungeon World success thresholds
-      if (total >= 10) {
-        interpretation = ' ✅ Success!';
-        context = getSuccessContext(description);
-      } else if (total >= 7) {
-        interpretation = ' ⚠️ Partial Success';
-        context = getPartialContext(description);
-      } else {
-        interpretation = ' ❌ Failure';
-        context = getFailureContext(description);
-        if (autoXpOnMiss) {
-          setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
-        }
-      }
-    } else if (formula.startsWith('d')) {
-      const sides = parseInt(formula.replace('d', '').split('+')[0]);
-      const baseModifier = parseInt(formula.split('+')[1] || '0');
-      const roll = rollDie(sides);
-
-      const rollType =
-        description.includes('damage') || description.includes('Damage') ? 'damage' : 'general';
-      const statusMods = getStatusModifiers(rollType);
-      const totalModifier = baseModifier + statusMods.modifier;
-      total = roll + totalModifier;
-
-      result = `d${sides}: ${roll}`;
-      if (baseModifier !== 0) {
-        result += ` +${baseModifier}`;
-      }
-      if (statusMods.modifier !== 0) {
-        result += ` ${statusMods.modifier >= 0 ? '+' : ''}${statusMods.modifier}`;
-      }
-      result += ` = ${total}`;
-
-      if (statusMods.notes.length > 0) {
-        result += ` (${statusMods.notes.join(', ')})`;
-      }
-    }
-
-    const rollData = {
-      result: result + interpretation,
-      description,
-      context,
-      total,
-      timestamp: new Date().toLocaleTimeString(),
-    };
-
-    // Add to roll history (keep last 10)
-    setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);
-    setRollModalData(rollData);
-    rollModal.open();
-  };
-
-  // Context helpers for roll results
-  const getSuccessContext = (description) => {
-    if (description.includes('STR')) return 'Power through with overwhelming force!';
-    if (description.includes('DEX')) return 'Graceful and precise execution!';
-    if (description.includes('CON')) return 'Tough as cybernetic nails!';
-    if (description.includes('INT')) return 'Brilliant tactical insight!';
-    if (description.includes('WIS')) return 'Crystal clear perception!';
-    if (description.includes('CHA')) return 'Surprisingly charming for a cyber-barbarian!';
-    if (description.includes('Hack')) return "Clean hit, enemy can't counter!";
-    if (description.includes('Taunt')) return "They're completely focused on you now!";
-    return 'Perfect execution!';
-  };
-
-  const getPartialContext = (description) => {
-    if (description.includes('STR')) return 'Success, but strain yourself or equipment';
-    if (description.includes('DEX')) return 'Stumble slightly, awkward position';
-    if (description.includes('CON')) return 'Feel the strain, maybe take harm';
-    if (description.includes('INT')) return 'Confusing situation, partial info';
-    if (description.includes('WIS')) return "Something seems off, can't quite tell what";
-    if (description.includes('CHA')) return 'Awkward interaction, mixed signals';
-    if (description.includes('Hack')) return 'Hit them, but they hit you back!';
-    if (description.includes('Taunt')) return 'They attack you but with +1 ongoing damage!';
-    return 'Success with complications';
-  };
-
-  const getFailureContext = (description) => {
-    if (description.includes('STR')) return 'Too heavy, equipment fails, or overpower backfires';
-    if (description.includes('DEX')) return 'Trip, fumble, or end up in worse position';
-    if (description.includes('CON')) return 'Exhausted, hurt, or overcome by conditions';
-    if (description.includes('INT')) return 'No clue, wrong conclusion, or miss key detail';
-    if (description.includes('WIS')) return 'Completely missed the signs';
-    if (description.includes('CHA')) return 'Offensive, rude, or make things worse';
-    if (description.includes('Hack')) return 'Miss entirely, terrible position';
-    if (description.includes('Taunt')) return 'They ignore you completely';
-    return 'Things go badly';
-  };
+  }, [sessionNotes]);
 
   // Undo System
   const saveToHistory = (action) => {
@@ -253,7 +81,7 @@ function App() {
       ...prev,
       actionHistory: [
         { action, state: prev, timestamp: Date.now() },
-        ...prev.actionHistory.slice(0, 4), // Keep last 5 actions
+        ...prev.actionHistory.slice(0, 4),
       ],
     }));
   };
@@ -275,38 +103,6 @@ function App() {
     if (character.statusEffects.includes('frozen')) return 'frozen-overlay';
     if (character.statusEffects.includes('blessed')) return 'blessed-overlay';
     return '';
-  };
-
-  const handleEquipItem = (id) => {
-    setCharacter((prev) => ({
-      ...prev,
-      inventory: prev.inventory.map((item) =>
-        item.id === id ? { ...item, equipped: !item.equipped } : item,
-      ),
-    }));
-  };
-
-  const handleConsumeItem = (id) => {
-    setCharacter((prev) => ({
-      ...prev,
-      inventory: prev.inventory.reduce((acc, item) => {
-        if (item.id === id) {
-          if (item.quantity && item.quantity > 1) {
-            acc.push({ ...item, quantity: item.quantity - 1 });
-          }
-        } else {
-          acc.push(item);
-        }
-        return acc;
-      }, []),
-    }));
-  };
-
-  const handleDropItem = (id) => {
-    setCharacter((prev) => ({
-      ...prev,
-      inventory: prev.inventory.filter((item) => item.id !== id),
-    }));
   };
 
   const handleToggleStatusEffect = (effect) => {
@@ -338,10 +134,10 @@ function App() {
       return 'linear-gradient(45deg, #06b6d4, #3b82f6, #6366f1)';
     if (character.statusEffects.includes('blessed'))
       return 'linear-gradient(45deg, #fbbf24, #f59e0b, #00d4aa)';
-    return 'linear-gradient(45deg, #6366f1, #8b5cf6, #00d4aa)'; // default
+    return 'linear-gradient(45deg, #6366f1, #8b5cf6, #00d4aa)';
   };
 
-  // Styles using inline styles for Tauri compatibility
+  // Styles for Tauri compatibility
   const containerStyle = {
     minHeight: '100vh',
     background: 'linear-gradient(135deg, #1a1a2e, #16213e)',
@@ -462,204 +258,64 @@ function App() {
             autoXpOnMiss={autoXpOnMiss}
             setAutoXpOnMiss={setAutoXpOnMiss}
             setRollResult={setRollResult}
+            setSessionNotes={setSessionNotes}
+            clearRollHistory={clearRollHistory}
           />
 
           {/* Dice Roller Panel */}
-          <div style={panelStyle}>
-            <h3 style={{ color: '#00ff88', marginBottom: '15px', fontSize: '1.3rem' }}>
-              🎲 Dice Roller
-            </h3>
+          <DiceRoller
+            character={character}
+            rollDice={rollDice}
+            rollResult={rollResult}
+            rollHistory={rollHistory}
+            getEquippedWeaponDamage={getEquippedWeaponDamage}
+            rollModal={rollModal}
+            rollModalData={rollModalData}
+          />
 
-            {/* Stat Check Buttons */}
-            <div style={{ marginBottom: '15px' }}>
-              <h4 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1rem' }}>
-                Stat Checks
-              </h4>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '5px' }}>
-                {Object.entries(character.stats).map(([stat, data]) => (
-                  <button
-                    key={stat}
-                    onClick={() => rollDice(`2d6+${data.mod}`, `${stat} Check`)}
-                    style={{
-                      ...buttonStyle,
-                      background: 'linear-gradient(45deg, #8b5cf6, #7c3aed)',
-                      padding: '8px 6px',
-                      margin: '2px',
-                      fontSize: '11px',
-                    }}
-                  >
-                    {stat} ({data.mod >= 0 ? '+' : ''}
-                    {data.mod})
-                  </button>
-                ))}
-              </div>
-            </div>
+          {/* Quick Inventory Panel */}
+          <InventoryPanel
+            character={character}
+            setCharacter={setCharacter}
+            rollDie={rollDie}
+            setRollResult={setRollResult}
+          />
 
-            {/* Combat Rolls */}
-            <div style={{ marginBottom: '15px' }}>
-              <h4 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1rem' }}>
-                Combat Rolls
-              </h4>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '5px' }}>
-                <button
-                  onClick={() => rollDice(getEquippedWeaponDamage(), 'Weapon Damage')}
-                  style={{
-                    ...buttonStyle,
-                    background: 'linear-gradient(45deg, #ef4444, #dc2626)',
-                    margin: '2px',
-                    fontSize: '11px',
-                  }}
-                >
-                  Weapon ({getEquippedWeaponDamage()})
-                </button>
-                <button
-                  onClick={() => rollDice('2d6+3', 'Hack & Slash')}
-                  style={{
-                    ...buttonStyle,
-                    background: 'linear-gradient(45deg, #8b5cf6, #7c3aed)',
-                    margin: '2px',
-                    fontSize: '11px',
-                  }}
-                >
-                  Hack & Slash
-                </button>
-                <button
-                  onClick={() => rollDice('d4', 'Upper Hand')}
-                  style={{
-                    ...buttonStyle,
-                    background: 'linear-gradient(45deg, #f97316, #ea580c)',
-                    margin: '2px',
-                    fontSize: '11px',
-                  }}
-                >
-                  Upper Hand d4
-                </button>
-                <button
-                  onClick={() => rollDice('2d6-1', 'Taunt')}
-                  style={{
-                    ...buttonStyle,
-                    background: 'linear-gradient(45deg, #eab308, #d97706)',
-                    margin: '2px',
-                    fontSize: '11px',
-                  }}
-                >
-                  Taunt Enemy
-                </button>
-              </div>
-            </div>
-
-            {/* Basic Dice */}
-            <div style={{ marginBottom: '15px' }}>
-              <h4 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1rem' }}>
-                Basic Dice
-              </h4>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '5px' }}>
-                {[4, 6, 8, 10, 12, 20].map((sides) => (
-                  <button
-                    key={sides}
-                    onClick={() => rollDice(`d${sides}`)}
-                    style={{
-                      ...buttonStyle,
-                      background: 'linear-gradient(45deg, #06b6d4, #0891b2)',
-                      padding: '8px 4px',
-                      margin: '2px',
-                      fontSize: '11px',
-                    }}
-                  >
-                    d{sides}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Roll Result Display */}
-            <div
-              style={{
-                background: 'rgba(0, 255, 136, 0.2)',
-                padding: '10px',
-                borderRadius: '6px',
-                textAlign: 'center',
-                fontWeight: 'bold',
-                minHeight: '40px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              {rollResult}
-            </div>
-
-            {/* Roll History */}
-            {rollHistory.length > 0 && (
-              <div style={{ marginTop: '10px', fontSize: '0.8rem' }}>
-                <div style={{ color: '#00ff88', marginBottom: '5px' }}>Recent Rolls:</div>
-                {rollHistory.slice(0, 3).map((roll, index) => (
-                  <div key={index} style={{ color: '#aaa', marginBottom: '2px' }}>
-                    <span style={{ color: '#00ff88' }}>{roll.timestamp}</span> - {roll.result}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-            {/* Quick Inventory Panel */}
-            <InventoryPanel
-              character={character}
-              setCharacter={setCharacter}
-              rollDie={rollDie}
-              setRollResult={setRollResult}
-            />
-
-            {/* Session Notes Panel */}
-
-            <SessionNotes
-              sessionNotes={sessionNotes}
-              setSessionNotes={setSessionNotes}
-              compactMode={compactMode}
-              setCompactMode={setCompactMode}
-            />
+          {/* Session Notes Panel */}
+          <SessionNotes
+            sessionNotes={sessionNotes}
+            setSessionNotes={setSessionNotes}
+            compactMode={compactMode}
+            setCompactMode={setCompactMode}
+          />
         </div>
       </div>
 
-      <RollModal isOpen={rollModal.isOpen} data={rollModalData} onClose={rollModal.close} />
-
-      {showLevelUpModal && (
-        <LevelUpModal
-          character={character}
-          setCharacter={setCharacter}
-          levelUpState={levelUpState}
-          setLevelUpState={setLevelUpState}
-          onClose={() => setShowLevelUpModal(false)}
-          rollDie={rollDie}
-          setRollResult={setRollResult}
-        />
-      )}
-
-      {showStatusModal && (
-        <StatusModal
-          statusEffects={character.statusEffects}
-          debilities={character.debilities}
-          statusEffectTypes={statusEffectTypes}
-          debilityTypes={debilityTypes}
-          onToggleStatusEffect={handleToggleStatusEffect}
-          onToggleDebility={handleToggleDebility}
-          onClose={() => setShowStatusModal(false)}
-        />
-      )}
-
-      <DamageModal isOpen={showDamageModal} onClose={() => setShowDamageModal(false)} />
-
-      {showInventoryModal && (
-        <InventoryModal
-          inventory={character.inventory}
-          onEquip={handleEquipItem}
-          onConsume={handleConsumeItem}
-          onDrop={handleDropItem}
-          onClose={() => setShowInventoryModal(false)}
-        />
-      )}
-
-      <BondsModal isOpen={bondsModal.isOpen} onClose={bondsModal.close} />
+      <GameModals
+        character={character}
+        setCharacter={setCharacter}
+        levelUpState={levelUpState}
+        setLevelUpState={setLevelUpState}
+        showLevelUpModal={showLevelUpModal}
+        setShowLevelUpModal={setShowLevelUpModal}
+        rollDie={rollDie}
+        setRollResult={setRollResult}
+        showStatusModal={showStatusModal}
+        setShowStatusModal={setShowStatusModal}
+        statusEffectTypes={statusEffectTypes}
+        debilityTypes={debilityTypes}
+        handleToggleStatusEffect={handleToggleStatusEffect}
+        handleToggleDebility={handleToggleDebility}
+        showDamageModal={showDamageModal}
+        setShowDamageModal={setShowDamageModal}
+        showInventoryModal={showInventoryModal}
+        setShowInventoryModal={setShowInventoryModal}
+        inventory={character.inventory}
+        handleEquipItem={handleEquipItem}
+        handleConsumeItem={handleConsumeItem}
+        handleDropItem={handleDropItem}
+        bondsModal={bondsModal}
+      />
     </div>
   );
 }

--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -120,6 +120,8 @@ const CharacterStats = ({
   autoXpOnMiss,
   setAutoXpOnMiss,
   setRollResult,
+  setSessionNotes,
+  clearRollHistory,
 }) => {
   return (
     <div style={panelStyle}>
@@ -315,6 +317,8 @@ const CharacterStats = ({
               advGear: 5,
             },
           }));
+          setSessionNotes('');
+          clearRollHistory();
           setRollResult('🔄 All resources restored!');
         }}
         style={resetButtonStyle}

--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import RollModal from './RollModal.jsx';
+import { panelStyle, buttonStyle } from './styles.js';
+
+const DiceRoller = ({
+  character,
+  rollDice,
+  rollResult,
+  rollHistory,
+  getEquippedWeaponDamage,
+  rollModal,
+  rollModalData,
+}) => (
+  <>
+    <div style={panelStyle}>
+      <h3 style={{ color: '#00ff88', marginBottom: '15px', fontSize: '1.3rem' }}>🎲 Dice Roller</h3>
+
+      {/* Stat Check Buttons */}
+      <div style={{ marginBottom: '15px' }}>
+        <h4 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1rem' }}>Stat Checks</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '5px' }}>
+          {Object.entries(character.stats).map(([stat, data]) => (
+            <button
+              key={stat}
+              onClick={() => rollDice(`2d6+${data.mod}`, `${stat} Check`)}
+              style={{
+                ...buttonStyle,
+                background: 'linear-gradient(45deg, #8b5cf6, #7c3aed)',
+                padding: '8px 6px',
+                margin: '2px',
+                fontSize: '11px',
+              }}
+            >
+              {stat} ({data.mod >= 0 ? '+' : ''}
+              {data.mod})
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Combat Rolls */}
+      <div style={{ marginBottom: '15px' }}>
+        <h4 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1rem' }}>Combat Rolls</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '5px' }}>
+          <button
+            onClick={() => rollDice(getEquippedWeaponDamage(), 'Weapon Damage')}
+            style={{
+              ...buttonStyle,
+              background: 'linear-gradient(45deg, #ef4444, #dc2626)',
+              margin: '2px',
+              fontSize: '11px',
+            }}
+          >
+            Weapon ({getEquippedWeaponDamage()})
+          </button>
+          <button
+            onClick={() => rollDice('2d6+3', 'Hack & Slash')}
+            style={{
+              ...buttonStyle,
+              background: 'linear-gradient(45deg, #8b5cf6, #7c3aed)',
+              margin: '2px',
+              fontSize: '11px',
+            }}
+          >
+            Hack & Slash
+          </button>
+          <button
+            onClick={() => rollDice('d4', 'Upper Hand')}
+            style={{
+              ...buttonStyle,
+              background: 'linear-gradient(45deg, #f97316, #ea580c)',
+              margin: '2px',
+              fontSize: '11px',
+            }}
+          >
+            Upper Hand d4
+          </button>
+          <button
+            onClick={() => rollDice('2d6-1', 'Taunt')}
+            style={{
+              ...buttonStyle,
+              background: 'linear-gradient(45deg, #eab308, #d97706)',
+              margin: '2px',
+              fontSize: '11px',
+            }}
+          >
+            Taunt Enemy
+          </button>
+        </div>
+      </div>
+
+      {/* Basic Dice */}
+      <div style={{ marginBottom: '15px' }}>
+        <h4 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1rem' }}>Basic Dice</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '5px' }}>
+          {[4, 6, 8, 10, 12, 20].map((sides) => (
+            <button
+              key={sides}
+              onClick={() => rollDice(`d${sides}`)}
+              style={{
+                ...buttonStyle,
+                background: 'linear-gradient(45deg, #06b6d4, #0891b2)',
+                padding: '8px 4px',
+                margin: '2px',
+                fontSize: '11px',
+              }}
+            >
+              d{sides}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Roll Result Display */}
+      <div
+        style={{
+          background: 'rgba(0, 255, 136, 0.2)',
+          padding: '10px',
+          borderRadius: '6px',
+          textAlign: 'center',
+          fontWeight: 'bold',
+          minHeight: '40px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {rollResult}
+      </div>
+
+      {/* Roll History */}
+      {rollHistory.length > 0 && (
+        <div style={{ marginTop: '10px', fontSize: '0.8rem' }}>
+          <div style={{ color: '#00ff88', marginBottom: '5px' }}>Recent Rolls:</div>
+          {rollHistory.slice(0, 3).map((roll, index) => (
+            <div key={index} style={{ color: '#aaa', marginBottom: '2px' }}>
+              <span style={{ color: '#00ff88' }}>{roll.timestamp}</span> - {roll.result}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+    <RollModal isOpen={rollModal.isOpen} data={rollModalData} onClose={rollModal.close} />
+  </>
+);
+
+export default DiceRoller;

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import BondsModal from './BondsModal.jsx';
+import DamageModal from './DamageModal.jsx';
+import InventoryModal from './InventoryModal.jsx';
+import LevelUpModal from './LevelUpModal.jsx';
+import StatusModal from './StatusModal.jsx';
+
+const GameModals = ({
+  character,
+  setCharacter,
+  levelUpState,
+  setLevelUpState,
+  showLevelUpModal,
+  setShowLevelUpModal,
+  rollDie,
+  setRollResult,
+  showStatusModal,
+  setShowStatusModal,
+  statusEffectTypes,
+  debilityTypes,
+  handleToggleStatusEffect,
+  handleToggleDebility,
+  showDamageModal,
+  setShowDamageModal,
+  showInventoryModal,
+  setShowInventoryModal,
+  inventory,
+  handleEquipItem,
+  handleConsumeItem,
+  handleDropItem,
+  bondsModal,
+}) => (
+  <>
+    {showLevelUpModal && (
+      <LevelUpModal
+        character={character}
+        setCharacter={setCharacter}
+        levelUpState={levelUpState}
+        setLevelUpState={setLevelUpState}
+        onClose={() => setShowLevelUpModal(false)}
+        rollDie={rollDie}
+        setRollResult={setRollResult}
+      />
+    )}
+
+    {showStatusModal && (
+      <StatusModal
+        statusEffects={character.statusEffects}
+        debilities={character.debilities}
+        statusEffectTypes={statusEffectTypes}
+        debilityTypes={debilityTypes}
+        onToggleStatusEffect={handleToggleStatusEffect}
+        onToggleDebility={handleToggleDebility}
+        onClose={() => setShowStatusModal(false)}
+      />
+    )}
+
+    <DamageModal isOpen={showDamageModal} onClose={() => setShowDamageModal(false)} />
+
+    {showInventoryModal && (
+      <InventoryModal
+        inventory={inventory}
+        onEquip={handleEquipItem}
+        onConsume={handleConsumeItem}
+        onDrop={handleDropItem}
+        onClose={() => setShowInventoryModal(false)}
+      />
+    )}
+
+    <BondsModal isOpen={bondsModal.isOpen} onClose={bondsModal.close} />
+  </>
+);
+
+export default GameModals;

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -1,0 +1,206 @@
+import { useState, useEffect } from 'react';
+import { debilityTypes } from '../state/character';
+import useModal from './useModal';
+
+export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
+  const [rollResult, setRollResult] = useState('Ready to roll!');
+  const [rollModalData, setRollModalData] = useState({});
+  const [rollHistory, setRollHistory] = useState(() => {
+    const saved = localStorage.getItem('rollHistory');
+    return saved ? JSON.parse(saved) : [];
+  });
+  const rollModal = useModal();
+
+  const rollDie = (sides) => Math.floor(Math.random() * sides) + 1;
+
+  useEffect(() => {
+    if (rollHistory.length > 0) {
+      localStorage.setItem('rollHistory', JSON.stringify(rollHistory));
+    } else {
+      localStorage.removeItem('rollHistory');
+    }
+  }, [rollHistory]);
+
+  const getStatusModifiers = (rollType = 'general') => {
+    let modifier = 0;
+    const notes = [];
+
+    if (character.statusEffects.includes('poisoned')) {
+      modifier -= 1;
+      notes.push('Poisoned (-1)');
+    }
+    if (character.statusEffects.includes('shocked') && rollType === 'dex') {
+      modifier -= 2;
+      notes.push('Shocked (-2 DEX)');
+    }
+    if (character.statusEffects.includes('weakened') && rollType === 'damage') {
+      modifier -= 1;
+      notes.push('Weakened (-1 damage)');
+    }
+    if (character.statusEffects.includes('frozen') && (rollType === 'str' || rollType === 'dex')) {
+      modifier -= 1;
+      notes.push('Frozen (-1 physical)');
+    }
+    if (character.statusEffects.includes('blessed')) {
+      modifier += 1;
+      notes.push('Blessed (+1)');
+    }
+
+    character.debilities.forEach((debility) => {
+      if (
+        (debility === 'weak' && rollType === 'str') ||
+        (debility === 'shaky' && rollType === 'dex') ||
+        (debility === 'sick' && rollType === 'con') ||
+        (debility === 'stunned' && rollType === 'int') ||
+        (debility === 'confused' && rollType === 'wis') ||
+        (debility === 'scarred' && rollType === 'cha')
+      ) {
+        modifier -= 1;
+        notes.push(`${debilityTypes[debility].name} (-1)`);
+      }
+    });
+
+    return { modifier, notes };
+  };
+
+  const getSuccessContext = (description) => {
+    if (description.includes('STR')) return 'Power through with overwhelming force!';
+    if (description.includes('DEX')) return 'Graceful and precise execution!';
+    if (description.includes('CON')) return 'Tough as cybernetic nails!';
+    if (description.includes('INT')) return 'Brilliant tactical insight!';
+    if (description.includes('WIS')) return 'Crystal clear perception!';
+    if (description.includes('CHA')) return 'Surprisingly charming for a cyber-barbarian!';
+    if (description.includes('Hack')) return "Clean hit, enemy can't counter!";
+    if (description.includes('Taunt')) return "They're completely focused on you now!";
+    return 'Perfect execution!';
+  };
+
+  const getPartialContext = (description) => {
+    if (description.includes('STR')) return 'Success, but strain yourself or equipment';
+    if (description.includes('DEX')) return 'Stumble slightly, awkward position';
+    if (description.includes('CON')) return 'Feel the strain, maybe take harm';
+    if (description.includes('INT')) return 'Confusing situation, partial info';
+    if (description.includes('WIS')) return "Something seems off, can't quite tell what";
+    if (description.includes('CHA')) return 'Awkward interaction, mixed signals';
+    if (description.includes('Hack')) return 'Hit them, but they hit you back!';
+    if (description.includes('Taunt')) return 'They attack you but with +1 ongoing damage!';
+    return 'Success with complications';
+  };
+
+  const getFailureContext = (description) => {
+    if (description.includes('STR')) return 'Too heavy, equipment fails, or overpower backfires';
+    if (description.includes('DEX')) return 'Trip, fumble, or end up in worse position';
+    if (description.includes('CON')) return 'Exhausted, hurt, or overcome by conditions';
+    if (description.includes('INT')) return 'No clue, wrong conclusion, or miss key detail';
+    if (description.includes('WIS')) return 'Completely missed the signs';
+    if (description.includes('CHA')) return 'Offensive, rude, or make things worse';
+    if (description.includes('Hack')) return 'Miss entirely, terrible position';
+    if (description.includes('Taunt')) return 'They ignore you completely';
+    return 'Things go badly';
+  };
+
+  const rollDice = (formula, description = '') => {
+    let result = '';
+    let total = 0;
+    let interpretation = '';
+    let context = '';
+
+    if (formula.includes('2d6')) {
+      const die1 = rollDie(6);
+      const die2 = rollDie(6);
+      const baseModifier = parseInt(formula.replace('2d6', '').replace('+', '') || '0');
+
+      let rollType = 'general';
+      if (description.includes('STR') || description.includes('Hack')) rollType = 'str';
+      else if (description.includes('DEX')) rollType = 'dex';
+      else if (description.includes('CON')) rollType = 'con';
+      else if (description.includes('INT')) rollType = 'int';
+      else if (description.includes('WIS')) rollType = 'wis';
+      else if (description.includes('CHA')) rollType = 'cha';
+      else if (
+        description.includes('damage') ||
+        description.includes('Damage') ||
+        description.includes('Upper Hand') ||
+        description.includes('Bonus Damage')
+      )
+        rollType = 'damage';
+
+      const statusMods = getStatusModifiers(rollType);
+      const totalModifier = baseModifier + statusMods.modifier;
+      total = die1 + die2 + totalModifier;
+
+      result = `2d6: [${die1}, ${die2}]`;
+      if (baseModifier !== 0) {
+        result += ` ${baseModifier >= 0 ? '+' : ''}${baseModifier}`;
+      }
+      if (statusMods.modifier !== 0) {
+        result += ` ${statusMods.modifier >= 0 ? '+' : ''}${statusMods.modifier}`;
+      }
+      result += ` = ${total}`;
+
+      if (statusMods.notes.length > 0) {
+        result += ` (${statusMods.notes.join(', ')})`;
+      }
+
+      if (total >= 10) {
+        interpretation = ' ✅ Success!';
+        context = getSuccessContext(description);
+      } else if (total >= 7) {
+        interpretation = ' ⚠️ Partial Success';
+        context = getPartialContext(description);
+      } else {
+        interpretation = ' ❌ Failure';
+        context = getFailureContext(description);
+        if (autoXpOnMiss) {
+          setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
+        }
+      }
+    } else if (formula.startsWith('d')) {
+      const sides = parseInt(formula.replace('d', '').split('+')[0]);
+      const baseModifier = parseInt(formula.split('+')[1] || '0');
+      const roll = rollDie(sides);
+
+      const rollType =
+        description.includes('damage') || description.includes('Damage') ? 'damage' : 'general';
+      const statusMods = getStatusModifiers(rollType);
+      const totalModifier = baseModifier + statusMods.modifier;
+      total = roll + totalModifier;
+
+      result = `d${sides}: ${roll}`;
+      if (baseModifier !== 0) {
+        result += ` +${baseModifier}`;
+      }
+      if (statusMods.modifier !== 0) {
+        result += ` ${statusMods.modifier >= 0 ? '+' : ''}${statusMods.modifier}`;
+      }
+      result += ` = ${total}`;
+
+      if (statusMods.notes.length > 0) {
+        result += ` (${statusMods.notes.join(', ')})`;
+      }
+    }
+
+    const rollData = {
+      result: result + interpretation,
+      description,
+      context,
+      total,
+      timestamp: new Date().toLocaleTimeString(),
+    };
+
+    setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);
+    setRollModalData(rollData);
+    rollModal.open();
+  };
+
+  return {
+    rollResult,
+    setRollResult,
+    rollHistory,
+    rollDice,
+    rollModal,
+    rollModalData,
+    rollDie,
+    clearRollHistory: () => setRollHistory([]),
+  };
+}

--- a/src/hooks/useInventory.js
+++ b/src/hooks/useInventory.js
@@ -1,0 +1,65 @@
+import { useCallback } from 'react';
+
+export default function useInventory(character, setCharacter) {
+  const getTotalArmor = useCallback(() => {
+    const baseArmor = character.armor || 0;
+    const equippedArmor = character.inventory
+      .filter((item) => item.equipped && item.armor)
+      .reduce((total, item) => total + (item.armor || 0), 0);
+    return baseArmor + equippedArmor;
+  }, [character]);
+
+  const getEquippedWeaponDamage = useCallback(() => {
+    const weapon = character.inventory.find((item) => item.equipped && item.type === 'weapon');
+    return weapon ? weapon.damage || 'd6' : 'd6';
+  }, [character]);
+
+  const handleEquipItem = useCallback(
+    (id) => {
+      setCharacter((prev) => ({
+        ...prev,
+        inventory: prev.inventory.map((item) =>
+          item.id === id ? { ...item, equipped: !item.equipped } : item,
+        ),
+      }));
+    },
+    [setCharacter],
+  );
+
+  const handleConsumeItem = useCallback(
+    (id) => {
+      setCharacter((prev) => ({
+        ...prev,
+        inventory: prev.inventory.reduce((acc, item) => {
+          if (item.id === id) {
+            if (item.quantity && item.quantity > 1) {
+              acc.push({ ...item, quantity: item.quantity - 1 });
+            }
+          } else {
+            acc.push(item);
+          }
+          return acc;
+        }, []),
+      }));
+    },
+    [setCharacter],
+  );
+
+  const handleDropItem = useCallback(
+    (id) => {
+      setCharacter((prev) => ({
+        ...prev,
+        inventory: prev.inventory.filter((item) => item.id !== id),
+      }));
+    },
+    [setCharacter],
+  );
+
+  return {
+    getTotalArmor,
+    getEquippedWeaponDamage,
+    handleEquipItem,
+    handleConsumeItem,
+    handleDropItem,
+  };
+}


### PR DESCRIPTION
## Summary
- modularize dice rolling into `useDiceRoller` hook and `DiceRoller` component with history persistence
- extract inventory operations into `useInventory` hook
- centralize modal rendering via new `GameModals` component and tidy reset behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899694d1e208332a7669e387ff38746