### PR TITLE
refactor: move inline styles to CSS modules

### DIFF
--- a/src/components/BondsModal.jsx
+++ b/src/components/BondsModal.jsx
@@ -1,26 +1,6 @@
 import React, { useState } from 'react';
-import { useCharacter } from '../state/CharacterContext';
-
-const buttonStyle = {
-  background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
-  border: 'none',
-  borderRadius: '6px',
-  color: 'white',
-  padding: '8px 15px',
-  cursor: 'pointer',
-  fontWeight: 'bold',
-  transition: 'all 0.3s ease',
-  margin: '5px',
-};
-
-const inputStyle = {
-  background: '#0f0f1f',
-  border: '1px solid #00ff88',
-  borderRadius: '6px',
-  color: 'white',
-  padding: '8px',
-  width: '100%',
-};
+import { useCharacter } from '../state/CharacterContext.jsx';
+import styles from './BondsModal.module.css';
 
 export default function BondsModal({ isOpen, onClose }) {
   const { character, setCharacter } = useCharacter();
@@ -60,65 +40,28 @@ export default function BondsModal({ isOpen, onClose }) {
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        background: 'rgba(0, 0, 0, 0.8)',
-        zIndex: 1000,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <div
-        style={{
-          background: '#1a1a2e',
-          border: '2px solid #00ff88',
-          borderRadius: '15px',
-          padding: '30px',
-          textAlign: 'center',
-          width: '400px',
-          maxHeight: '80%',
-          overflowY: 'auto',
-        }}
-      >
-        <h2 style={{ color: '#00ff88' }}>👥 Character Bonds</h2>
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h2 className={styles.title}>👥 Character Bonds</h2>
         {character.bonds.length === 0 ? (
-          <p style={{ color: '#aaa', margin: '20px 0' }}>No bonds yet.</p>
+          <p className={styles.empty}>No bonds yet.</p>
         ) : (
-          <ul style={{ listStyle: 'none', padding: 0, margin: '20px 0' }}>
+          <ul className={styles.bondList}>
             {character.bonds.map((bond, index) => (
-              <li key={index} style={{ marginBottom: '15px', textAlign: 'left' }}>
-                <div
-                  style={{
-                    textDecoration: bond.resolved ? 'line-through' : 'none',
-                    color: '#fff',
-                  }}
-                >
+              <li key={index} className={styles.bondItem}>
+                <div className={bond.resolved ? styles.bondResolved : styles.bondText}>
                   <strong>{bond.name}</strong>: {bond.relationship}
                 </div>
-                <div style={{ marginTop: '5px' }}>
+                <div className={styles.bondActions}>
                   <button
                     onClick={() => toggleResolved(index)}
-                    style={{
-                      ...buttonStyle,
-                      background: bond.resolved
-                        ? 'linear-gradient(45deg, #6366f1, #4f46e5)'
-                        : 'linear-gradient(45deg, #10b981, #059669)',
-                    }}
+                    className={`${styles.button} ${bond.resolved ? styles.unresolveButton : styles.resolveButton}`}
                   >
                     {bond.resolved ? 'Unresolve' : 'Resolve'}
                   </button>
                   <button
                     onClick={() => removeBond(index)}
-                    style={{
-                      ...buttonStyle,
-                      background: 'linear-gradient(45deg, #ef4444, #dc2626)',
-                    }}
+                    className={`${styles.button} ${styles.removeButton}`}
                   >
                     Remove
                   </button>
@@ -128,27 +71,27 @@ export default function BondsModal({ isOpen, onClose }) {
           </ul>
         )}
 
-        <div style={{ textAlign: 'left' }}>
+        <div className={styles.form}>
           <input
             type="text"
             placeholder="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            style={{ ...inputStyle, marginBottom: '10px' }}
+            className={styles.input}
           />
           <input
             type="text"
             placeholder="Relationship"
             value={relationship}
             onChange={(e) => setRelationship(e.target.value)}
-            style={{ ...inputStyle, marginBottom: '10px' }}
+            className={styles.input}
           />
-          <button onClick={addBond} style={buttonStyle}>
+          <button onClick={addBond} className={styles.button}>
             Add Bond
           </button>
         </div>
 
-        <button onClick={onClose} style={{ ...buttonStyle, marginTop: '20px' }}>
+        <button onClick={onClose} className={`${styles.button} ${styles.closeButton}`}>
           Close
         </button>
       </div>

--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -1,0 +1,98 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #1a1a2e;
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  padding: 30px;
+  text-align: center;
+  width: 400px;
+  max-height: 80%;
+  overflow-y: auto;
+}
+
+.title {
+  color: #00ff88;
+}
+
+.empty {
+  color: #aaa;
+  margin: 20px 0;
+}
+
+.bondList {
+  list-style: none;
+  padding: 0;
+  margin: 20px 0;
+}
+
+.bondItem {
+  margin-bottom: 15px;
+  text-align: left;
+}
+
+.bondText {
+  color: #fff;
+}
+
+.bondResolved {
+  color: #fff;
+  text-decoration: line-through;
+}
+
+.bondActions {
+  margin-top: 5px;
+}
+
+.button {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 8px 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  margin: 5px;
+}
+
+.resolveButton {
+  background: linear-gradient(45deg, #10b981, #059669);
+}
+
+.unresolveButton {
+  background: linear-gradient(45deg, #6366f1, #4f46e5);
+}
+
+.removeButton {
+  background: linear-gradient(45deg, #ef4444, #dc2626);
+}
+
+.input {
+  background: #0f0f1f;
+  border: 1px solid #00ff88;
+  border-radius: 6px;
+  color: white;
+  padding: 8px;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.form {
+  text-align: left;
+}
+
+.closeButton {
+  margin-top: 20px;
+}

--- a/src/components/DamageModal.jsx
+++ b/src/components/DamageModal.jsx
@@ -1,26 +1,6 @@
 import React, { useState } from 'react';
-import { useCharacter } from '../state/CharacterContext';
-
-const buttonStyle = {
-  background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
-  border: 'none',
-  borderRadius: '6px',
-  color: 'white',
-  padding: '8px 15px',
-  cursor: 'pointer',
-  fontWeight: 'bold',
-  transition: 'all 0.3s ease',
-  margin: '5px',
-};
-
-const inputStyle = {
-  background: '#0f0f1f',
-  border: '1px solid #00ff88',
-  borderRadius: '6px',
-  color: 'white',
-  padding: '8px',
-  width: '100%',
-};
+import { useCharacter } from '../state/CharacterContext.jsx';
+import styles from './DamageModal.module.css';
 
 export default function DamageModal({ isOpen, onClose }) {
   const { character, setCharacter } = useCharacter();
@@ -65,51 +45,23 @@ export default function DamageModal({ isOpen, onClose }) {
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        background: 'rgba(0, 0, 0, 0.8)',
-        zIndex: 1000,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <div
-        style={{
-          background: '#1a1a2e',
-          border: '2px solid #00ff88',
-          borderRadius: '15px',
-          padding: '30px',
-          textAlign: 'center',
-          width: '300px',
-        }}
-      >
-        <h2 style={{ color: '#00ff88' }}>💔 Damage Calculator</h2>
-        <div style={{ margin: '15px 0', color: '#fff' }}>Armor: {getTotalArmor()}</div>
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h2 className={styles.title}>💔 Damage Calculator</h2>
+        <div className={styles.info}>Armor: {getTotalArmor()}</div>
         <input
           type="number"
           placeholder="Incoming damage"
           value={damage}
           onChange={(e) => setDamage(e.target.value)}
-          style={{ ...inputStyle, marginBottom: '10px' }}
+          className={styles.input}
         />
-        <div style={{ color: '#aaa', marginBottom: '20px' }}>After armor: {effectiveDamage()}</div>
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <button
-            onClick={applyDamage}
-            style={{
-              ...buttonStyle,
-              background: 'linear-gradient(45deg, #ef4444, #dc2626)',
-            }}
-          >
+        <div className={styles.summary}>After armor: {effectiveDamage()}</div>
+        <div className={styles.buttonGroup}>
+          <button onClick={applyDamage} className={`${styles.button} ${styles.applyButton}`}>
             Apply
           </button>
-          <button onClick={onClose} style={buttonStyle}>
+          <button onClick={onClose} className={styles.button}>
             Cancel
           </button>
         </div>

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -1,0 +1,66 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #1a1a2e;
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  padding: 30px;
+  text-align: center;
+  width: 300px;
+}
+
+.title {
+  color: #00ff88;
+}
+
+.info {
+  margin: 15px 0;
+  color: #fff;
+}
+
+.input {
+  background: #0f0f1f;
+  border: 1px solid #00ff88;
+  border-radius: 6px;
+  color: white;
+  padding: 8px;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.summary {
+  color: #aaa;
+  margin-bottom: 20px;
+}
+
+.buttonGroup {
+  display: flex;
+  justify-content: center;
+}
+
+.button {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 8px 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  margin: 5px;
+}
+
+.applyButton {
+  background: linear-gradient(45deg, #ef4444, #dc2626);
+}

--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -1,17 +1,6 @@
 import React, { useState } from 'react';
 import { useCharacter } from '../state/CharacterContext.jsx';
-
-const buttonStyle = {
-  background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
-  border: 'none',
-  borderRadius: '6px',
-  color: 'white',
-  padding: '8px 15px',
-  cursor: 'pointer',
-  fontWeight: 'bold',
-  transition: 'all 0.3s ease',
-  margin: '5px',
-};
+import styles from './EndSessionModal.module.css';
 
 export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
   const { character, setCharacter } = useCharacter();
@@ -54,52 +43,28 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        background: 'rgba(0, 0, 0, 0.8)',
-        zIndex: 1000,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}
-    >
-      <div
-        style={{
-          background: '#1a1a2e',
-          border: '2px solid #00ff88',
-          borderRadius: '15px',
-          padding: '30px',
-          textAlign: 'center',
-          width: '400px',
-          maxHeight: '80%',
-          overflowY: 'auto',
-        }}
-      >
-        <h2 style={{ color: '#00ff88' }}>🏁 End of Session</h2>
-        <div style={{ textAlign: 'left', marginBottom: '15px' }}>
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h2 className={styles.title}>🏁 End of Session</h2>
+        <div className={styles.section}>
           <label>
             <input type="checkbox" checked={answers.q1} onChange={() => toggleAnswer('q1')} /> Did
             we learn something new and important about the world?
           </label>
         </div>
-        <div style={{ textAlign: 'left', marginBottom: '15px' }}>
+        <div className={styles.section}>
           <label>
             <input type="checkbox" checked={answers.q2} onChange={() => toggleAnswer('q2')} /> Did
             we overcome a notable monster or enemy?
           </label>
         </div>
-        <div style={{ textAlign: 'left', marginBottom: '15px' }}>
+        <div className={styles.section}>
           <label>
             <input type="checkbox" checked={answers.q3} onChange={() => toggleAnswer('q3')} /> Did
             we loot a memorable treasure?
           </label>
         </div>
-        <div style={{ textAlign: 'left', marginBottom: '15px' }}>
+        <div className={styles.section}>
           <label>
             <input
               type="checkbox"
@@ -111,11 +76,11 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
         </div>
 
         {character.bonds.length > 0 && (
-          <div style={{ marginBottom: '15px', textAlign: 'left' }}>
-            <h3 style={{ color: '#00ff88' }}>Bonds Resolved</h3>
-            <ul style={{ listStyle: 'none', padding: 0 }}>
+          <div className={styles.section}>
+            <h3 className={styles.title}>Bonds Resolved</h3>
+            <ul className={styles.bondList}>
               {character.bonds.map((bond, idx) => (
-                <li key={idx} style={{ marginBottom: '5px' }}>
+                <li key={idx} className={styles.bondItem}>
                   <label>
                     <input
                       type="checkbox"
@@ -130,19 +95,13 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
           </div>
         )}
 
-        <div style={{ marginTop: '10px', color: '#fff' }}>Total XP Gained: {totalXP}</div>
+        <div className={styles.total}>Total XP Gained: {totalXP}</div>
 
-        <div style={{ marginTop: '20px' }}>
-          <button onClick={handleEnd} style={buttonStyle}>
+        <div className={styles.actions}>
+          <button onClick={handleEnd} className={styles.button}>
             End Session
           </button>
-          <button
-            onClick={onClose}
-            style={{
-              ...buttonStyle,
-              background: 'linear-gradient(45deg, #ef4444, #dc2626)',
-            }}
-          >
+          <button onClick={onClose} className={`${styles.button} ${styles.cancelButton}`}>
             Cancel
           </button>
         </div>

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -1,0 +1,66 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #1a1a2e;
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  padding: 30px;
+  text-align: center;
+  width: 400px;
+  max-height: 80%;
+  overflow-y: auto;
+}
+
+.title {
+  color: #00ff88;
+}
+
+.section {
+  text-align: left;
+  margin-bottom: 15px;
+}
+
+.bondList {
+  list-style: none;
+  padding: 0;
+}
+
+.bondItem {
+  margin-bottom: 5px;
+}
+
+.total {
+  margin-top: 10px;
+  color: #fff;
+}
+
+.actions {
+  margin-top: 20px;
+}
+
+.button {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 8px 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  margin: 5px;
+}
+
+.cancelButton {
+  background: linear-gradient(45deg, #ef4444, #dc2626);
+}

--- a/src/components/RollModal.jsx
+++ b/src/components/RollModal.jsx
@@ -1,92 +1,24 @@
 import React from 'react';
-
-const buttonStyle = {
-  background: 'linear-gradient(45deg, #00ff88, #00cc6a)',
-  border: 'none',
-  borderRadius: '6px',
-  color: 'white',
-  padding: '8px 15px',
-  cursor: 'pointer',
-  fontWeight: 'bold',
-  transition: 'all 0.3s ease',
-  margin: '5px',
-};
+import styles from './RollModal.module.css';
 
 export default function RollModal({ isOpen, data, onClose }) {
   if (!isOpen || !data) return null;
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        width: '100%',
-        height: '100%',
-        background: 'rgba(0, 0, 0, 0.8)',
-        backdropFilter: 'blur(5px)',
-        zIndex: 1000,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '20px',
-      }}
-    >
-      <div
-        style={{
-          background: 'linear-gradient(135deg, #1a1a2e, #16213e)',
-          border: '2px solid #00ff88',
-          borderRadius: '15px',
-          maxWidth: '500px',
-          width: '100%',
-          boxShadow: '0 0 30px rgba(0, 255, 136, 0.5)',
-        }}
-      >
-        <div
-          style={{
-            textAlign: 'center',
-            padding: '20px',
-            background: 'linear-gradient(45deg, #0f3460, #533483)',
-            borderRadius: '13px 13px 0 0',
-          }}
-        >
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <h2 style={{ fontSize: '1.5rem', color: '#00ff88', margin: 0 }}>🎲 Roll Result</h2>
-            <button
-              onClick={onClose}
-              style={{
-                background: 'rgba(239, 68, 68, 0.8)',
-                border: '2px solid #ef4444',
-                color: 'white',
-                fontSize: '1.2rem',
-                cursor: 'pointer',
-                padding: '5px 10px',
-                borderRadius: '8px',
-              }}
-            >
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <div className={styles.header}>
+          <div className={styles.headerRow}>
+            <h2 className={styles.title}>🎲 Roll Result</h2>
+            <button onClick={onClose} className={styles.closeButton}>
               ×
             </button>
           </div>
         </div>
-        <div style={{ padding: '30px', textAlign: 'center' }}>
-          <div
-            style={{
-              fontSize: '1.5rem',
-              fontWeight: 'bold',
-              color: '#00ff88',
-              marginBottom: '15px',
-            }}
-          >
-            {data.result}
-          </div>
-          {data.description && (
-            <div style={{ color: '#e0e0e0', marginBottom: '15px' }}>{data.description}</div>
-          )}
-          {data.context && (
-            <div style={{ color: '#aaa', fontSize: '0.9rem', marginBottom: '20px' }}>
-              {data.context}
-            </div>
-          )}
-          <button onClick={onClose} style={buttonStyle}>
+        <div className={styles.body}>
+          <div className={styles.result}>{data.result}</div>
+          {data.description && <div className={styles.description}>{data.description}</div>}
+          {data.context && <div className={styles.context}>{data.context}</div>}
+          <button onClick={onClose} className={styles.button}>
             Close
           </button>
         </div>

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -1,0 +1,87 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal {
+  background: linear-gradient(135deg, #1a1a2e, #16213e);
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  max-width: 500px;
+  width: 100%;
+  box-shadow: 0 0 30px rgba(0, 255, 136, 0.5);
+}
+
+.header {
+  text-align: center;
+  padding: 20px;
+  background: linear-gradient(45deg, #0f3460, #533483);
+  border-radius: 13px 13px 0 0;
+}
+
+.headerRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.title {
+  font-size: 1.5rem;
+  color: #00ff88;
+  margin: 0;
+}
+
+.closeButton {
+  background: rgba(239, 68, 68, 0.8);
+  border: 2px solid #ef4444;
+  color: white;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 5px 10px;
+  border-radius: 8px;
+}
+
+.body {
+  padding: 30px;
+  text-align: center;
+}
+
+.result {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #00ff88;
+  margin-bottom: 15px;
+}
+
+.description {
+  color: #e0e0e0;
+  margin-bottom: 15px;
+}
+
+.context {
+  color: #aaa;
+  font-size: 0.9rem;
+  margin-bottom: 20px;
+}
+
+.button {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 8px 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  margin: 5px;
+}


### PR DESCRIPTION
## Summary
- extract RollModal styles into RollModal.module.css
- replace inline styles in EndSessionModal, BondsModal, and DamageModal with CSS modules

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689972a7af98833293f3ac9e9a2f21b9