### PR TITLE
test: add rollDice max count case

### DIFF
--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -58,22 +58,26 @@ describe('DiceRoller', () => {
   it('updates displayed roll result when prop changes', () => {
     const rollDice = vi.fn();
     const { rerender } = render(
-      <MoveList
+      <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
         getEquippedWeaponDamage={() => 'd8'}
         rollResult="Result: 9"
         rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
       />,
     );
     expect(screen.getByText('Result: 9')).toBeInTheDocument();
     rerender(
-      <MoveList
+      <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
         getEquippedWeaponDamage={() => 'd8'}
         rollResult="Result: 10"
         rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
       />,
     );
     expect(screen.getByText('Result: 10')).toBeInTheDocument();

--- a/src/utils/dice.test.js
+++ b/src/utils/dice.test.js
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 import { rollDie, rollDice } from './dice.js';
+const MAX_COUNT = 1000; // should match value in dice.js
 
 describe('rollDie', () => {
   it('returns a value within 1..sides', () => {
@@ -79,6 +80,10 @@ describe('rollDice', () => {
 
   it('throws on non-positive counts', () => {
     expect(() => rollDice('0d6')).toThrow('count must be a positive integer');
+  });
+
+  it('throws when count exceeds MAX_COUNT', () => {
+    expect(() => rollDice(`${MAX_COUNT + 1}d6`)).toThrow(`count must not exceed ${MAX_COUNT}`);
   });
 
   it('throws on non-positive sides', () => {


### PR DESCRIPTION
## Summary
- duplicate MAX_COUNT and test that rollDice rejects counts above the limit
- fix DiceRoller test to render DiceRoller with required props

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68997908bce88332be760411ceea4028