### PR TITLE
chore: remove jest setup

### DIFF
--- a/jest.setup.cjs
+++ b/jest.setup.cjs
@@ -1,2 +1,0 @@
-﻿const { webcrypto } = require('crypto');
-if (!global.crypto) global.crypto = webcrypto;

--- a/package.json
+++ b/package.json
@@ -53,11 +53,6 @@
       "prettier --write"
     ]
   },
-  "jest": {
-    "setupFiles": [
-      "<rootDir>/jest.setup.cjs"
-    ]
-  },
   "engines": {
     "node": ">=20"
   }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,8 @@
-import '@testing-library/jest-dom';
+import { webcrypto } from 'node:crypto';
+
+// Provide Web Crypto API in test environment if missing
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}
+
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- remove leftover Jest configuration
- polyfill Web Crypto in Vitest setup and use `@testing-library/jest-dom/vitest`

## Testing
- `npm test` *(fails: useRef is not defined; Cannot destructure property 'theme')*

------
https://chatgpt.com/codex/tasks/task_e_689aaf0b56588332a13513cc0b76b6ae