### PR TITLE
Remove unused roll history return from LevelUpModal

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './LevelUpModal.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import Message from './Message.jsx';
@@ -15,6 +15,14 @@ const LevelUpModal = ({
 }) => {
   const [showMoveDetails, setShowMoveDetails] = useState('');
   const [validationMessage, setValidationMessage] = useState('');
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   // Helper functions
   const canIncreaseTwo = () => {
@@ -60,17 +68,20 @@ const LevelUpModal = ({
     setLevelUpState((prev) => ({ ...prev, hpIncrease: increase }));
     setRollResult(`HP Roll: d10(${roll}) + CON(${conMod}) = +${increase} HP`);
 
-    // Add visual feedback
-    const rollHistory = {
-      type: 'HP Roll',
-      result: `+${increase} HP`,
-      rolls: [roll],
-      modifier: conMod,
-      total: increase,
-      timestamp: new Date().toLocaleTimeString(),
-    };
-
-    return rollHistory;
+    setCharacter((prev) => ({
+      ...prev,
+      rollHistory: [
+        {
+          type: 'HP Roll',
+          result: `+${increase} HP`,
+          rolls: [roll],
+          modifier: conMod,
+          total: increase,
+          timestamp: new Date().toLocaleTimeString(),
+        },
+        ...(prev.rollHistory ? prev.rollHistory.slice(0, 9) : []),
+      ],
+    }));
   };
 
   const completeLevelUp = () => {


### PR DESCRIPTION
## Summary
- Remove unused rollHistory object and return in LevelUpModal's HP roll
- Log HP roll to character roll history and add global Escape handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9b41a7108332ab18f3bc23b75189