### PR TITLE
feat: add theme selection context

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,8 +9,8 @@
 
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: linear-gradient(135deg, #1a1a2e, #16213e);
-  color: #e0e0e0;
+  background: var(--background);
+  color: var(--text-color);
   overflow-x: hidden;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import DiceRoller from './components/DiceRoller.jsx';
 import GameModals from './components/GameModals.jsx';
 import InventoryPanel from './components/InventoryPanel.jsx';
 import SessionNotes from './components/SessionNotes.jsx';
+import Settings from './components/Settings.jsx';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
 import useModal from './hooks/useModal.js';
@@ -139,6 +140,7 @@ function App() {
               >
                 💾 Export/Save
               </button>
+              <Settings />
             </div>
           </div>
         </div>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import App from './App.jsx';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
 import CharacterContext from './state/CharacterContext.jsx';
+import { ThemeProvider } from './state/ThemeContext.jsx';
 
 describe('App level up auto-detection', () => {
   it('opens LevelUpModal when xp exceeds xpNeeded', async () => {
@@ -14,9 +15,11 @@ describe('App level up auto-detection', () => {
       const [character, setChar] = React.useState(initialCharacter);
       setCharacter = setChar;
       return (
-        <CharacterContext.Provider value={{ character, setCharacter: setChar }}>
-          {children}
-        </CharacterContext.Provider>
+        <ThemeProvider>
+          <CharacterContext.Provider value={{ character, setCharacter: setChar }}>
+            {children}
+          </CharacterContext.Provider>
+        </ThemeProvider>
       );
     };
 
@@ -45,9 +48,11 @@ describe('XP gain on miss', () => {
     const Wrapper = ({ children }) => {
       const [character, setCharacter] = React.useState(initialCharacter);
       return (
-        <CharacterContext.Provider value={{ character, setCharacter }}>
-          {children}
-        </CharacterContext.Provider>
+        <ThemeProvider>
+          <CharacterContext.Provider value={{ character, setCharacter }}>
+            {children}
+          </CharacterContext.Provider>
+        </ThemeProvider>
       );
     };
 
@@ -76,9 +81,11 @@ describe('XP gain on miss', () => {
     const Wrapper = ({ children }) => {
       const [character, setCharacter] = React.useState(initialCharacter);
       return (
-        <CharacterContext.Provider value={{ character, setCharacter }}>
-          {children}
-        </CharacterContext.Provider>
+        <ThemeProvider>
+          <CharacterContext.Provider value={{ character, setCharacter }}>
+            {children}
+          </CharacterContext.Provider>
+        </ThemeProvider>
       );
     };
 
@@ -109,9 +116,11 @@ describe.skip('localStorage persistence', () => {
   const Wrapper = ({ children }) => {
     const [character, setCharacter] = React.useState(INITIAL_CHARACTER_DATA);
     return (
-      <CharacterContext.Provider value={{ character, setCharacter }}>
-        {children}
-      </CharacterContext.Provider>
+      <ThemeProvider>
+        <CharacterContext.Provider value={{ character, setCharacter }}>
+          {children}
+        </CharacterContext.Provider>
+      </ThemeProvider>
     );
   };
 

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -152,6 +152,8 @@ describe('LevelUpModal visibility and closing', () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
     render(<LevelUpWrapper isOpen {...baseProps} onClose={onClose} />);
+    const overlay = screen.getByLabelText('Close');
+    overlay.focus();
     await user.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useTheme } from '../state/ThemeContext.jsx';
+
+const Settings = () => {
+  const { theme, setTheme, themes } = useTheme();
+
+  return (
+    <div>
+      <label htmlFor="theme-select">Theme:</label>{' '}
+      <select id="theme-select" value={theme} onChange={(e) => setTheme(e.target.value)}>
+        {themes.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default Settings;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App';
-import { CharacterProvider } from './state/CharacterContext';
+import App from './App.jsx';
+import { CharacterProvider } from './state/CharacterContext.jsx';
+import { ThemeProvider } from './state/ThemeContext.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <CharacterProvider>
-      <App />
-    </CharacterProvider>
+    <ThemeProvider>
+      <CharacterProvider>
+        <App />
+      </CharacterProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 );

--- a/src/state/ThemeContext.jsx
+++ b/src/state/ThemeContext.jsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { THEMES, DEFAULT_THEME } from './theme.js';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || DEFAULT_THEME);
+
+  useEffect(() => {
+    const themeVars = THEMES[theme];
+    if (themeVars) {
+      Object.entries(themeVars).forEach(([key, value]) => {
+        document.documentElement.style.setProperty(key, value);
+      });
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const value = { theme, setTheme, themes: Object.keys(THEMES) };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext);
+
+export default ThemeContext;

--- a/src/state/theme.js
+++ b/src/state/theme.js
@@ -1,0 +1,16 @@
+export const THEMES = {
+  cosmic: {
+    '--background': 'linear-gradient(135deg, #1a1a2e, #16213e)',
+    '--text-color': '#e0e0e0',
+    '--accent-color': '#00ff88',
+    '--accent-shadow': 'rgba(0, 255, 136, 0.3)',
+  },
+  classic: {
+    '--background': '#f4f4f4',
+    '--text-color': '#222222',
+    '--accent-color': '#3333ff',
+    '--accent-shadow': 'rgba(51, 51, 255, 0.3)',
+  },
+};
+
+export const DEFAULT_THEME = 'cosmic';

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -1,7 +1,7 @@
 .container {
   min-height: 100vh;
-  background: linear-gradient(135deg, #1a1a2e, #16213e);
-  color: #e0e0e0;
+  background: var(--background);
+  color: var(--text-color);
   padding: 20px;
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
@@ -16,8 +16,8 @@
   margin-bottom: 30px;
   padding: 20px;
   border-radius: 15px;
-  border: 2px solid #00ff88;
-  box-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
+  border: 2px solid var(--accent-color);
+  box-shadow: 0 0 20px var(--accent-shadow);
   transition: all 0.5s ease;
 }
 
@@ -30,7 +30,7 @@
 .title {
   font-size: 2.5rem;
   margin-bottom: 10px;
-  text-shadow: 0 0 10px #00ff88;
+  text-shadow: 0 0 10px var(--accent-color);
 }
 
 .subHeader {


### PR DESCRIPTION
## Summary
- add ThemeContext with cosmic and classic themes
- add Settings component to select and persist theme
- convert global styles to theme variables and wrap app with ThemeProvider

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9cb9c50c833287a9505875660685