### PR TITLE
chore: specify required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A cross-platform desktop application for managing tabletop RPG characters. Built
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) and npm
+- [Node.js](https://nodejs.org/) >=20 and npm
 - [Rust](https://www.rust-lang.org/tools/install) and Cargo
 - Tauri CLI (`npm install` or `cargo install tauri-cli`)
 
@@ -60,8 +60,6 @@ _Add screenshots or GIFs demonstrating character stats, dice roller, and invento
 2. Create a branch for your feature or fix.
 3. Submit a pull request with a clear description of changes.
 
-
 ## License
-
 
 This project is licensed under a custom Non-Commercial License; commercial use requires prior written permission. See [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "setupFiles": [
       "<rootDir>/jest.setup.cjs"
     ]
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Summary
- declare Node.js >=20 support via package.json `engines` field
- document Node.js >=20 requirement in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a8fc55e5c8332ac85a4d16374d680