### PR TITLE
Trigger Last Breath on fatal damage

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 import {
-  FaClock,
   FaMeteor,
   FaRadiation,
   FaBoxOpen,
@@ -35,6 +34,7 @@ function App() {
   const [showLevelUpModal, setShowLevelUpModal] = useState(false);
   const [showStatusModal, setShowStatusModal] = useState(false);
   const [showDamageModal, setShowDamageModal] = useState(false);
+  const [showLastBreathModal, setShowLastBreathModal] = useState(false);
   const [showInventoryModal, setShowInventoryModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [compactMode, setCompactMode] = useState(false);
@@ -236,6 +236,8 @@ function App() {
         handleToggleDebility={toggleDebility}
         showDamageModal={showDamageModal}
         setShowDamageModal={setShowDamageModal}
+        showLastBreathModal={showLastBreathModal}
+        setShowLastBreathModal={setShowLastBreathModal}
         showInventoryModal={showInventoryModal}
         setShowInventoryModal={setShowInventoryModal}
         inventory={character.inventory}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -137,9 +137,11 @@ describe('XP gain on miss', () => {
     const Wrapper = ({ children }) => {
       const [character, setCharacter] = React.useState(initialCharacter);
       return (
-        <CharacterContext.Provider value={{ character, setCharacter }}>
-          {children}
-        </CharacterContext.Provider>
+        <ThemeProvider>
+          <CharacterContext.Provider value={{ character, setCharacter }}>
+            {children}
+          </CharacterContext.Provider>
+        </ThemeProvider>
       );
     };
 
@@ -158,7 +160,7 @@ describe('XP gain on miss', () => {
     });
 
     expect(screen.getByText(/XP: 2\/5/i)).toBeInTheDocument();
-    expect(screen.getByText(/Original:/i)).toBeInTheDocument();
+    expect(screen.getByText(/Original Roll:/i)).toBeInTheDocument();
     expect(screen.getByText(/With Help:/i)).toBeInTheDocument();
 
     randomSpy.mockRestore();

--- a/src/components/DamageModal.jsx
+++ b/src/components/DamageModal.jsx
@@ -5,7 +5,7 @@ import useInventory from '../hooks/useInventory';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './DamageModal.module.css';
 
-export default function DamageModal({ isOpen, onClose }) {
+export default function DamageModal({ isOpen, onClose, onLastBreath }) {
   const { character, setCharacter } = useCharacter();
   const [damage, setDamage] = useState('');
   const { totalArmor } = useInventory(character, setCharacter);
@@ -21,16 +21,20 @@ export default function DamageModal({ isOpen, onClose }) {
     const dmg = parseInt(damage, 10);
     if (isNaN(dmg)) return;
     const finalDamage = Math.max(0, dmg - totalArmor);
+    const newHp = Math.max(0, character.hp - finalDamage);
     setCharacter((prev) => ({
       ...prev,
       actionHistory: [
         { action: 'HP Change', state: prev, timestamp: Date.now() },
         ...prev.actionHistory.slice(0, 4),
       ],
-      hp: Math.max(0, prev.hp - finalDamage),
+      hp: newHp,
     }));
     setDamage('');
     onClose();
+    if (newHp <= 0) {
+      onLastBreath();
+    }
   };
 
   return (
@@ -64,4 +68,5 @@ export default function DamageModal({ isOpen, onClose }) {
 DamageModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  onLastBreath: PropTypes.func.isRequired,
 };

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -4,6 +4,7 @@ import BondsModal from './BondsModal.jsx';
 import DamageModal from './DamageModal.jsx';
 import ExportModal from './ExportModal.jsx';
 import InventoryModal from './InventoryModal.jsx';
+import LastBreathModal from './LastBreathModal.jsx';
 import LevelUpModal from './LevelUpModal.jsx';
 import StatusModal from './StatusModal.jsx';
 
@@ -24,6 +25,8 @@ const GameModals = ({
   handleToggleDebility,
   showDamageModal,
   setShowDamageModal,
+  showLastBreathModal,
+  setShowLastBreathModal,
   showInventoryModal,
   setShowInventoryModal,
   inventory,
@@ -59,7 +62,17 @@ const GameModals = ({
       />
     )}
 
-    <DamageModal isOpen={showDamageModal} onClose={() => setShowDamageModal(false)} />
+    <DamageModal
+      isOpen={showDamageModal}
+      onClose={() => setShowDamageModal(false)}
+      onLastBreath={() => setShowLastBreathModal(true)}
+    />
+
+    <LastBreathModal
+      isOpen={showLastBreathModal}
+      onClose={() => setShowLastBreathModal(false)}
+      rollDie={rollDie}
+    />
 
     {showInventoryModal && (
       <InventoryModal
@@ -94,6 +107,8 @@ GameModals.propTypes = {
   handleToggleDebility: PropTypes.func.isRequired,
   showDamageModal: PropTypes.bool.isRequired,
   setShowDamageModal: PropTypes.func.isRequired,
+  showLastBreathModal: PropTypes.bool.isRequired,
+  setShowLastBreathModal: PropTypes.func.isRequired,
   showInventoryModal: PropTypes.bool.isRequired,
   setShowInventoryModal: PropTypes.func.isRequired,
   inventory: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/src/components/LastBreathModal.jsx
+++ b/src/components/LastBreathModal.jsx
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import { FaSkull } from 'react-icons/fa6';
+import styles from './LastBreathModal.module.css';
+
+export default function LastBreathModal({ isOpen, onClose, rollDie }) {
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      const total = rollDie(6) + rollDie(6);
+      let outcome;
+      if (total >= 10) outcome = 'You evade Death... for now.';
+      else if (total >= 7) outcome = 'Death offers you a bargain.';
+      else outcome = 'Your journey ends here.';
+      setResult({ total, outcome });
+    } else {
+      setResult(null);
+    }
+  }, [isOpen, rollDie]);
+
+  if (!isOpen || !result) return null;
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h2 className={styles.title}>
+          <FaSkull style={{ marginRight: '4px' }} /> Last Breath
+        </h2>
+        <div className={styles.result}>Roll: {result.total}</div>
+        <div className={styles.outcome}>{result.outcome}</div>
+        <button onClick={onClose} className={styles.button}>
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+LastBreathModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  rollDie: PropTypes.func.isRequired,
+};

--- a/src/components/LastBreathModal.module.css
+++ b/src/components/LastBreathModal.module.css
@@ -1,0 +1,52 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal {
+  background: linear-gradient(135deg, #1a1a2e, #16213e);
+  border: 2px solid #ff0066;
+  border-radius: 15px;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: 0 0 30px rgba(255, 0, 102, 0.5);
+  text-align: center;
+  padding: 30px;
+  color: #fff;
+}
+
+.title {
+  font-size: 1.5rem;
+  color: #ff0066;
+  margin: 0 0 20px 0;
+}
+
+.result {
+  font-size: 1.3rem;
+  margin-bottom: 10px;
+}
+
+.outcome {
+  margin-bottom: 20px;
+}
+
+.button {
+  background: linear-gradient(45deg, #ff0066, #cc0052);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  padding: 8px 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.3s ease;
+}

--- a/src/components/LastBreathModal.test.jsx
+++ b/src/components/LastBreathModal.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import LastBreathModal from './LastBreathModal.jsx';
+
+describe('LastBreathModal', () => {
+  it('rolls 2d6 and shows outcome', () => {
+    const rollDie = vi.fn().mockReturnValueOnce(4).mockReturnValueOnce(5); // total 9
+    render(<LastBreathModal isOpen onClose={() => {}} rollDie={rollDie} />);
+    expect(screen.getByText('Roll: 9')).toBeInTheDocument();
+    expect(screen.getByText(/Death offers you a bargain/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import './LevelUpModal.module.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import Message from './Message.jsx';

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -206,6 +206,9 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
           } else {
             interpretation = ' ❌ Failure';
             context = getFailureContext(desc);
+            if (autoXpOnMiss) {
+              setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
+            }
           }
         }
       }

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -115,7 +115,7 @@ describe('help mechanics', () => {
     );
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     window.confirm.mockReturnValue(true);
-    window.prompt.mockReturnValue('0');
+    vi.spyOn(window, 'prompt').mockReturnValue('0');
     act(() => {
       result.current.rollDice('2d6', 'str');
     });


### PR DESCRIPTION
## Summary
- Detect zero HP in DamageModal and trigger a new Last Breath modal
- Last Breath modal rolls flat 2d6 and reports the outcome
- Wire Last Breath modal into GameModals and App, with tests
- Award XP for failed assistance rolls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ac608633c833289cc3723c3fc721f