### PR TITLE
Add Export modal for saving and loading character sheets

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ function App() {
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [showDamageModal, setShowDamageModal] = useState(false);
   const [showInventoryModal, setShowInventoryModal] = useState(false);
+  const [showExportModal, setShowExportModal] = useState(false);
   const [compactMode, setCompactMode] = useState(false);
   const [autoXpOnMiss, setAutoXpOnMiss] = useState(true);
 
@@ -61,11 +62,7 @@ function App() {
     }
   }, [sessionNotes]);
 
-  const { actionHistory, saveToHistory, undoLastAction } = useUndo(
-    character,
-    setCharacter,
-    setRollResult,
-  );
+  const { saveToHistory, undoLastAction } = useUndo(character, setCharacter, setRollResult);
 
   const {
     statusEffects,
@@ -135,6 +132,12 @@ function App() {
                 className={`${styles.button} ${styles.bondsButton}`}
               >
                 👥 Bonds ({character.bonds.filter((b) => !b.resolved).length})
+              </button>
+              <button
+                onClick={() => setShowExportModal(true)}
+                className={`${styles.button} ${styles.exportButton}`}
+              >
+                💾 Export/Save
               </button>
             </div>
           </div>
@@ -215,6 +218,8 @@ function App() {
         handleConsumeItem={handleConsumeItem}
         handleDropItem={handleDropItem}
         bondsModal={bondsModal}
+        showExportModal={showExportModal}
+        setShowExportModal={setShowExportModal}
       />
     </div>
   );

--- a/src/components/ExportModal.jsx
+++ b/src/components/ExportModal.jsx
@@ -1,0 +1,68 @@
+import { invoke } from '@tauri-apps/api/core';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { useCharacter } from '../state/CharacterContext.jsx';
+import styles from './ExportModal.module.css';
+
+export default function ExportModal({ isOpen, onClose }) {
+  const { character, setCharacter } = useCharacter();
+  const [fileName, setFileName] = useState('character.json');
+  const [message, setMessage] = useState('');
+
+  if (!isOpen) return null;
+
+  const handleSave = async () => {
+    try {
+      await invoke('write_file', {
+        path: fileName,
+        contents: JSON.stringify(character, null, 2),
+      });
+      setMessage('Character saved!');
+    } catch (err) {
+      setMessage('Failed to save.');
+    }
+  };
+
+  const handleLoad = async () => {
+    try {
+      const contents = await invoke('read_file', { path: fileName });
+      const data = JSON.parse(contents);
+      setCharacter(data);
+      setMessage('Character loaded!');
+    } catch (err) {
+      setMessage('Failed to load.');
+    }
+  };
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h2 className={styles.title}>💾 Export / Import</h2>
+        <input
+          type="text"
+          value={fileName}
+          onChange={(e) => setFileName(e.target.value)}
+          placeholder="filename.json"
+          className={styles.input}
+        />
+        {message && <div className={styles.message}>{message}</div>}
+        <div className={styles.buttonGroup}>
+          <button onClick={handleSave} className={styles.button}>
+            Save
+          </button>
+          <button onClick={handleLoad} className={styles.button}>
+            Load
+          </button>
+          <button onClick={onClose} className={styles.button}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ExportModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -1,0 +1,59 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  background: #1a1a2e;
+  border: 2px solid #00ff88;
+  border-radius: 15px;
+  padding: 30px;
+  text-align: center;
+  width: 300px;
+}
+
+.title {
+  color: #00ff88;
+  margin-bottom: 10px;
+}
+
+.input {
+  background: #0f0f1f;
+  border: 1px solid #00ff88;
+  border-radius: 6px;
+  color: white;
+  padding: 8px;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.message {
+  color: #00ff88;
+  margin-bottom: 10px;
+}
+
+.buttonGroup {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.button {
+  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 8px 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  margin: 5px;
+}

--- a/src/components/ExportModal.test.jsx
+++ b/src/components/ExportModal.test.jsx
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+import { invoke } from '@tauri-apps/api/core';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import CharacterContext from '../state/CharacterContext.jsx';
+import ExportModal from './ExportModal.jsx';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+function renderWithCharacter(ui, { character }) {
+  const Wrapper = ({ children }) => {
+    const [charState, setCharState] = React.useState(character);
+    return (
+      <CharacterContext.Provider value={{ character: charState, setCharacter: setCharState }}>
+        {children}
+        <div data-testid="name">{charState.name}</div>
+      </CharacterContext.Provider>
+    );
+  };
+  return render(ui, { wrapper: Wrapper });
+}
+
+describe('ExportModal', () => {
+  it('toggles visibility with isOpen prop', () => {
+    const onClose = vi.fn();
+    const initial = { name: 'Hero' };
+    const { rerender } = renderWithCharacter(<ExportModal isOpen={false} onClose={onClose} />, {
+      character: initial,
+    });
+    expect(screen.queryByText(/Export \/ Import/)).not.toBeInTheDocument();
+    rerender(<ExportModal isOpen onClose={onClose} />);
+    expect(screen.getByText(/Export \/ Import/)).toBeInTheDocument();
+  });
+
+  it('loads character from file', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const initial = { name: 'Hero' };
+    invoke.mockResolvedValueOnce('{"name":"New"}');
+    renderWithCharacter(<ExportModal isOpen onClose={onClose} />, { character: initial });
+    await user.click(screen.getByText('Load'));
+    expect(screen.getByTestId('name')).toHaveTextContent('New');
+  });
+});

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import BondsModal from './BondsModal.jsx';
 import DamageModal from './DamageModal.jsx';
+import ExportModal from './ExportModal.jsx';
 import InventoryModal from './InventoryModal.jsx';
 import LevelUpModal from './LevelUpModal.jsx';
 import StatusModal from './StatusModal.jsx';
@@ -29,6 +30,8 @@ const GameModals = ({
   handleEquipItem,
   handleConsumeItem,
   handleDropItem,
+  showExportModal,
+  setShowExportModal,
   bondsModal,
 }) => (
   <>
@@ -69,6 +72,8 @@ const GameModals = ({
     )}
 
     <BondsModal isOpen={bondsModal.isOpen} onClose={bondsModal.close} />
+
+    <ExportModal isOpen={showExportModal} onClose={() => setShowExportModal(false)} />
   </>
 );
 
@@ -95,6 +100,8 @@ GameModals.propTypes = {
   handleEquipItem: PropTypes.func.isRequired,
   handleConsumeItem: PropTypes.func.isRequired,
   handleDropItem: PropTypes.func.isRequired,
+  showExportModal: PropTypes.bool.isRequired,
+  setShowExportModal: PropTypes.func.isRequired,
   bondsModal: PropTypes.shape({
     isOpen: PropTypes.bool.isRequired,
     close: PropTypes.func.isRequired,

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -101,3 +101,7 @@
 .bondsButton {
   background: linear-gradient(45deg, #3b82f6, #2563eb);
 }
+
+.exportButton {
+  background: linear-gradient(45deg, #14b8a6, #0d9488);
+}


### PR DESCRIPTION
## Summary
- add ExportModal component allowing save/load of character data to JSON files
- integrate export modal into GameModals and App with new Export/Save button
- style export button and include unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a8e283b408332a4a6aba26c9c98c6