### PR TITLE
Add PropTypes validation to UI components

### DIFF
--- a/src/components/BondsModal.jsx
+++ b/src/components/BondsModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './BondsModal.module.css';
@@ -98,3 +99,8 @@ export default function BondsModal({ isOpen, onClose }) {
     </div>
   );
 }
+
+BondsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import { panelStyle, buttonStyle } from './styles.js';
 
 const statsGridStyle = {
@@ -327,6 +328,32 @@ const CharacterStats = ({
       </button>
     </div>
   );
+};
+
+CharacterStats.propTypes = {
+  character: PropTypes.shape({
+    stats: PropTypes.object.isRequired,
+    hp: PropTypes.number.isRequired,
+    maxHp: PropTypes.number.isRequired,
+    xp: PropTypes.number.isRequired,
+    xpNeeded: PropTypes.number.isRequired,
+    level: PropTypes.number.isRequired,
+    resources: PropTypes.object.isRequired,
+  }).isRequired,
+  setCharacter: PropTypes.func.isRequired,
+  saveToHistory: PropTypes.func.isRequired,
+  totalArmor: PropTypes.number.isRequired,
+  setShowLevelUpModal: PropTypes.func.isRequired,
+  autoXpOnMiss: PropTypes.bool.isRequired,
+  setAutoXpOnMiss: PropTypes.func.isRequired,
+  setRollResult: PropTypes.func.isRequired,
+  setSessionNotes: PropTypes.func,
+  clearRollHistory: PropTypes.func,
+};
+
+CharacterStats.defaultProps = {
+  setSessionNotes: () => {},
+  clearRollHistory: () => {},
 };
 
 export default CharacterStats;

--- a/src/components/DamageModal.jsx
+++ b/src/components/DamageModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './DamageModal.module.css';
@@ -69,3 +70,8 @@ export default function DamageModal({ isOpen, onClose }) {
     </div>
   );
 }
+
+DamageModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import RollModal from './RollModal.jsx';
 import { panelStyle, buttonStyle } from './styles.js';
@@ -143,5 +144,19 @@ const DiceRoller = ({
     <RollModal isOpen={rollModal.isOpen} data={rollModalData} onClose={rollModal.close} />
   </>
 );
+DiceRoller.propTypes = {
+  character: PropTypes.shape({
+    stats: PropTypes.object.isRequired,
+  }).isRequired,
+  rollDice: PropTypes.func.isRequired,
+  rollResult: PropTypes.string.isRequired,
+  rollHistory: PropTypes.arrayOf(PropTypes.object).isRequired,
+  equippedWeaponDamage: PropTypes.string.isRequired,
+  rollModal: PropTypes.shape({
+    isOpen: PropTypes.bool.isRequired,
+    close: PropTypes.func.isRequired,
+  }).isRequired,
+  rollModalData: PropTypes.object.isRequired,
+};
 
 export default DiceRoller;

--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './EndSessionModal.module.css';
@@ -109,3 +110,9 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
     </div>
   );
 }
+
+EndSessionModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onLevelUp: PropTypes.func.isRequired,
+};

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import BondsModal from './BondsModal.jsx';
 import DamageModal from './DamageModal.jsx';
@@ -70,5 +71,34 @@ const GameModals = ({
     <BondsModal isOpen={bondsModal.isOpen} onClose={bondsModal.close} />
   </>
 );
+
+GameModals.propTypes = {
+  character: PropTypes.object.isRequired,
+  setCharacter: PropTypes.func.isRequired,
+  levelUpState: PropTypes.object.isRequired,
+  setLevelUpState: PropTypes.func.isRequired,
+  showLevelUpModal: PropTypes.bool.isRequired,
+  setShowLevelUpModal: PropTypes.func.isRequired,
+  rollDie: PropTypes.func.isRequired,
+  setRollResult: PropTypes.func.isRequired,
+  showStatusModal: PropTypes.bool.isRequired,
+  setShowStatusModal: PropTypes.func.isRequired,
+  statusEffectTypes: PropTypes.object.isRequired,
+  debilityTypes: PropTypes.object.isRequired,
+  handleToggleStatusEffect: PropTypes.func.isRequired,
+  handleToggleDebility: PropTypes.func.isRequired,
+  showDamageModal: PropTypes.bool.isRequired,
+  setShowDamageModal: PropTypes.func.isRequired,
+  showInventoryModal: PropTypes.bool.isRequired,
+  setShowInventoryModal: PropTypes.func.isRequired,
+  inventory: PropTypes.arrayOf(PropTypes.object).isRequired,
+  handleEquipItem: PropTypes.func.isRequired,
+  handleConsumeItem: PropTypes.func.isRequired,
+  handleDropItem: PropTypes.func.isRequired,
+  bondsModal: PropTypes.shape({
+    isOpen: PropTypes.bool.isRequired,
+    close: PropTypes.func.isRequired,
+  }).isRequired,
+};
 
 export default GameModals;

--- a/src/components/InventoryModal.jsx
+++ b/src/components/InventoryModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import './InventoryModal.css';
 
@@ -43,6 +44,14 @@ const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
       </div>
     </div>
   );
