### PR TITLE
Remove auto XP toggle and always award XP on miss

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 import {
-  FaClock,
   FaMeteor,
   FaRadiation,
   FaBoxOpen,
@@ -38,7 +37,6 @@ function App() {
   const [showInventoryModal, setShowInventoryModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [compactMode, setCompactMode] = useState(false);
-  const [autoXpOnMiss, setAutoXpOnMiss] = useState(true);
 
   const getDefaultLevelUpState = () => ({
     selectedStats: [],
@@ -58,7 +56,7 @@ function App() {
     rollModalData,
     rollDie,
     clearRollHistory,
-  } = useDiceRoller(character, setCharacter, autoXpOnMiss);
+  } = useDiceRoller(character, setCharacter);
 
   const { totalArmor, equippedWeaponDamage, handleEquipItem, handleConsumeItem, handleDropItem } =
     useInventory(character, setCharacter);
@@ -183,8 +181,6 @@ function App() {
             saveToHistory={saveToHistory}
             totalArmor={totalArmor}
             setShowLevelUpModal={setShowLevelUpModal}
-            autoXpOnMiss={autoXpOnMiss}
-            setAutoXpOnMiss={setAutoXpOnMiss}
             setRollResult={setRollResult}
             setSessionNotes={setSessionNotes}
             clearRollHistory={clearRollHistory}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -92,8 +92,8 @@ describe('XP gain on miss', () => {
     Math.random.mockRestore();
   });
 
-  it('does not increment XP when auto XP toggle is off', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0);
+  it('increments XP for both players when help still fails', () => {
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
 
     const initialCharacter = { ...INITIAL_CHARACTER_DATA, xp: 0, xpNeeded: 5 };
 
@@ -105,41 +105,6 @@ describe('XP gain on miss', () => {
             {children}
           </CharacterContext.Provider>
         </ThemeProvider>
-      );
-    };
-
-    render(
-      <Wrapper>
-        <App />
-      </Wrapper>,
-    );
-
-    const toggle = screen.getByLabelText(/Auto XP on Miss/i);
-    act(() => {
-      fireEvent.click(toggle);
-    });
-
-    const button = screen.getByRole('button', { name: 'INT (+0)' });
-    act(() => {
-      fireEvent.click(button);
-    });
-
-    expect(screen.getByText(/XP: 0\/5/i)).toBeInTheDocument();
-
-    Math.random.mockRestore();
-  });
-
-  it('increments XP for both players when help still fails', () => {
-    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
-
-    const initialCharacter = { ...INITIAL_CHARACTER_DATA, xp: 0, xpNeeded: 5 };
-
-    const Wrapper = ({ children }) => {
-      const [character, setCharacter] = React.useState(initialCharacter);
-      return (
-        <CharacterContext.Provider value={{ character, setCharacter }}>
-          {children}
-        </CharacterContext.Provider>
       );
     };
 
@@ -158,7 +123,7 @@ describe('XP gain on miss', () => {
     });
 
     expect(screen.getByText(/XP: 2\/5/i)).toBeInTheDocument();
-    expect(screen.getByText(/Original:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Original Roll:/i)).toBeInTheDocument();
     expect(screen.getByText(/With Help:/i)).toBeInTheDocument();
 
     randomSpy.mockRestore();

--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -7,8 +7,6 @@ const CharacterStats = ({
   saveToHistory,
   totalArmor,
   setShowLevelUpModal,
-  autoXpOnMiss,
-  setAutoXpOnMiss,
   setRollResult,
   setSessionNotes,
   clearRollHistory,
@@ -85,14 +83,6 @@ const CharacterStats = ({
           -1 XP
         </button>
       </div>
-      <label className={styles.autoXpLabel}>
-        <input
-          type="checkbox"
-          checked={autoXpOnMiss}
-          onChange={() => setAutoXpOnMiss((prev) => !prev)}
-        />{' '}
-        Auto XP on Miss
-      </label>
       {import.meta.env.DEV && (
         <button
           onClick={() => setShowLevelUpModal(true)}
@@ -254,8 +244,6 @@ CharacterStats.propTypes = {
   saveToHistory: PropTypes.func.isRequired,
   totalArmor: PropTypes.number.isRequired,
   setShowLevelUpModal: PropTypes.func.isRequired,
-  autoXpOnMiss: PropTypes.bool.isRequired,
-  setAutoXpOnMiss: PropTypes.func.isRequired,
   setRollResult: PropTypes.func.isRequired,
   setSessionNotes: PropTypes.func,
   clearRollHistory: PropTypes.func,

--- a/src/components/CharacterStats.test.jsx
+++ b/src/components/CharacterStats.test.jsx
@@ -36,8 +36,6 @@ describe('CharacterStats', () => {
       saveToHistory: vi.fn(),
       totalArmor: 0,
       setShowLevelUpModal: vi.fn(),
-      autoXpOnMiss: false,
-      setAutoXpOnMiss: vi.fn(),
       setRollResult: vi.fn(),
       ...propOverrides,
     };
@@ -54,14 +52,6 @@ describe('CharacterStats', () => {
     expect(levelUpButton).toBeInTheDocument();
     await user.click(levelUpButton);
     expect(props.setShowLevelUpModal).toHaveBeenCalledWith(true);
-  });
-
-  it('toggles auto XP on miss checkbox', async () => {
-    const user = userEvent.setup();
-    const { props } = renderComponent();
-    const checkbox = screen.getByLabelText(/Auto XP on Miss/i);
-    await user.click(checkbox);
-    expect(props.setAutoXpOnMiss).toHaveBeenCalled();
   });
 
   it('disables chrono-retcon button when no uses left', () => {

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import './LevelUpModal.module.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import Message from './Message.jsx';

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -4,7 +4,7 @@ import * as diceUtils from '../utils/dice.js';
 import safeLocalStorage from '../utils/safeLocalStorage.js';
 import useModal from './useModal';
 
-export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
+export default function useDiceRoller(character, setCharacter) {
   const [rollResult, setRollResult] = useState('Ready to roll!');
   const [rollModalData, setRollModalData] = useState({});
   const [rollHistory, setRollHistory] = useState(() => {
@@ -173,9 +173,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
       } else {
         interpretation = ' ❌ Failure';
         context = getFailureContext(desc);
-        if (autoXpOnMiss) {
-          setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
-        }
+        setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
         if (window.confirm('Did you get help?')) {
           originalResult = result + interpretation;
           let bond = parseInt(window.prompt('Bond bonus? (0-3)', '0'), 10);
@@ -206,6 +204,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
           } else {
             interpretation = ' ❌ Failure';
             context = getFailureContext(desc);
+            setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
           }
         }
       }

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -5,10 +5,12 @@ import useDiceRoller from './useDiceRoller.js';
 
 beforeEach(() => {
   vi.spyOn(window, 'confirm').mockReturnValue(false);
+  vi.spyOn(window, 'prompt').mockReturnValue('0');
 });
 
 afterEach(() => {
   window.confirm.mockRestore();
+  window.prompt.mockRestore();
 });
 
 describe('useDiceRoller contexts', () => {
@@ -28,7 +30,7 @@ describe('useDiceRoller contexts', () => {
     ['unknown', 'Perfect execution!'],
   ])('returns correct success context for %s', (desc, expected) => {
     localStorage.clear();
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999);
     act(() => {
       result.current.rollDice('2d6', desc);
@@ -39,7 +41,7 @@ describe('useDiceRoller contexts', () => {
 
   it('returns correct partial context for HaCk', () => {
     localStorage.clear();
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random');
     randomSpy.mockReturnValueOnce(0.35).mockReturnValueOnce(0.55);
     act(() => {
@@ -51,7 +53,7 @@ describe('useDiceRoller contexts', () => {
 
   it('returns correct partial context for upper hand', () => {
     localStorage.clear();
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random');
     randomSpy.mockReturnValueOnce(0.35).mockReturnValueOnce(0.55);
     act(() => {
@@ -63,7 +65,7 @@ describe('useDiceRoller contexts', () => {
 
   it('returns correct failure context for taunt', () => {
     localStorage.clear();
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     act(() => {
       result.current.rollDice('2d6', 'taunt');
@@ -74,7 +76,7 @@ describe('useDiceRoller contexts', () => {
 
   it('returns correct failure context for upper hand', () => {
     localStorage.clear();
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     act(() => {
       result.current.rollDice('2d6', 'upper hand');
@@ -85,7 +87,7 @@ describe('useDiceRoller contexts', () => {
 
   it('updates rollResult with latest roll', () => {
     localStorage.clear();
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     act(() => {
       result.current.rollDice('d4', 'test');
@@ -96,7 +98,7 @@ describe('useDiceRoller contexts', () => {
 
   it('retains the original description in rollModalData', () => {
     localStorage.clear();
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999);
     act(() => {
       result.current.rollDice('2d6', 'Upper Hand');
@@ -111,7 +113,7 @@ describe('help mechanics', () => {
     localStorage.clear();
     const setCharacter = vi.fn();
     const { result } = renderHook(() =>
-      useDiceRoller({ statusEffects: [], debilities: [], xp: 0 }, setCharacter, true),
+      useDiceRoller({ statusEffects: [], debilities: [], xp: 0 }, setCharacter),
     );
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     window.confirm.mockReturnValue(true);
@@ -134,7 +136,7 @@ describe('useDiceRoller localStorage', () => {
     localStorage.clear();
     localStorage.setItem('rollHistory', 'not json');
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     expect(result.current.rollHistory).toEqual([]);
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
@@ -151,7 +153,7 @@ describe('useDiceRoller mixed-case status modifiers', () => {
       debilities: [],
       xp: 0,
     };
-    const { result } = renderHook(() => useDiceRoller(character, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(character, setCharacter));
     const randomSpy = vi.spyOn(Math, 'random');
 
     randomSpy.mockReturnValueOnce(0.4).mockReturnValueOnce(0.4);
@@ -180,7 +182,7 @@ describe('useDiceRoller safe localStorage handling', () => {
 
   it('initializes with empty history when localStorage is undefined', () => {
     global.localStorage = undefined;
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     expect(result.current.rollHistory).toEqual([]);
   });
 
@@ -196,7 +198,7 @@ describe('useDiceRoller safe localStorage handling', () => {
         throw new Error('fail');
       },
     };
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     expect(result.current.rollHistory).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- remove Auto XP on Miss checkbox and related props
- always award XP on failed rolls, including failed help rerolls
- update app and tests for automatic XP gains

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ac5f9ff308332a38a4e9163792592