### PR TITLE
refactor: reuse dice utilities

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { debilityTypes } from '../state/character';
+import { rollDie, rollDice as rollDiceUtil } from '../utils/dice.js';
 import useModal from './useModal';
 
 export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
@@ -10,8 +11,6 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
     return saved ? JSON.parse(saved) : [];
   });
   const rollModal = useModal();
-
-  const rollDie = (sides) => Math.floor(Math.random() * sides) + 1;
 
   useEffect(() => {
     if (rollHistory.length > 0) {
@@ -161,7 +160,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
     } else if (formula.startsWith('d')) {
       const sides = parseInt(formula.replace('d', '').split('+')[0]);
       const baseModifier = parseInt(formula.split('+')[1] || '0');
-      const roll = rollDie(sides);
+      const roll = rollDiceUtil(`1d${sides}`);
 
       const rollType =
         description.includes('damage') || description.includes('Damage') ? 'damage' : 'general';

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import { renderHook, act } from '@testing-library/react';
 import { vi } from 'vitest';
+import * as diceUtils from '../utils/dice.js';
 import useDiceRoller from './useDiceRoller.js';
 
 describe('useDiceRoller contexts', () => {
@@ -20,35 +21,34 @@ describe('useDiceRoller contexts', () => {
   ])('returns correct success context for %s', (desc, expected) => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
-    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    const rollDieSpy = vi.spyOn(diceUtils, 'rollDie').mockReturnValue(6);
     act(() => {
       result.current.rollDice('2d6', desc);
     });
-    randomSpy.mockRestore();
+    rollDieSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe(expected);
   });
 
   it('returns correct partial context for HaCk', () => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
-    const randomSpy = vi.spyOn(Math, 'random');
-    randomSpy.mockReturnValueOnce(0.4).mockReturnValueOnce(0.6);
+    const rollDieSpy = vi.spyOn(diceUtils, 'rollDie');
+    rollDieSpy.mockReturnValueOnce(3).mockReturnValueOnce(4);
     act(() => {
       result.current.rollDice('2d6', 'HaCk');
     });
-    randomSpy.mockRestore();
+    rollDieSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('Hit them, but they hit you back!');
   });
 
   it('returns correct failure context for taunt', () => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
-    const randomSpy = vi.spyOn(Math, 'random');
-    randomSpy.mockReturnValueOnce(0).mockReturnValueOnce(0);
+    const rollDieSpy = vi.spyOn(diceUtils, 'rollDie').mockReturnValue(1);
     act(() => {
       result.current.rollDice('2d6', 'taunt');
     });
-    randomSpy.mockRestore();
+    rollDieSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('They ignore you completely');
   });
 });


### PR DESCRIPTION
## Summary
- reuse shared `rollDie` and `rollDice` helpers in `useDiceRoller`
- update dice roller tests to mock shared utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689972952dd08332a58257a3bacc08cd