### PR TITLE
Clone undo history to avoid state mutation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,7 +79,7 @@ function App() {
     setCharacter((prev) => ({
       ...prev,
       actionHistory: [
-        { action, state: prev, timestamp: Date.now() },
+        { action, state: structuredClone(prev), timestamp: Date.now() },
         ...prev.actionHistory.slice(0, 4),
       ],
     }));
@@ -88,7 +88,7 @@ function App() {
   const undoLastAction = () => {
     if (character.actionHistory.length > 0) {
       const lastAction = character.actionHistory[0];
-      setCharacter(lastAction.state);
+      setCharacter(structuredClone(lastAction.state));
       setRollResult(`↶ Undid: ${lastAction.action}`);
       timeoutRef.current = setTimeout(() => setRollResult('Ready to roll!'), 2000);
     }

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -58,22 +58,26 @@ describe('DiceRoller', () => {
   it('updates displayed roll result when prop changes', () => {
     const rollDice = vi.fn();
     const { rerender } = render(
-      <MoveList
+      <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
         getEquippedWeaponDamage={() => 'd8'}
         rollResult="Result: 9"
         rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
       />,
     );
     expect(screen.getByText('Result: 9')).toBeInTheDocument();
     rerender(
-      <MoveList
+      <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
         getEquippedWeaponDamage={() => 'd8'}
         rollResult="Result: 10"
         rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
       />,
     );
     expect(screen.getByText('Result: 10')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- deep clone character state when saving to action history
- restore cloned state when undoing
- update DiceRoller test to render component with modal props

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689978fecdd88332878b2cfd31cf754b