### PR TITLE
feat: add help reroll option

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,9 +1,19 @@
 import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import App from './App.jsx';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
 import CharacterContext from './state/CharacterContext.jsx';
+
+beforeEach(() => {
+  vi.spyOn(window, 'confirm').mockReturnValue(false);
+  vi.spyOn(window, 'prompt').mockReturnValue('0');
+});
+
+afterEach(() => {
+  window.confirm.mockRestore();
+  window.prompt.mockRestore();
+});
 
 describe('App level up auto-detection', () => {
   it('opens LevelUpModal when xp exceeds xpNeeded', async () => {
@@ -101,6 +111,41 @@ describe('XP gain on miss', () => {
     expect(screen.getByText(/XP: 0\/5/i)).toBeInTheDocument();
 
     Math.random.mockRestore();
+  });
+
+  it('increments XP for both players when help still fails', () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    const initialCharacter = { ...INITIAL_CHARACTER_DATA, xp: 0, xpNeeded: 5 };
+
+    const Wrapper = ({ children }) => {
+      const [character, setCharacter] = React.useState(initialCharacter);
+      return (
+        <CharacterContext.Provider value={{ character, setCharacter }}>
+          {children}
+        </CharacterContext.Provider>
+      );
+    };
+
+    window.confirm.mockReturnValue(true);
+    window.prompt.mockReturnValue('0');
+
+    render(
+      <Wrapper>
+        <App />
+      </Wrapper>,
+    );
+
+    const button = screen.getByRole('button', { name: 'INT (+0)' });
+    act(() => {
+      fireEvent.click(button);
+    });
+
+    expect(screen.getByText(/XP: 2\/5/i)).toBeInTheDocument();
+    expect(screen.getByText(/Original:/i)).toBeInTheDocument();
+    expect(screen.getByText(/With Help:/i)).toBeInTheDocument();
+
+    randomSpy.mockRestore();
   });
 });
 

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -152,6 +152,7 @@ describe('LevelUpModal visibility and closing', () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
     render(<LevelUpWrapper isOpen {...baseProps} onClose={onClose} />);
+    screen.getByLabelText('Close').focus();
     await user.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/components/RollModal.jsx
+++ b/src/components/RollModal.jsx
@@ -16,7 +16,12 @@ export default function RollModal({ isOpen, data, onClose }) {
           </div>
         </div>
         <div className={styles.body}>
-          <div className={styles.result}>{data.result}</div>
+          {data.originalResult && (
+            <div className={styles.original}>Original: {data.originalResult}</div>
+          )}
+          <div className={styles.result}>
+            {data.originalResult ? `With Help: ${data.result}` : data.result}
+          </div>
           {data.description && <div className={styles.description}>{data.description}</div>}
           {data.context && <div className={styles.context}>{data.context}</div>}
           <button onClick={onClose} className={styles.button}>

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -74,6 +74,12 @@
   margin-bottom: 20px;
 }
 
+.original {
+  font-size: 1rem;
+  color: #aaa;
+  margin-bottom: 10px;
+}
+
 .button {
   background: linear-gradient(45deg, #00ff88, #00cc6a);
   border: none;

--- a/src/components/RollModal.test.jsx
+++ b/src/components/RollModal.test.jsx
@@ -30,4 +30,11 @@ describe('RollModal', () => {
 
     expect(onClose).toHaveBeenCalledTimes(2);
   });
+
+  it('displays original and helped results when provided', () => {
+    const data = { result: '2d6: 7', originalResult: '2d6: 5' };
+    render(<RollModal isOpen data={data} onClose={() => {}} />);
+    expect(screen.getByText(/Original: 2d6: 5/)).toBeInTheDocument();
+    expect(screen.getByText(/With Help: 2d6: 7/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- allow reroll with bond modifier after a failed 2d6 roll
- show original and helped results in roll modal
- add tests for helper XP and roll displays

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9ca6c4c083328f5be8ca25119438