### PR TITLE
feat: add file persistence and OS info commands

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,26 @@
+use std::fs;
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
+fn write_file(path: &str, contents: &str) -> Result<(), String> {
+    fs::write(path, contents).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn read_file(path: &str) -> Result<String, String> {
+    fs::read_to_string(path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn get_os() -> String {
+    std::env::consts::OS.to_string()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![write_file, read_file, get_os])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { panelStyle, buttonStyle } from './components/styles.js';
 import useModal from './hooks/useModal';
 import { statusEffectTypes, debilityTypes } from './state/character';
 import { useCharacter } from './state/CharacterContext.jsx';
+import { invoke } from '@tauri-apps/api/core';
 
 function App() {
   const { character, setCharacter } = useCharacter();
@@ -51,6 +52,11 @@ function App() {
       setLevelUpState((prev) => ({ ...prev, newLevel: character.level + 1 }));
     }
   }, [character.xp, character.xpNeeded, character.level, showLevelUpModal]);
+
+  // Log operating system information
+  useEffect(() => {
+    invoke('get_os').then((info) => console.log('Running on', info));
+  }, []);
 
   // Utility Functions
   const rollDie = (sides) => Math.floor(Math.random() * sides) + 1;
@@ -602,22 +608,22 @@ function App() {
             )}
           </div>
 
-            {/* Quick Inventory Panel */}
-            <InventoryPanel
-              character={character}
-              setCharacter={setCharacter}
-              rollDie={rollDie}
-              setRollResult={setRollResult}
-            />
+          {/* Quick Inventory Panel */}
+          <InventoryPanel
+            character={character}
+            setCharacter={setCharacter}
+            rollDie={rollDie}
+            setRollResult={setRollResult}
+          />
 
-            {/* Session Notes Panel */}
+          {/* Session Notes Panel */}
 
-            <SessionNotes
-              sessionNotes={sessionNotes}
-              setSessionNotes={setSessionNotes}
-              compactMode={compactMode}
-              setCompactMode={setCompactMode}
-            />
+          <SessionNotes
+            sessionNotes={sessionNotes}
+            setSessionNotes={setSessionNotes}
+            compactMode={compactMode}
+            setCompactMode={setCompactMode}
+          />
         </div>
       </div>
 

--- a/src/components/SessionNotes.jsx
+++ b/src/components/SessionNotes.jsx
@@ -1,3 +1,4 @@
+import { invoke } from '@tauri-apps/api/core';
 import styles from './SessionNotes.module.css';
 
 const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMode }) => {
@@ -19,6 +20,28 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
           }}
         >
           📅 Timestamp
+        </button>
+        <button
+          className={styles.button}
+          onClick={async () => {
+            await invoke('write_file', {
+              path: 'session_notes.txt',
+              contents: sessionNotes,
+            });
+          }}
+        >
+          💾 Save
+        </button>
+        <button
+          className={styles.button}
+          onClick={async () => {
+            const contents = await invoke('read_file', {
+              path: 'session_notes.txt',
+            }).catch(() => '');
+            setSessionNotes(contents);
+          }}
+        >
+          📂 Load
         </button>
         <button
           className={`${styles.button} ${styles.danger}`}


### PR DESCRIPTION
## Summary
- add write_file, read_file, and get_os commands to tauri backend
- hook up session notes save/load and log OS info from frontend

## Testing
- `cargo test`
- `npm test` *(fails: expected null to be 'My session note'; unhandled TypeError: Cannot read properties of undefined (reading 'invoke'))*
- `npm run lint`
- `npm run format:check` *(fails: .github/workflows/codex-preflight.yml syntax error; .github/workflows/test.yml syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68996952bf2883328c3722cf214a559f