### PR TITLE
feat: replace resolved bonds

### DIFF
--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -40,6 +40,16 @@
   margin-bottom: 5px;
 }
 
+.bondInput {
+  width: 100%;
+  margin-top: 5px;
+  padding: 5px;
+  border-radius: 4px;
+  border: 1px solid #00ff88;
+  background: #0f0f1a;
+  color: #fff;
+}
+
 .total {
   margin-top: 10px;
   color: #fff;

--- a/src/components/EndSessionModal.test.jsx
+++ b/src/components/EndSessionModal.test.jsx
@@ -64,13 +64,16 @@ describe('EndSessionModal', () => {
     expect(getCharacter().xp).toBe(0);
   });
 
-  it('awards XP for resolved bonds and removes them', async () => {
+  it('replaces resolved bonds with new entries and awards XP', async () => {
     const user = userEvent.setup();
     const initial = {
       xp: 0,
       level: 1,
       xpNeeded: 8,
-      bonds: [{ name: 'Alice', relationship: 'Friend', resolved: false }],
+      bonds: [
+        { name: 'Alice', relationship: 'Friend', resolved: false },
+        { name: 'Bob', relationship: 'Ally', resolved: false },
+      ],
     };
     const { getCharacter } = renderWithCharacter(
       <EndSessionModal isOpen onClose={() => {}} onLevelUp={() => {}} />,
@@ -78,9 +81,13 @@ describe('EndSessionModal', () => {
     );
 
     await user.click(screen.getByLabelText(/Alice: Friend/));
+    await user.type(screen.getByPlaceholderText('New bond text'), 'Best buds');
     await user.click(screen.getByText(/end session/i));
 
     expect(getCharacter().xp).toBe(1);
-    expect(getCharacter().bonds).toHaveLength(0);
+    expect(getCharacter().bonds).toEqual([
+      { name: 'Bob', relationship: 'Ally', resolved: false },
+      { name: 'Alice', relationship: 'Best buds', resolved: false },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- allow entering replacement text for resolved bonds in EndSessionModal
- append new bond entries when resolving bonds at session end
- test bond replacement flow

## Testing
- `npm test` *(fails: useRef is not defined; Cannot destructure property 'theme' of '(0 , useTheme)(...)' as it is undefined; window.prompt.mockReturnValue is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689ac60c56048332bd3616e41fe0c7e3