### PR TITLE
feat: show item descriptions in inventory

### DIFF
--- a/src/components/InventoryModal.css
+++ b/src/components/InventoryModal.css
@@ -45,6 +45,26 @@
 .inventory-item-name {
   color: #fff;
   font-weight: bold;
+  position: relative;
+}
+
+.inventory-item-description {
+  display: none;
+  position: absolute;
+  background: #333;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  top: 100%;
+  left: 0;
+  font-size: 0.8rem;
+  width: max-content;
+  max-width: 250px;
+  z-index: 10;
+}
+
+.inventory-item-name:hover .inventory-item-description {
+  display: block;
 }
 
 .inventory-item-actions {

--- a/src/components/InventoryModal.jsx
+++ b/src/components/InventoryModal.jsx
@@ -16,6 +16,9 @@ const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
                 <div className="inventory-item-name">
                   {item.name}
                   {item.quantity ? ` x${item.quantity}` : ''}
+                  {item.description && (
+                    <div className="inventory-item-description">{item.description}</div>
+                  )}
                 </div>
                 <div className="inventory-item-actions">
                   {'equipped' in item && (

--- a/src/components/InventoryModal.test.jsx
+++ b/src/components/InventoryModal.test.jsx
@@ -37,6 +37,26 @@ describe('InventoryModal', () => {
     expect(screen.getByText('No items')).toBeInTheDocument();
   });
 
+  it('renders item descriptions', () => {
+    const inventory = [
+      {
+        id: 1,
+        name: 'Lantern',
+        description: 'Lights up dark places',
+      },
+    ];
+    render(
+      <InventoryModal
+        inventory={inventory}
+        onEquip={() => {}}
+        onConsume={() => {}}
+        onDrop={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText('Lights up dark places')).toBeInTheDocument();
+  });
+
   it('calls handlers on user actions', async () => {
     const user = userEvent.setup();
     const onEquip = vi.fn();

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -23,6 +23,9 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult }) => 
                   {(!item.type || item.type === 'gear') && '🎒'}
                   {item.name}
                   {item.equipped && <span className={styles.equippedMark}>✓</span>}
+                  {item.description && (
+                    <div className={styles.itemDescription}>{item.description}</div>
+                  )}
                 </div>
                 <div className={styles.itemDetails}>
                   {item.damage && `${item.damage} damage`}

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -46,6 +46,26 @@
   display: flex;
   align-items: center;
   gap: 5px;
+  position: relative;
+}
+
+.itemDescription {
+  display: none;
+  position: absolute;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+  top: 100%;
+  left: 0;
+  font-size: 0.7rem;
+  width: max-content;
+  max-width: 200px;
+  z-index: 10;
+}
+
+.itemName:hover .itemDescription {
+  display: block;
 }
 
 .equippedMark {

--- a/src/components/InventoryPanel.test.jsx
+++ b/src/components/InventoryPanel.test.jsx
@@ -43,4 +43,26 @@ describe('InventoryPanel', () => {
     expect(screen.getByText(/Active Debilities:/i)).toBeInTheDocument();
     expect(screen.getByText(/Weak/)).toBeInTheDocument();
   });
+
+  it('renders item descriptions', () => {
+    const character = {
+      inventory: [
+        {
+          id: 1,
+          name: 'Sword',
+          description: 'A sharp blade',
+        },
+      ],
+      debilities: [],
+    };
+    render(
+      <InventoryPanel
+        character={character}
+        setCharacter={() => {}}
+        rollDie={() => 1}
+        setRollResult={() => {}}
+      />,
+    );
+    expect(screen.getByText('A sharp blade')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- show item descriptions in InventoryPanel and modal via hover tooltips
- add styles for tooltip positioning and appearance
- test rendering of item descriptions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a8e1328548332aca12f206240e486