### PR TITLE
feat: support modifiers in single die rolls

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -156,8 +156,9 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
         }
       }
     } else if (formula.startsWith('d')) {
-      const sides = parseInt(formula.replace('d', '').split('+')[0]);
-      const baseModifier = parseInt(formula.split('+')[1] || '0');
+      const match = formula.match(/^d(\d+)([+-]\d+)?$/);
+      const sides = match ? parseInt(match[1], 10) : 0;
+      const baseModifier = match && match[2] ? parseInt(match[2], 10) : 0;
       const roll = rollDie(sides);
 
       const rollType =
@@ -168,7 +169,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
 
       result = `d${sides}: ${roll}`;
       if (baseModifier !== 0) {
-        result += ` +${baseModifier}`;
+        result += ` ${baseModifier >= 0 ? '+' : ''}${baseModifier}`;
       }
       if (statusMods.modifier !== 0) {
         result += ` ${statusMods.modifier >= 0 ? '+' : ''}${statusMods.modifier}`;


### PR DESCRIPTION
## Summary
- handle optional + or - modifiers in single die formulas

## Testing
- `npm test` *(fails: ReferenceError: useModal is not defined)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68996f441a848332aa96c626191f7e9a