### PR TITLE
Include useRef import for LevelUpModal

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import './LevelUpModal.module.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import Message from './Message.jsx';


### PR DESCRIPTION
## Summary
- import `useRef` in LevelUpModal component

## Testing
- `npm run lint`
- `npm test` *(fails: useTheme undefined in Settings and window.prompt not mocked)*

------
https://chatgpt.com/codex/tasks/task_e_689ac5f3c34083329e328f5663d6f2a2