### PR TITLE
refactor: return result from run

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -61,11 +61,15 @@ fn get_os() -> String {
     std::env::consts::OS.to_string()
 }
 
+/// Runs the Tauri application.
+///
+/// Returns `Ok` if the application starts successfully or a
+/// `tauri::Error` if Tauri fails to launch.
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run() -> Result<(), tauri::Error> {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![write_file, read_file, get_os])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .run(tauri::generate_context!())?;
+    Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    zimbo_panel_lib::run()
+    zimbo_panel_lib::run().expect("error while running tauri application")
 }


### PR DESCRIPTION
## Summary
- return `Result<(), tauri::Error>` from `zimbo_panel_lib::run`
- centralize panic in `main.rs`

## Testing
- `cargo test`
- `npm test` *(fails: expected vs received context strings)*

------
https://chatgpt.com/codex/tasks/task_e_6899cc545dec8332b014b7e14810e77c