### PR TITLE
feat: add item consume effects

### DIFF
--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -1,23 +1,9 @@
+import useInventory from '../hooks/useInventory';
 import { debilityTypes } from '../state/character';
 import styles from './InventoryPanel.module.css';
 
 const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult }) => {
-  const handleUseItem = (item) => {
-    if (item.name === 'Healing Potion') {
-      const healing = rollDie(8);
-      const newHP = Math.min(character.maxHp, character.hp + healing);
-      setCharacter((prev) => ({
-        ...prev,
-        hp: newHP,
-        inventory: prev.inventory
-          .map((invItem) =>
-            invItem.id === item.id ? { ...invItem, quantity: invItem.quantity - 1 } : invItem,
-          )
-          .filter((invItem) => invItem.type !== 'consumable' || invItem.quantity > 0),
-      }));
-      setRollResult(`Used ${item.name}: healed ${healing} HP!`);
-    }
-  };
+  const { handleConsumeItem } = useInventory(character, setCharacter);
 
   return (
     <div className={styles.panel}>
@@ -44,7 +30,21 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult }) => 
                 </div>
               </div>
               {item.type === 'consumable' && item.quantity > 0 && (
-                <button className={styles.useButton} onClick={() => handleUseItem(item)}>
+                <button
+                  className={styles.useButton}
+                  onClick={() => {
+                    if (item.name === 'Healing Potion') {
+                      const healing = rollDie(8);
+                      setRollResult(`Used ${item.name}: healed ${healing} HP!`);
+                      handleConsumeItem(item.id, (char) => ({
+                        ...char,
+                        hp: Math.min(char.maxHp, char.hp + healing),
+                      }));
+                    } else {
+                      handleConsumeItem(item.id);
+                    }
+                  }}
+                >
                   Use
                 </button>
               )}

--- a/src/hooks/useInventory.js
+++ b/src/hooks/useInventory.js
@@ -27,20 +27,23 @@ export default function useInventory(character, setCharacter) {
   );
 
   const handleConsumeItem = useCallback(
-    (id) => {
-      setCharacter((prev) => ({
-        ...prev,
-        inventory: prev.inventory.reduce((acc, item) => {
-          if (item.id === id) {
-            if (item.quantity && item.quantity > 1) {
-              acc.push({ ...item, quantity: item.quantity - 1 });
+    (id, effect) => {
+      setCharacter((prev) => {
+        const updated = {
+          ...prev,
+          inventory: prev.inventory.reduce((acc, item) => {
+            if (item.id === id) {
+              if (item.quantity && item.quantity > 1) {
+                acc.push({ ...item, quantity: item.quantity - 1 });
+              }
+            } else {
+              acc.push(item);
             }
-          } else {
-            acc.push(item);
-          }
-          return acc;
-        }, []),
-      }));
+            return acc;
+          }, []),
+        };
+        return typeof effect === 'function' ? effect(updated) : updated;
+      });
     },
     [setCharacter],
   );


### PR DESCRIPTION
## Summary
- support item consumption effects in `useInventory` hook
- wire `InventoryPanel` to use `handleConsumeItem` and apply healing potion logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689972a987708332bc00fdfc1d0205ba