### PR TITLE
chore: use cmd wrapper for npm

### DIFF
--- a/just-errors.ps1
+++ b/just-errors.ps1
@@ -1,0 +1,22 @@
+# just-errors.ps1 — run npm commands via cmd.exe and capture errors
+param([string[]]$Args)
+
+$cmdArgs = "/c npm " + ($Args -join ' ')
+
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = "cmd"
+$psi.Arguments = $cmdArgs
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false
+
+$process = [System.Diagnostics.Process]::Start($psi)
+
+$stdout = $process.StandardOutput.ReadToEnd()
+$stderr = $process.StandardError.ReadToEnd()
+$process.WaitForExit()
+
+if ($stdout) { Write-Output $stdout }
+if ($stderr) { Write-Error $stderr }
+
+exit $process.ExitCode


### PR DESCRIPTION
## Summary
- add just-errors script running npm via cmd.exe with stdout/stderr redirection

## Testing
- `npm test` *(fails: 3 files, 9 tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ab14dcaa48332adc555dbbb937820