### PR TITLE
feat: improve level up modal accessibility

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import './LevelUpModal.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import Message from './Message.jsx';
@@ -15,6 +15,38 @@ const LevelUpModal = ({
 }) => {
   const [showMoveDetails, setShowMoveDetails] = useState('');
   const [validationMessage, setValidationMessage] = useState('');
+  const modalRef = useRef(null);
+
+  useEffect(() => {
+    if (!modalRef.current) return;
+    modalRef.current.focus();
+
+    const handleTabTrap = (e) => {
+      if (e.key !== 'Tab') return;
+      const focusable = modalRef.current.querySelectorAll(
+        'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    const node = modalRef.current;
+    node.addEventListener('keydown', handleTabTrap);
+    return () => node.removeEventListener('keydown', handleTabTrap);
+  }, []);
 
   // Helper functions
   const canIncreaseTwo = () => {
@@ -173,24 +205,25 @@ const LevelUpModal = ({
   };
 
   const handleOverlayKeyDown = (e) => {
-    if (e.key === 'Escape' || e.key === 'Enter') onClose();
+    if (e.key === 'Escape') onClose();
   };
 
   return (
+    /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
     <div
       className="levelup-overlay"
       onClick={handleOverlayClick}
       onKeyDown={handleOverlayKeyDown}
-      role="button"
-      tabIndex={0}
       aria-label="Close"
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
       <div
+        ref={modalRef}
         className="levelup-modal"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
+        tabIndex={-1}
       >
         {/* Header */}
         <div className="levelup-header">

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -140,6 +140,12 @@ describe('LevelUpModal visibility and closing', () => {
     expect(screen.getByRole('heading', { name: /LEVEL UP!/i })).toBeInTheDocument();
   });
 
+  it('focuses the modal when opened', () => {
+    const onClose = vi.fn();
+    render(<LevelUpWrapper isOpen {...baseProps} onClose={onClose} />);
+    expect(document.activeElement).toBe(screen.getByRole('dialog'));
+  });
+
   it('closes when clicking the overlay', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();


### PR DESCRIPTION
## Summary
- focus modal when opened and trap focus inside
- remove button semantics from level-up overlay
- cover modal focus behavior with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9b43077c8332ab7755e14f36eb39