### PR TITLE
Handle malformed roll history data

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -7,7 +7,13 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
   const [rollModalData, setRollModalData] = useState({});
   const [rollHistory, setRollHistory] = useState(() => {
     const saved = localStorage.getItem('rollHistory');
-    return saved ? JSON.parse(saved) : [];
+    if (!saved) return [];
+    try {
+      return JSON.parse(saved);
+    } catch (error) {
+      console.error('Error parsing roll history from localStorage', error);
+      return [];
+    }
   });
   const rollModal = useModal();
 

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -52,3 +52,18 @@ describe('useDiceRoller contexts', () => {
     expect(result.current.rollModalData.context).toBe('They ignore you completely');
   });
 });
+
+describe('useDiceRoller localStorage', () => {
+  const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
+  const setCharacter = () => {};
+
+  it('falls back to empty history on invalid JSON', () => {
+    localStorage.clear();
+    localStorage.setItem('rollHistory', 'not json');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    expect(result.current.rollHistory).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Guard roll history initialization against invalid JSON by wrapping localStorage parsing in try/catch and defaulting to an empty list
- Test that invalid stored roll history logs an error and resets state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689972acd9688332954c8552c6a4f030