### PR TITLE
Add safe localStorage wrapper and tests

### DIFF
--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -106,3 +106,35 @@ describe('useDiceRoller mixed-case status modifiers', () => {
     expect(result.current.rollModalData.result).toMatch(/Weakened \(-1 damage\)/);
   });
 });
+
+describe('useDiceRoller safe localStorage handling', () => {
+  const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
+  const setCharacter = () => {};
+  const original = global.localStorage;
+
+  afterEach(() => {
+    global.localStorage = original;
+  });
+
+  it('initializes with empty history when localStorage is undefined', () => {
+    global.localStorage = undefined;
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    expect(result.current.rollHistory).toEqual([]);
+  });
+
+  it('initializes with empty history when localStorage throws', () => {
+    global.localStorage = {
+      getItem() {
+        throw new Error('fail');
+      },
+      setItem() {
+        throw new Error('fail');
+      },
+      removeItem() {
+        throw new Error('fail');
+      },
+    };
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    expect(result.current.rollHistory).toEqual([]);
+  });
+});

--- a/src/utils/safeLocalStorage.js
+++ b/src/utils/safeLocalStorage.js
@@ -1,0 +1,31 @@
+const safeLocalStorage = {
+  getItem(key, fallback = null) {
+    try {
+      if (typeof localStorage === 'undefined') return fallback;
+      const value = localStorage.getItem(key);
+      return value === null ? fallback : value;
+    } catch (error) {
+      return fallback;
+    }
+  },
+
+  setItem(key, value) {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(key, value);
+    } catch (error) {
+      // ignore
+    }
+  },
+
+  removeItem(key) {
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.removeItem(key);
+    } catch (error) {
+      // ignore
+    }
+  },
+};
+
+export default safeLocalStorage;

--- a/src/utils/safeLocalStorage.test.js
+++ b/src/utils/safeLocalStorage.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+import { describe, it, expect, vi } from 'vitest';
+import safeLocalStorage from './safeLocalStorage.js';
+
+describe('safeLocalStorage', () => {
+  it('returns fallback and does not throw when localStorage is undefined', () => {
+    const original = global.localStorage;
+    global.localStorage = undefined;
+    expect(safeLocalStorage.getItem('key', 'fallback')).toBe('fallback');
+    expect(() => safeLocalStorage.setItem('key', 'value')).not.toThrow();
+    expect(() => safeLocalStorage.removeItem('key')).not.toThrow();
+    global.localStorage = original;
+  });
+
+  it('returns fallback when getItem throws', () => {
+    const original = global.localStorage;
+    global.localStorage = {
+      getItem: vi.fn(() => {
+        throw new Error('fail');
+      }),
+    };
+    expect(safeLocalStorage.getItem('key', 'fallback')).toBe('fallback');
+    global.localStorage = original;
+  });
+
+  it('swallows errors from setItem and removeItem', () => {
+    const original = global.localStorage;
+    global.localStorage = {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(() => {
+        throw new Error('fail');
+      }),
+      removeItem: vi.fn(() => {
+        throw new Error('fail');
+      }),
+    };
+    expect(() => safeLocalStorage.setItem('key', 'value')).not.toThrow();
+    expect(() => safeLocalStorage.removeItem('key')).not.toThrow();
+    global.localStorage = original;
+  });
+});


### PR DESCRIPTION
## Summary
- add safeLocalStorage utility with guarded get/set/remove operations
- use safeLocalStorage in dice roller hook and handle missing storage gracefully
- add tests for storage failure scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899cc521cbc8332b4e4d64cbfb80bf8