### PR TITLE
Make dice context checks case-insensitive

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import SessionNotes from './components/SessionNotes.jsx';
 import { buttonStyle } from './components/styles.js';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
+import useModal from './hooks/useModal.js';
 import { statusEffectTypes, debilityTypes } from './state/character';
 import { useCharacter } from './state/CharacterContext.jsx';
 
@@ -17,7 +18,7 @@ function App() {
   // UI State
   const bondsModal = useModal();
   const [sessionNotes, setSessionNotes] = useState(
-    () => localStorage.getItem('sessionNotes') ?? 'My session note'
+    () => localStorage.getItem('sessionNotes') ?? 'My session note',
   );
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
   const [showStatusModal, setShowStatusModal] = useState(false);

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -64,38 +64,41 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
   };
 
   const getSuccessContext = (description) => {
-    if (description.includes('STR')) return 'Power through with overwhelming force!';
-    if (description.includes('DEX')) return 'Graceful and precise execution!';
-    if (description.includes('CON')) return 'Tough as cybernetic nails!';
-    if (description.includes('INT')) return 'Brilliant tactical insight!';
-    if (description.includes('WIS')) return 'Crystal clear perception!';
-    if (description.includes('CHA')) return 'Surprisingly charming for a cyber-barbarian!';
-    if (description.includes('Hack')) return "Clean hit, enemy can't counter!";
-    if (description.includes('Taunt')) return "They're completely focused on you now!";
+    description = description.toLowerCase();
+    if (description.includes('str')) return 'Power through with overwhelming force!';
+    if (description.includes('dex')) return 'Graceful and precise execution!';
+    if (description.includes('con')) return 'Tough as cybernetic nails!';
+    if (description.includes('int')) return 'Brilliant tactical insight!';
+    if (description.includes('wis')) return 'Crystal clear perception!';
+    if (description.includes('cha')) return 'Surprisingly charming for a cyber-barbarian!';
+    if (description.includes('hack')) return "Clean hit, enemy can't counter!";
+    if (description.includes('taunt')) return "They're completely focused on you now!";
     return 'Perfect execution!';
   };
 
   const getPartialContext = (description) => {
-    if (description.includes('STR')) return 'Success, but strain yourself or equipment';
-    if (description.includes('DEX')) return 'Stumble slightly, awkward position';
-    if (description.includes('CON')) return 'Feel the strain, maybe take harm';
-    if (description.includes('INT')) return 'Confusing situation, partial info';
-    if (description.includes('WIS')) return "Something seems off, can't quite tell what";
-    if (description.includes('CHA')) return 'Awkward interaction, mixed signals';
-    if (description.includes('Hack')) return 'Hit them, but they hit you back!';
-    if (description.includes('Taunt')) return 'They attack you but with +1 ongoing damage!';
+    description = description.toLowerCase();
+    if (description.includes('str')) return 'Success, but strain yourself or equipment';
+    if (description.includes('dex')) return 'Stumble slightly, awkward position';
+    if (description.includes('con')) return 'Feel the strain, maybe take harm';
+    if (description.includes('int')) return 'Confusing situation, partial info';
+    if (description.includes('wis')) return "Something seems off, can't quite tell what";
+    if (description.includes('cha')) return 'Awkward interaction, mixed signals';
+    if (description.includes('hack')) return 'Hit them, but they hit you back!';
+    if (description.includes('taunt')) return 'They attack you but with +1 ongoing damage!';
     return 'Success with complications';
   };
 
   const getFailureContext = (description) => {
-    if (description.includes('STR')) return 'Too heavy, equipment fails, or overpower backfires';
-    if (description.includes('DEX')) return 'Trip, fumble, or end up in worse position';
-    if (description.includes('CON')) return 'Exhausted, hurt, or overcome by conditions';
-    if (description.includes('INT')) return 'No clue, wrong conclusion, or miss key detail';
-    if (description.includes('WIS')) return 'Completely missed the signs';
-    if (description.includes('CHA')) return 'Offensive, rude, or make things worse';
-    if (description.includes('Hack')) return 'Miss entirely, terrible position';
-    if (description.includes('Taunt')) return 'They ignore you completely';
+    description = description.toLowerCase();
+    if (description.includes('str')) return 'Too heavy, equipment fails, or overpower backfires';
+    if (description.includes('dex')) return 'Trip, fumble, or end up in worse position';
+    if (description.includes('con')) return 'Exhausted, hurt, or overcome by conditions';
+    if (description.includes('int')) return 'No clue, wrong conclusion, or miss key detail';
+    if (description.includes('wis')) return 'Completely missed the signs';
+    if (description.includes('cha')) return 'Offensive, rude, or make things worse';
+    if (description.includes('hack')) return 'Miss entirely, terrible position';
+    if (description.includes('taunt')) return 'They ignore you completely';
     return 'Things go badly';
   };
 

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import useDiceRoller from './useDiceRoller.js';
+
+describe('useDiceRoller contexts', () => {
+  const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
+  const setCharacter = () => {};
+
+  it.each([
+    ['STR', 'Power through with overwhelming force!'],
+    ['dex', 'Graceful and precise execution!'],
+    ['Con', 'Tough as cybernetic nails!'],
+    ['int', 'Brilliant tactical insight!'],
+    ['Wis', 'Crystal clear perception!'],
+    ['cHa', 'Surprisingly charming for a cyber-barbarian!'],
+    ['hack', "Clean hit, enemy can't counter!"],
+    ['TAUNT', "They're completely focused on you now!"],
+    ['unknown', 'Perfect execution!'],
+  ])('returns correct success context for %s', (desc, expected) => {
+    localStorage.clear();
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    act(() => {
+      result.current.rollDice('2d6', desc);
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollModalData.context).toBe(expected);
+  });
+
+  it('returns correct partial context for HaCk', () => {
+    localStorage.clear();
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0.4).mockReturnValueOnce(0.6);
+    act(() => {
+      result.current.rollDice('2d6', 'HaCk');
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollModalData.context).toBe('Hit them, but they hit you back!');
+  });
+
+  it('returns correct failure context for taunt', () => {
+    localStorage.clear();
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0).mockReturnValueOnce(0);
+    act(() => {
+      result.current.rollDice('2d6', 'taunt');
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollModalData.context).toBe('They ignore you completely');
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize descriptions in dice context helpers before substring matching
- Add tests ensuring success, partial, and failure contexts work with varied casing
- Import `useModal` in `App.jsx` so tests run

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68996f4640748332a2fb3bf242bd78e0