### PR TITLE
Normalize roll descriptions for case-insensitive checks

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -103,6 +103,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
   };
 
   const rollDice = (formula, description = '') => {
+    const desc = description.toLowerCase();
     let result = '';
     let total = 0;
     let interpretation = '';
@@ -114,17 +115,16 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
       const baseModifier = parseInt(formula.replace('2d6', '').replace('+', '') || '0');
 
       let rollType = 'general';
-      if (description.includes('STR') || description.includes('Hack')) rollType = 'str';
-      else if (description.includes('DEX')) rollType = 'dex';
-      else if (description.includes('CON')) rollType = 'con';
-      else if (description.includes('INT')) rollType = 'int';
-      else if (description.includes('WIS')) rollType = 'wis';
-      else if (description.includes('CHA')) rollType = 'cha';
+      if (desc.includes('str') || desc.includes('hack')) rollType = 'str';
+      else if (desc.includes('dex')) rollType = 'dex';
+      else if (desc.includes('con')) rollType = 'con';
+      else if (desc.includes('int')) rollType = 'int';
+      else if (desc.includes('wis')) rollType = 'wis';
+      else if (desc.includes('cha')) rollType = 'cha';
       else if (
-        description.includes('damage') ||
-        description.includes('Damage') ||
-        description.includes('Upper Hand') ||
-        description.includes('Bonus Damage')
+        desc.includes('damage') ||
+        desc.includes('upper hand') ||
+        desc.includes('bonus damage')
       )
         rollType = 'damage';
 
@@ -147,13 +147,13 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
 
       if (total >= 10) {
         interpretation = ' ✅ Success!';
-        context = getSuccessContext(description);
+        context = getSuccessContext(desc);
       } else if (total >= 7) {
         interpretation = ' ⚠️ Partial Success';
-        context = getPartialContext(description);
+        context = getPartialContext(desc);
       } else {
         interpretation = ' ❌ Failure';
-        context = getFailureContext(description);
+        context = getFailureContext(desc);
         if (autoXpOnMiss) {
           setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
         }
@@ -163,8 +163,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
       const baseModifier = parseInt(formula.split('+')[1] || '0');
       const roll = rollDie(sides);
 
-      const rollType =
-        description.includes('damage') || description.includes('Damage') ? 'damage' : 'general';
+      const rollType = desc.includes('damage') ? 'damage' : 'general';
       const statusMods = getStatusModifiers(rollType);
       const totalModifier = baseModifier + statusMods.modifier;
       total = roll + totalModifier;

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -52,3 +52,31 @@ describe('useDiceRoller contexts', () => {
     expect(result.current.rollModalData.context).toBe('They ignore you completely');
   });
 });
+
+describe('useDiceRoller mixed-case status modifiers', () => {
+  const setCharacter = () => {};
+
+  it('applies modifiers regardless of description casing', () => {
+    localStorage.clear();
+    const character = {
+      statusEffects: ['shocked', 'weakened'],
+      debilities: [],
+      xp: 0,
+    };
+    const { result } = renderHook(() => useDiceRoller(character, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random');
+
+    randomSpy.mockReturnValueOnce(0.4).mockReturnValueOnce(0.4);
+    act(() => {
+      result.current.rollDice('2d6', 'dEx test');
+    });
+    expect(result.current.rollModalData.result).toMatch(/Shocked \(-2 DEX\)/);
+
+    randomSpy.mockReturnValueOnce(0.25);
+    act(() => {
+      result.current.rollDice('d4', 'DaMaGe roll');
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollModalData.result).toMatch(/Weakened \(-1 damage\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize `rollDice` descriptions to lowercase before running `.includes` checks
- Adjust roll type detection to use normalized description
- Test mixed-case descriptions for status modifiers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689972a0fa6883328eb923736bbc5aa4