### PR TITLE
Refactor undo and status effect logic into hooks

### DIFF
--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 import { renderHook, act } from '@testing-library/react';
 import { vi } from 'vitest';
-import * as diceUtils from '../utils/dice.js';
 import useDiceRoller from './useDiceRoller.js';
 
 describe('useDiceRoller contexts', () => {
@@ -21,34 +20,34 @@ describe('useDiceRoller contexts', () => {
   ])('returns correct success context for %s', (desc, expected) => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
-    const rollDieSpy = vi.spyOn(diceUtils, 'rollDie').mockReturnValue(6);
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999);
     act(() => {
       result.current.rollDice('2d6', desc);
     });
-    rollDieSpy.mockRestore();
+    randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe(expected);
   });
 
   it('returns correct partial context for HaCk', () => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
-    const rollDieSpy = vi.spyOn(diceUtils, 'rollDie');
-    rollDieSpy.mockReturnValueOnce(3).mockReturnValueOnce(4);
+    const randomSpy = vi.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0.35).mockReturnValueOnce(0.55);
     act(() => {
       result.current.rollDice('2d6', 'HaCk');
     });
-    rollDieSpy.mockRestore();
+    randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('Hit them, but they hit you back!');
   });
 
   it('returns correct failure context for taunt', () => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
-    const rollDieSpy = vi.spyOn(diceUtils, 'rollDie').mockReturnValue(1);
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     act(() => {
       result.current.rollDice('2d6', 'taunt');
     });
-    rollDieSpy.mockRestore();
+    randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('They ignore you completely');
   });
 

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -1,0 +1,62 @@
+export default function useStatusEffects(character, setCharacter) {
+  const statusEffects = character.statusEffects;
+  const debilities = character.debilities;
+
+  const statusEffectClassMap = {
+    poisoned: 'poisoned-overlay',
+    burning: 'burning-overlay',
+    shocked: 'shocked-overlay',
+    frozen: 'frozen-overlay',
+    blessed: 'blessed-overlay',
+  };
+
+  const getActiveVisualEffects = () => {
+    for (const [effect, cssClass] of Object.entries(statusEffectClassMap)) {
+      if (statusEffects.includes(effect)) {
+        return cssClass;
+      }
+    }
+    return '';
+  };
+
+  const toggleStatusEffect = (effect) => {
+    setCharacter((prev) => ({
+      ...prev,
+      statusEffects: prev.statusEffects.includes(effect)
+        ? prev.statusEffects.filter((e) => e !== effect)
+        : [...prev.statusEffects, effect],
+    }));
+  };
+
+  const toggleDebility = (debility) => {
+    setCharacter((prev) => ({
+      ...prev,
+      debilities: prev.debilities.includes(debility)
+        ? prev.debilities.filter((d) => d !== debility)
+        : [...prev.debilities, debility],
+    }));
+  };
+
+  const getHeaderColor = () => {
+    if (statusEffects.includes('poisoned'))
+      return 'linear-gradient(45deg, #22c55e, #059669, #00d4aa)';
+    if (statusEffects.includes('burning'))
+      return 'linear-gradient(45deg, #ef4444, #f97316, #fbbf24)';
+    if (statusEffects.includes('shocked'))
+      return 'linear-gradient(45deg, #3b82f6, #eab308, #00d4aa)';
+    if (statusEffects.includes('frozen'))
+      return 'linear-gradient(45deg, #06b6d4, #3b82f6, #6366f1)';
+    if (statusEffects.includes('blessed'))
+      return 'linear-gradient(45deg, #fbbf24, #f59e0b, #00d4aa)';
+    return 'linear-gradient(45deg, #6366f1, #8b5cf6, #00d4aa)';
+  };
+
+  return {
+    statusEffects,
+    debilities,
+    getActiveVisualEffects,
+    getHeaderColor,
+    toggleStatusEffect,
+    toggleDebility,
+  };
+}

--- a/src/hooks/useStatusEffects.test.jsx
+++ b/src/hooks/useStatusEffects.test.jsx
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+import { renderHook, act } from '@testing-library/react';
+import { useState } from 'react';
+import useStatusEffects from './useStatusEffects.js';
+
+describe('useStatusEffects', () => {
+  it('toggles status effects and debilities', () => {
+    const { result } = renderHook(() => {
+      const [character, setCharacter] = useState({ statusEffects: [], debilities: [] });
+      const status = useStatusEffects(character, setCharacter);
+      return { character, ...status };
+    });
+
+    act(() => result.current.toggleStatusEffect('poisoned'));
+    expect(result.current.character.statusEffects).toContain('poisoned');
+    act(() => result.current.toggleStatusEffect('poisoned'));
+    expect(result.current.character.statusEffects).not.toContain('poisoned');
+
+    act(() => result.current.toggleDebility('weak'));
+    expect(result.current.character.debilities).toContain('weak');
+    act(() => result.current.toggleDebility('weak'));
+    expect(result.current.character.debilities).not.toContain('weak');
+  });
+});

--- a/src/hooks/useUndo.js
+++ b/src/hooks/useUndo.js
@@ -1,0 +1,40 @@
+import { useRef, useEffect } from 'react';
+
+export default function useUndo(character, setCharacter, setRollResult) {
+  const timeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const saveToHistory = (action) => {
+    setCharacter((prev) => ({
+      ...prev,
+      actionHistory: [
+        { action, state: structuredClone(prev), timestamp: Date.now() },
+        ...prev.actionHistory.slice(0, 4),
+      ],
+    }));
+  };
+
+  const undoLastAction = () => {
+    if (character.actionHistory.length > 0) {
+      const lastAction = character.actionHistory[0];
+      setCharacter(structuredClone(lastAction.state));
+      if (setRollResult) {
+        setRollResult(`\u21B6 Undid: ${lastAction.action}`);
+        timeoutRef.current = setTimeout(() => setRollResult('Ready to roll!'), 2000);
+      }
+    }
+  };
+
+  return {
+    actionHistory: character.actionHistory,
+    saveToHistory,
+    undoLastAction,
+  };
+}

--- a/src/hooks/useUndo.test.jsx
+++ b/src/hooks/useUndo.test.jsx
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+import { renderHook, act } from '@testing-library/react';
+import { useState } from 'react';
+import { vi } from 'vitest';
+import useUndo from './useUndo.js';
+
+describe('useUndo', () => {
+  it('restores previous state on undo', () => {
+    vi.useFakeTimers();
+    const setRollResult = vi.fn();
+    const { result } = renderHook(() => {
+      const [character, setCharacter] = useState({ value: 1, actionHistory: [] });
+      const undo = useUndo(character, setCharacter, setRollResult);
+      return { character, setCharacter, ...undo };
+    });
+
+    act(() => {
+      result.current.saveToHistory('increment');
+      result.current.setCharacter((prev) => ({ ...prev, value: prev.value + 1 }));
+    });
+    expect(result.current.character.value).toBe(2);
+
+    act(() => {
+      result.current.undoLastAction();
+      vi.runAllTimers();
+    });
+
+    expect(result.current.character.value).toBe(1);
+    expect(setRollResult).toHaveBeenNthCalledWith(1, '↶ Undid: increment');
+    expect(setRollResult).toHaveBeenNthCalledWith(2, 'Ready to roll!');
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- Extract undo functionality into a reusable `useUndo` hook and wire it into `App`
- Encapsulate status effects and debility management with `useStatusEffects`
- Add unit tests for the new hooks and stabilize dice roller tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899cc535e348332bbc4f108d9277550