### PR TITLE
test: validate last breath and xp on miss

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 import {
-  FaClock,
   FaMeteor,
   FaRadiation,
   FaBoxOpen,
@@ -58,7 +57,7 @@ function App() {
     rollModalData,
     rollDie,
     clearRollHistory,
-  } = useDiceRoller(character, setCharacter, autoXpOnMiss);
+  } = useDiceRoller(character, setCharacter);
 
   const { totalArmor, equippedWeaponDamage, handleEquipItem, handleConsumeItem, handleDropItem } =
     useInventory(character, setCharacter);

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -12,7 +12,7 @@ const minimalCharacter = {
   },
 };
 
-const rollHistory = [{ timestamp: '10:00', result: '2d6: 7' }];
+const rollHistory = [{ timestamp: '10:00', result: '2d6: 7 = 7' }];
 
 describe('DiceRoller', () => {
   it('calls rollDice for stat checks and basic dice', async () => {
@@ -23,7 +23,7 @@ describe('DiceRoller', () => {
         character={minimalCharacter}
         rollDice={rollDice}
         equippedWeaponDamage="d8"
-        rollResult="Result: 9"
+        rollResult="d20: 9 = 9"
         rollHistory={rollHistory}
         rollModal={{ isOpen: false, close: vi.fn() }}
         rollModalData={{}}
@@ -44,15 +44,15 @@ describe('DiceRoller', () => {
         character={minimalCharacter}
         rollDice={rollDice}
         equippedWeaponDamage="d8"
-        rollResult="Result: 9"
+        rollResult="d20: 9 = 9"
         rollHistory={rollHistory}
         rollModal={{ isOpen: false, close: vi.fn() }}
         rollModalData={{}}
       />,
     );
-    expect(screen.getByText('Result: 9')).toBeInTheDocument();
+    expect(screen.getByText('d20: 9 = 9')).toBeInTheDocument();
     expect(screen.getByText('Recent Rolls:')).toBeInTheDocument();
-    expect(screen.getByText(/2d6: 7/)).toBeInTheDocument();
+    expect(screen.getByText(/2d6: 7 = 7/)).toBeInTheDocument();
   });
 
   it('updates displayed roll result when prop changes', () => {
@@ -62,24 +62,24 @@ describe('DiceRoller', () => {
         character={minimalCharacter}
         rollDice={rollDice}
         equippedWeaponDamage="d8"
-        rollResult="Result: 9"
+        rollResult="d20: 9 = 9"
         rollHistory={rollHistory}
         rollModal={{ isOpen: false, close: vi.fn() }}
         rollModalData={{}}
       />,
     );
-    expect(screen.getByText('Result: 9')).toBeInTheDocument();
+    expect(screen.getByText('d20: 9 = 9')).toBeInTheDocument();
     rerender(
       <DiceRoller
         character={minimalCharacter}
         rollDice={rollDice}
         equippedWeaponDamage="d8"
-        rollResult="Result: 10"
+        rollResult="d20: 10 = 10"
         rollHistory={rollHistory}
         rollModal={{ isOpen: false, close: vi.fn() }}
         rollModalData={{}}
       />,
     );
-    expect(screen.getByText('Result: 10')).toBeInTheDocument();
+    expect(screen.getByText('d20: 10 = 10')).toBeInTheDocument();
   });
 });

--- a/src/components/LastBreathModal.jsx
+++ b/src/components/LastBreathModal.jsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { FaSkull } from 'react-icons/fa6';
+import * as diceUtils from '../utils/dice.js';
+
+export default function LastBreathModal({ isOpen, onClose, rollDie }) {
+  const [roll, setRoll] = useState(null);
+  if (!isOpen) return null;
+
+  const handleRoll = () => {
+    const total = rollDie(6) + rollDie(6);
+    let message;
+    if (total >= 10) message = 'You survive by sheer will!';
+    else if (total >= 7) message = 'Death offers a bargain.';
+    else message = 'Your time has come.';
+    setRoll({ total, message });
+  };
+
+  return (
+    <div role="dialog">
+      <h2>
+        <FaSkull /> Last Breath
+      </h2>
+      {roll ? (
+        <>
+          <div>2d6: {roll.total}</div>
+          <div>{roll.message}</div>
+        </>
+      ) : (
+        <button onClick={handleRoll}>Roll</button>
+      )}
+      <button onClick={onClose}>Close</button>
+    </div>
+  );
+}
+
+LastBreathModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  rollDie: PropTypes.func,
+};
+
+LastBreathModal.defaultProps = {
+  rollDie: diceUtils.rollDie,
+};

--- a/src/components/LastBreathModal.test.jsx
+++ b/src/components/LastBreathModal.test.jsx
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import LastBreathModal from './LastBreathModal.jsx';
+
+describe('LastBreathModal', () => {
+  it('toggles visibility with isOpen prop', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(<LastBreathModal isOpen={false} onClose={onClose} />);
+    expect(screen.queryByText(/Last Breath/)).not.toBeInTheDocument();
+    rerender(<LastBreathModal isOpen onClose={onClose} />);
+    expect(screen.getByText(/Last Breath/)).toBeInTheDocument();
+  });
+
+  it('shows success outcome on 10+', async () => {
+    const user = userEvent.setup();
+    const rollDie = vi.fn().mockReturnValueOnce(6).mockReturnValueOnce(5);
+    render(<LastBreathModal isOpen onClose={() => {}} rollDie={rollDie} />);
+    await user.click(screen.getByText('Roll'));
+    expect(screen.getByText('You survive by sheer will!')).toBeInTheDocument();
+  });
+
+  it('shows bargain outcome on 7-9', async () => {
+    const user = userEvent.setup();
+    const rollDie = vi.fn().mockReturnValueOnce(3).mockReturnValueOnce(4);
+    render(<LastBreathModal isOpen onClose={() => {}} rollDie={rollDie} />);
+    await user.click(screen.getByText('Roll'));
+    expect(screen.getByText('Death offers a bargain.')).toBeInTheDocument();
+  });
+
+  it('shows death outcome on 6-', async () => {
+    const user = userEvent.setup();
+    const rollDie = vi.fn().mockReturnValueOnce(1).mockReturnValueOnce(2);
+    render(<LastBreathModal isOpen onClose={() => {}} rollDie={rollDie} />);
+    await user.click(screen.getByText('Roll'));
+    expect(screen.getByText('Your time has come.')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useDiceRoller.help.test.js
+++ b/src/hooks/useDiceRoller.help.test.js
@@ -18,7 +18,7 @@ describe('useDiceRoller help reroll', () => {
       .mockReturnValueOnce(3)
       .mockReturnValueOnce(4);
 
-    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter, false));
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
     act(() => {
       result.current.rollDice('2d6', 'test');
     });

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -4,7 +4,7 @@ import * as diceUtils from '../utils/dice.js';
 import safeLocalStorage from '../utils/safeLocalStorage.js';
 import useModal from './useModal';
 
-export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
+export default function useDiceRoller(character, setCharacter) {
   const [rollResult, setRollResult] = useState('Ready to roll!');
   const [rollModalData, setRollModalData] = useState({});
   const [rollHistory, setRollHistory] = useState(() => {
@@ -173,9 +173,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
       } else {
         interpretation = ' ❌ Failure';
         context = getFailureContext(desc);
-        if (autoXpOnMiss) {
-          setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
-        }
+        setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
         if (window.confirm('Did you get help?')) {
           originalResult = result + interpretation;
           let bond = parseInt(window.prompt('Bond bonus? (0-3)', '0'), 10);
@@ -206,6 +204,7 @@ export default function useDiceRoller(character, setCharacter, autoXpOnMiss) {
           } else {
             interpretation = ' ❌ Failure';
             context = getFailureContext(desc);
+            setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
           }
         }
       }


### PR DESCRIPTION
## Summary
- always award XP on failed rolls
- add LastBreathModal and comprehensive tests
- update component tests for new dice roll output format

## Testing
- `npx vitest run src/hooks/useDiceRoller.test.jsx src/components/LastBreathModal.test.jsx src/components/DiceRoller.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_689ac6162ec0833288157f6218efb913