### PR TITLE
feat: dev button to open Level Up modal

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -214,6 +214,19 @@ const CharacterStats = ({
         />{' '}
         Auto XP on Miss
       </label>
+      {import.meta.env.DEV && (
+        <button
+          onClick={() => setShowLevelUpModal(true)}
+          style={{
+            ...buttonStyle,
+            background: 'linear-gradient(45deg, #6366f1, #8b5cf6)',
+            width: '100%',
+            marginTop: '10px',
+          }}
+        >
+          Open Level Up Test Modal
+        </button>
+      )}
       {character.xp >= character.xpNeeded && (
         <button
           onClick={() => setShowLevelUpModal(true)}


### PR DESCRIPTION
## Summary
- allow opening the Level Up modal in development via test button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8e1da12483329ea2d0758575d0f3