### PR TITLE
feat: add upper hand context to dice rolls

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -79,6 +79,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
     if (description.includes('cha')) return 'Surprisingly charming for a cyber-barbarian!';
     if (description.includes('hack')) return "Clean hit, enemy can't counter!";
     if (description.includes('taunt')) return "They're completely focused on you now!";
+    if (description.includes('upper hand')) return 'Extra brutal damage with the upper hand!';
     return 'Perfect execution!';
   };
 
@@ -92,6 +93,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
     if (description.includes('cha')) return 'Awkward interaction, mixed signals';
     if (description.includes('hack')) return 'Hit them, but they hit you back!';
     if (description.includes('taunt')) return 'They attack you but with +1 ongoing damage!';
+    if (description.includes('upper hand')) return 'Deal damage, but lose the upper hand!';
     return 'Success with complications';
   };
 
@@ -105,6 +107,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
     if (description.includes('cha')) return 'Offensive, rude, or make things worse';
     if (description.includes('hack')) return 'Miss entirely, terrible position';
     if (description.includes('taunt')) return 'They ignore you completely';
+    if (description.includes('upper hand')) return 'Upper hand slips away completely!';
     return 'Things go badly';
   };
 

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -16,6 +16,7 @@ describe('useDiceRoller contexts', () => {
     ['cHa', 'Surprisingly charming for a cyber-barbarian!'],
     ['hack', "Clean hit, enemy can't counter!"],
     ['TAUNT', "They're completely focused on you now!"],
+    ['upper hand', 'Extra brutal damage with the upper hand!'],
     ['unknown', 'Perfect execution!'],
   ])('returns correct success context for %s', (desc, expected) => {
     localStorage.clear();
@@ -40,6 +41,18 @@ describe('useDiceRoller contexts', () => {
     expect(result.current.rollModalData.context).toBe('Hit them, but they hit you back!');
   });
 
+  it('returns correct partial context for upper hand', () => {
+    localStorage.clear();
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random');
+    randomSpy.mockReturnValueOnce(0.35).mockReturnValueOnce(0.55);
+    act(() => {
+      result.current.rollDice('2d6', 'upper hand');
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollModalData.context).toBe('Deal damage, but lose the upper hand!');
+  });
+
   it('returns correct failure context for taunt', () => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
@@ -51,6 +64,17 @@ describe('useDiceRoller contexts', () => {
     expect(result.current.rollModalData.context).toBe('They ignore you completely');
   });
 
+  it('returns correct failure context for upper hand', () => {
+    localStorage.clear();
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    act(() => {
+      result.current.rollDice('2d6', 'upper hand');
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollModalData.context).toBe('Upper hand slips away completely!');
+  });
+
   it('updates rollResult with latest roll', () => {
     localStorage.clear();
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
@@ -60,6 +84,17 @@ describe('useDiceRoller contexts', () => {
     });
     randomSpy.mockRestore();
     expect(result.current.rollResult).toBe('d4: 1 = 1');
+  });
+
+  it('retains the original description in rollModalData', () => {
+    localStorage.clear();
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999);
+    act(() => {
+      result.current.rollDice('2d6', 'Upper Hand');
+    });
+    randomSpy.mockRestore();
+    expect(result.current.rollModalData.description).toBe('Upper Hand');
   });
 });
 


### PR DESCRIPTION
## Summary
- add contextual messages for "upper hand" descriptions across success, partial, and failure rolls
- ensure roll descriptions persist so context is displayed in RollModal
- expand unit tests for new contexts and description retention

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8e075c248332a7074435fe23eb9d