### PR TITLE
fix: make LevelUpModal buttons clickable

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -172,23 +172,33 @@ const LevelUpModal = ({
     if (e.target === e.currentTarget) onClose();
   };
 
+  const handleOverlayKeyDown = (e) => {
+    if (e.key === 'Escape' || e.key === 'Enter') onClose();
+  };
+
   return (
     <div
       className="levelup-overlay"
       onClick={handleOverlayClick}
+      onKeyDown={handleOverlayKeyDown}
       role="button"
       tabIndex={0}
       aria-label="Close"
-      onKeyDown={(e) => e.key === 'Enter' && handleOverlayClick(e)}
     >
-      <div className="levelup-modal">
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
+      <div
+        className="levelup-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
         {/* Header */}
         <div className="levelup-header">
           <h2 className="levelup-header-title">LEVEL UP!</h2>
           <p className="levelup-header-text">
             {character.name} advances to Level {levelUpState.newLevel}
           </p>
-          <button onClick={onClose} className="levelup-close-button">
+          <button onClick={onClose} className="levelup-close-button" aria-label="Close modal">
             ×
           </button>
         </div>

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -147,4 +147,20 @@ describe('LevelUpModal visibility and closing', () => {
     await user.click(screen.getByLabelText('Close'));
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('closes when pressing Escape', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<LevelUpWrapper isOpen {...baseProps} onClose={onClose} />);
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes when clicking the close button', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<LevelUpWrapper isOpen {...baseProps} onClose={onClose} />);
+    await user.click(screen.getByLabelText('Close modal'));
+    expect(onClose).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- prevent LevelUpModal overlay from swallowing clicks
- allow closing overlay via keyboard and maintain accessibility
- handle overlay keydown explicitly and label close button for exit

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a881fdc508332956c014aa9ab4405