+};
+
+InventoryModal.propTypes = {
+  inventory: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onEquip: PropTypes.func.isRequired,
+  onConsume: PropTypes.func.isRequired,
+  onDrop: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default InventoryModal;

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import useInventory from '../hooks/useInventory';
 import { debilityTypes } from '../state/character';
 import styles from './InventoryPanel.module.css';
@@ -66,6 +67,13 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult }) => 
       )}
     </div>
   );
+};
+
+InventoryPanel.propTypes = {
+  character: PropTypes.object.isRequired,
+  setCharacter: PropTypes.func.isRequired,
+  rollDie: PropTypes.func.isRequired,
+  setRollResult: PropTypes.func.isRequired,
 };
 
 export default InventoryPanel;

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import { useState } from 'react';
 import './LevelUpModal.css';
 import { advancedMoves } from '../data/advancedMoves.js';
@@ -388,6 +389,16 @@ const LevelUpModal = ({
       </div>
     </div>
   );
+};
+
+LevelUpModal.propTypes = {
+  character: PropTypes.object.isRequired,
+  setCharacter: PropTypes.func.isRequired,
+  levelUpState: PropTypes.object.isRequired,
+  setLevelUpState: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  rollDie: PropTypes.func.isRequired,
+  setRollResult: PropTypes.func.isRequired,
 };
 
 export default LevelUpModal;

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import './Message.css';
 
 const Message = ({ type = 'error', children }) => {
@@ -5,3 +6,8 @@ const Message = ({ type = 'error', children }) => {
 };
 
 export default Message;
+
+Message.propTypes = {
+  type: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/RollModal.jsx
+++ b/src/components/RollModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './RollModal.module.css';
 
@@ -26,3 +27,13 @@ export default function RollModal({ isOpen, data, onClose }) {
     </div>
   );
 }
+
+RollModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  data: PropTypes.object,
+  onClose: PropTypes.func.isRequired,
+};
+
+RollModal.defaultProps = {
+  data: null,
+};

--- a/src/components/SessionNotes.jsx
+++ b/src/components/SessionNotes.jsx
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import PropTypes from 'prop-types';
 import styles from './SessionNotes.module.css';
 
 const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMode }) => {
@@ -62,6 +63,13 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
       </div>
     </div>
   );
+};
+
+SessionNotes.propTypes = {
+  sessionNotes: PropTypes.string.isRequired,
+  setSessionNotes: PropTypes.func.isRequired,
+  compactMode: PropTypes.bool.isRequired,
+  setCompactMode: PropTypes.func.isRequired,
 };
 
 export default SessionNotes;

--- a/src/components/StatusModal.jsx
+++ b/src/components/StatusModal.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import './StatusModal.css';
 
@@ -56,6 +57,16 @@ const StatusModal = ({
       </div>
     </div>
   );
+};
+
+StatusModal.propTypes = {
+  statusEffects: PropTypes.arrayOf(PropTypes.string).isRequired,
+  debilities: PropTypes.arrayOf(PropTypes.string).isRequired,
+  statusEffectTypes: PropTypes.object.isRequired,
+  debilityTypes: PropTypes.object.isRequired,
+  onToggleStatusEffect: PropTypes.func.isRequired,
+  onToggleDebility: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default StatusModal;


### PR DESCRIPTION
## Summary
- enforce PropTypes for CharacterStats and add defaults for optional props
- add PropTypes import and definitions across remaining UI components

## Testing
- `npm run lint`
- `npm test` *(fails: useDiceRoller contexts)*

------
https://chatgpt.com/codex/tasks/task_e_6899cc5051848332bf889eb2ed23b346