### PR TITLE
Update rollResult when rolling and test propagation

### DIFF
--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import useDiceRoller from '../hooks/useDiceRoller.js';
+import DiceRoller from './DiceRoller.jsx';
+
+const character = {
+  stats: {
+    STR: { mod: 0 },
+    DEX: { mod: 0 },
+    CON: { mod: 0 },
+    INT: { mod: 0 },
+    WIS: { mod: 0 },
+    CHA: { mod: 0 },
+  },
+  statusEffects: [],
+  debilities: [],
+};
+
+function Wrapper() {
+  const { rollDice, rollResult, rollHistory } = useDiceRoller(character, () => {}, false);
+  return (
+    <DiceRoller
+      character={character}
+      rollDice={rollDice}
+      rollResult={rollResult}
+      rollHistory={rollHistory}
+      getEquippedWeaponDamage={() => 'd4'}
+      rollModal={{ isOpen: false, open: () => {}, close: () => {} }}
+      rollModalData={{}}
+    />
+  );
+}
+
+describe('DiceRoller', () => {
+  it('displays latest roll result after rolling', async () => {
+    localStorage.clear();
+    const user = userEvent.setup();
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    render(<Wrapper />);
+    await user.click(screen.getByText('d4'));
+    randomSpy.mockRestore();
+    expect(screen.getByText('d4: 1 = 1')).toBeInTheDocument();
+  });
+});

--- a/src/components/MoveList.test.jsx
+++ b/src/components/MoveList.test.jsx
@@ -50,4 +50,28 @@ describe('MoveList', () => {
     expect(screen.getByText('Recent Rolls:')).toBeInTheDocument();
     expect(screen.getByText(/2d6: 7/)).toBeInTheDocument();
   });
+
+  it('updates displayed roll result when prop changes', () => {
+    const rollDice = vi.fn();
+    const { rerender } = render(
+      <MoveList
+        character={minimalCharacter}
+        rollDice={rollDice}
+        getEquippedWeaponDamage={() => 'd8'}
+        rollResult="Result: 9"
+        rollHistory={rollHistory}
+      />,
+    );
+    expect(screen.getByText('Result: 9')).toBeInTheDocument();
+    rerender(
+      <MoveList
+        character={minimalCharacter}
+        rollDice={rollDice}
+        getEquippedWeaponDamage={() => 'd8'}
+        rollResult="Result: 10"
+        rollHistory={rollHistory}
+      />,
+    );
+    expect(screen.getByText('Result: 10')).toBeInTheDocument();
+  });
 });

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -193,6 +193,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
 
     setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);
     setRollModalData(rollData);
+    setRollResult(rollData.result);
     rollModal.open();
   };
 

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -51,4 +51,15 @@ describe('useDiceRoller contexts', () => {
     randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('They ignore you completely');
   });
+
+  it('updates rollResult with latest roll', () => {
+    localStorage.clear();
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    act(() => {
+      result.current.rollDice('d4', 'test');
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollResult).toBe('d4: 1 = 1');
+  });
 });


### PR DESCRIPTION
## Summary
- Update `useDiceRoller` to set `rollResult` when dice are rolled
- Test that the hook and components show the latest roll result

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68997299d66c8332961d8430d0d121d8