### PR TITLE
Memoize inventory armor and weapon damage calculations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,13 +38,8 @@ function App() {
     clearRollHistory,
   } = useDiceRoller(character, setCharacter, autoXpOnMiss);
 
-  const {
-    getTotalArmor,
-    getEquippedWeaponDamage,
-    handleEquipItem,
-    handleConsumeItem,
-    handleDropItem,
-  } = useInventory(character, setCharacter);
+  const { totalArmor, equippedWeaponDamage, handleEquipItem, handleConsumeItem, handleDropItem } =
+    useInventory(character, setCharacter);
 
   // Auto-detect level up opportunity
   useEffect(() => {
@@ -251,7 +246,7 @@ function App() {
             character={character}
             setCharacter={setCharacter}
             saveToHistory={saveToHistory}
-            getTotalArmor={getTotalArmor}
+            totalArmor={totalArmor}
             setShowLevelUpModal={setShowLevelUpModal}
             autoXpOnMiss={autoXpOnMiss}
             setAutoXpOnMiss={setAutoXpOnMiss}
@@ -266,7 +261,7 @@ function App() {
             rollDice={rollDice}
             rollResult={rollResult}
             rollHistory={rollHistory}
-            getEquippedWeaponDamage={getEquippedWeaponDamage}
+            equippedWeaponDamage={equippedWeaponDamage}
             rollModal={rollModal}
             rollModalData={rollModalData}
           />

--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -115,7 +115,7 @@ const CharacterStats = ({
   character,
   setCharacter,
   saveToHistory,
-  getTotalArmor,
+  totalArmor,
   setShowLevelUpModal,
   autoXpOnMiss,
   setAutoXpOnMiss,
@@ -150,7 +150,7 @@ const CharacterStats = ({
         />
       </div>
       <div style={centerTextStyle}>
-        HP: {character.hp}/{character.maxHp} | Armor: {getTotalArmor()}
+        HP: {character.hp}/{character.maxHp} | Armor: {totalArmor}
       </div>
       <div style={controlsStyle}>
         <button

--- a/src/components/CharacterStats.test.jsx
+++ b/src/components/CharacterStats.test.jsx
@@ -34,7 +34,7 @@ describe('CharacterStats', () => {
       character: makeCharacter(),
       setCharacter: vi.fn(),
       saveToHistory: vi.fn(),
-      getTotalArmor: vi.fn(() => 0),
+      totalArmor: 0,
       setShowLevelUpModal: vi.fn(),
       autoXpOnMiss: false,
       setAutoXpOnMiss: vi.fn(),

--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -7,7 +7,7 @@ const DiceRoller = ({
   rollDice,
   rollResult,
   rollHistory,
-  getEquippedWeaponDamage,
+  equippedWeaponDamage,
   rollModal,
   rollModalData,
 }) => (
@@ -43,7 +43,7 @@ const DiceRoller = ({
         <h4 style={{ color: '#00ff88', marginBottom: '10px', fontSize: '1rem' }}>Combat Rolls</h4>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '5px' }}>
           <button
-            onClick={() => rollDice(getEquippedWeaponDamage(), 'Weapon Damage')}
+            onClick={() => rollDice(equippedWeaponDamage, 'Weapon Damage')}
             style={{
               ...buttonStyle,
               background: 'linear-gradient(45deg, #ef4444, #dc2626)',
@@ -51,7 +51,7 @@ const DiceRoller = ({
               fontSize: '11px',
             }}
           >
-            Weapon ({getEquippedWeaponDamage()})
+            Weapon ({equippedWeaponDamage})
           </button>
           <button
             onClick={() => rollDice('2d6+3', 'Hack & Slash')}

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -22,7 +22,7 @@ describe('DiceRoller', () => {
       <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
-        getEquippedWeaponDamage={() => 'd8'}
+        equippedWeaponDamage="d8"
         rollResult="Result: 9"
         rollHistory={rollHistory}
         rollModal={{ isOpen: false, close: vi.fn() }}
@@ -43,7 +43,7 @@ describe('DiceRoller', () => {
       <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
-        getEquippedWeaponDamage={() => 'd8'}
+        equippedWeaponDamage="d8"
         rollResult="Result: 9"
         rollHistory={rollHistory}
         rollModal={{ isOpen: false, close: vi.fn() }}
@@ -58,22 +58,26 @@ describe('DiceRoller', () => {
   it('updates displayed roll result when prop changes', () => {
     const rollDice = vi.fn();
     const { rerender } = render(
-      <MoveList
+      <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
-        getEquippedWeaponDamage={() => 'd8'}
+        equippedWeaponDamage="d8"
         rollResult="Result: 9"
         rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
       />,
     );
     expect(screen.getByText('Result: 9')).toBeInTheDocument();
     rerender(
-      <MoveList
+      <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
-        getEquippedWeaponDamage={() => 'd8'}
+        equippedWeaponDamage="d8"
         rollResult="Result: 10"
         rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
       />,
     );
     expect(screen.getByText('Result: 10')).toBeInTheDocument();

--- a/src/hooks/useInventory.js
+++ b/src/hooks/useInventory.js
@@ -1,18 +1,18 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export default function useInventory(character, setCharacter) {
-  const getTotalArmor = useCallback(() => {
+  const totalArmor = useMemo(() => {
     const baseArmor = character.armor || 0;
     const equippedArmor = character.inventory
       .filter((item) => item.equipped && item.armor)
       .reduce((total, item) => total + (item.armor || 0), 0);
     return baseArmor + equippedArmor;
-  }, [character]);
+  }, [character.inventory, character.armor]);
 
-  const getEquippedWeaponDamage = useCallback(() => {
+  const equippedWeaponDamage = useMemo(() => {
     const weapon = character.inventory.find((item) => item.equipped && item.type === 'weapon');
     return weapon ? weapon.damage || 'd6' : 'd6';
-  }, [character]);
+  }, [character.inventory]);
 
   const handleEquipItem = useCallback(
     (id) => {
@@ -59,8 +59,8 @@ export default function useInventory(character, setCharacter) {
   );
 
   return {
-    getTotalArmor,
-    getEquippedWeaponDamage,
+    totalArmor,
+    equippedWeaponDamage,
     handleEquipItem,
     handleConsumeItem,
     handleDropItem,


### PR DESCRIPTION
## Summary
- memoize total armor and weapon damage in `useInventory` to avoid full-character dependencies
- pass memoized values through `App` to `CharacterStats` and `DiceRoller`
- adjust components and tests to consume values instead of callback functions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68997904143c8332b06f3d5ab3199000