### PR TITLE
Add missing useModal import in App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import SessionNotes from './components/SessionNotes.jsx';
 import { buttonStyle } from './components/styles.js';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
+import useModal from './hooks/useModal';
 import { statusEffectTypes, debilityTypes } from './state/character';
 import { useCharacter } from './state/CharacterContext.jsx';
 
@@ -17,7 +18,7 @@ function App() {
   // UI State
   const bondsModal = useModal();
   const [sessionNotes, setSessionNotes] = useState(
-    () => localStorage.getItem('sessionNotes') ?? 'My session note'
+    () => localStorage.getItem('sessionNotes') ?? 'My session note',
   );
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
   const [showStatusModal, setShowStatusModal] = useState(false);


### PR DESCRIPTION
## Summary
- Import `useModal` hook into `App` to fix missing reference

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68996f41b83c8332aa1d36cfec83f2c4