### PR TITLE
Manage level up state centrally

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,15 @@ function App() {
   const [compactMode, setCompactMode] = useState(false);
   const [autoXpOnMiss, setAutoXpOnMiss] = useState(true);
 
+  const getDefaultLevelUpState = () => ({
+    selectedStats: [],
+    selectedMove: '',
+    hpIncrease: 0,
+    newLevel: character.level + 1,
+    expandedMove: '',
+  });
+  const [levelUpState, setLevelUpState] = useState(getDefaultLevelUpState);
+
   const {
     rollResult,
     setRollResult,
@@ -47,11 +56,17 @@ function App() {
   // Auto-detect level up opportunity
   useEffect(() => {
     if (character.xp >= character.xpNeeded && !showLevelUpModal) {
+      setLevelUpState((prev) => ({ ...prev, newLevel: character.level + 1 }));
       setShowLevelUpModal(true);
-      // ensure next level reflects current character.level
-      // (avoids stale closure if character.level changed)
     }
   }, [character.xp, character.xpNeeded, character.level, showLevelUpModal]);
+
+  // Reset level up state when modal closes or level changes
+  useEffect(() => {
+    if (!showLevelUpModal) {
+      setLevelUpState(getDefaultLevelUpState());
+    }
+  }, [showLevelUpModal, character.level]);
 
   // Persist session notes
   useEffect(() => {
@@ -191,14 +206,8 @@ function App() {
       <GameModals
         character={character}
         setCharacter={setCharacter}
-        levelUpState={{
-          selectedStats: [],
-          selectedMove: '',
-          hpIncrease: 0,
-          newLevel: character.level + 1,
-          expandedMove: '',
-        }}
-        setLevelUpState={() => {}}
+        levelUpState={levelUpState}
+        setLevelUpState={setLevelUpState}
         showLevelUpModal={showLevelUpModal}
         setShowLevelUpModal={setShowLevelUpModal}
         rollDie={rollDie}

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './LevelUpModal.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import Message from './Message.jsx';
@@ -15,6 +15,14 @@ const LevelUpModal = ({
 }) => {
   const [showMoveDetails, setShowMoveDetails] = useState('');
   const [validationMessage, setValidationMessage] = useState('');
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   // Helper functions
   const canIncreaseTwo = () => {


### PR DESCRIPTION
## Summary
- Track level-up selections in App state and reset when modal closes
- Pass level-up state into GameModals and update newLevel when XP threshold reached
- Allow pressing Escape anywhere to close the level-up modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a9b4085d08332974478c6a2e863d7