### PR TITLE
refactor: centralize component colors

### DIFF
--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -12,8 +12,8 @@
 }
 
 .modal {
-  background: #1a1a2e;
-  border: 2px solid #00ff88;
+  background: var(--color-modal-bg);
+  border: 2px solid var(--color-neon);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -23,11 +23,11 @@
 }
 
 .title {
-  color: #00ff88;
+  color: var(--color-neon);
 }
 
 .empty {
-  color: #aaa;
+  color: var(--color-gray-350);
   margin: 20px 0;
 }
 
@@ -43,11 +43,11 @@
 }
 
 .bondText {
-  color: #fff;
+  color: var(--color-white);
 }
 
 .bondResolved {
-  color: #fff;
+  color: var(--color-white);
   text-decoration: line-through;
 }
 
@@ -56,10 +56,10 @@
 }
 
 .button {
-  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;
@@ -68,22 +68,22 @@
 }
 
 .resolveButton {
-  background: linear-gradient(45deg, #10b981, #059669);
+  background: linear-gradient(45deg, var(--color-emerald), var(--color-emerald-dark));
 }
 
 .unresolveButton {
-  background: linear-gradient(45deg, #6366f1, #4f46e5);
+  background: linear-gradient(45deg, var(--color-indigo), var(--color-indigo-dark));
 }
 
 .removeButton {
-  background: linear-gradient(45deg, #ef4444, #dc2626);
+  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }
 
 .input {
-  background: #0f0f1f;
-  border: 1px solid #00ff88;
+  background: var(--color-modal-bg-dark);
+  border: 1px solid var(--color-neon);
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px;
   width: 100%;
   margin-bottom: 10px;

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -30,7 +30,7 @@
 
 .statName {
   font-size: 0.8rem;
-  color: #aaa;
+  color: var(--color-gray-350);
 }
 
 .statValue {
@@ -42,10 +42,10 @@
 .hpBarContainer {
   width: 100%;
   height: 25px;
-  background: #333;
+  background: var(--color-gray-800);
   border-radius: 12px;
   overflow: hidden;
-  border: 2px solid #555;
+  border: 2px solid var(--color-gray-750);
   margin: 10px 0;
 }
 
@@ -69,7 +69,7 @@
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;
@@ -84,7 +84,7 @@
 .xpBarContainer {
   width: 100%;
   height: 20px;
-  background: #333;
+  background: var(--color-gray-800);
   border-radius: 10px;
   overflow: hidden;
   margin: 15px 0 10px 0;
@@ -127,7 +127,7 @@
   background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
   margin: 0;
@@ -139,7 +139,7 @@
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
   margin: 0;
@@ -162,7 +162,7 @@
   background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;
@@ -195,7 +195,7 @@
   background: linear-gradient(45deg, var(--color-blue-light), var(--color-accent));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 10px 20px;
   cursor: pointer;
   font-weight: bold;

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -12,8 +12,8 @@
 }
 
 .modal {
-  background: #1a1a2e;
-  border: 2px solid #00ff88;
+  background: var(--color-modal-bg);
+  border: 2px solid var(--color-neon);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -21,26 +21,26 @@
 }
 
 .title {
-  color: #00ff88;
+  color: var(--color-neon);
 }
 
 .info {
   margin: 15px 0;
-  color: #fff;
+  color: var(--color-white);
 }
 
 .input {
-  background: #0f0f1f;
-  border: 1px solid #00ff88;
+  background: var(--color-modal-bg-dark);
+  border: 1px solid var(--color-neon);
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px;
   width: 100%;
   margin-bottom: 10px;
 }
 
 .summary {
-  color: #aaa;
+  color: var(--color-gray-350);
   margin-bottom: 20px;
 }
 
@@ -50,10 +50,10 @@
 }
 
 .button {
-  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;
@@ -62,5 +62,5 @@
 }
 
 .applyButton {
-  background: linear-gradient(45deg, #ef4444, #dc2626);
+  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -45,7 +45,7 @@
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;
@@ -108,7 +108,7 @@
 }
 
 .historyItem {
-  color: #aaa;
+  color: var(--color-gray-350);
   margin-bottom: 2px;
 }
 

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -12,8 +12,8 @@
 }
 
 .modal {
-  background: #1a1a2e;
-  border: 2px solid #00ff88;
+  background: var(--color-modal-bg);
+  border: 2px solid var(--color-neon);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -23,7 +23,7 @@
 }
 
 .title {
-  color: #00ff88;
+  color: var(--color-neon);
 }
 
 .section {
@@ -45,14 +45,14 @@
   margin-top: 5px;
   padding: 5px;
   border-radius: 4px;
-  border: 1px solid #00ff88;
-  background: #0f0f1a;
-  color: #fff;
+  border: 1px solid var(--color-neon);
+  background: var(--color-modal-bg-dark);
+  color: var(--color-white);
 }
 
 .total {
   margin-top: 10px;
-  color: #fff;
+  color: var(--color-white);
 }
 
 .actions {
@@ -60,10 +60,10 @@
 }
 
 .button {
-  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;
@@ -72,5 +72,5 @@
 }
 
 .cancelButton {
-  background: linear-gradient(45deg, #ef4444, #dc2626);
+  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -12,8 +12,8 @@
 }
 
 .modal {
-  background: #1a1a2e;
-  border: 2px solid #00ff88;
+  background: var(--color-modal-bg);
+  border: 2px solid var(--color-neon);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -21,22 +21,22 @@
 }
 
 .title {
-  color: #00ff88;
+  color: var(--color-neon);
   margin-bottom: 10px;
 }
 
 .input {
-  background: #0f0f1f;
-  border: 1px solid #00ff88;
+  background: var(--color-modal-bg-dark);
+  border: 1px solid var(--color-neon);
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px;
   width: 100%;
   margin-bottom: 10px;
 }
 
 .message {
-  color: #00ff88;
+  color: var(--color-neon);
   margin-bottom: 10px;
 }
 
@@ -47,10 +47,10 @@
 }
 
 .button {
-  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;

--- a/src/components/InventoryModal.module.css
+++ b/src/components/InventoryModal.module.css
@@ -28,7 +28,7 @@
 }
 
 .inventoryEmpty {
-  color: #aaa;
+  color: var(--color-gray-350);
 }
 
 .inventoryList {
@@ -38,12 +38,12 @@
 
 .inventoryItem {
   margin-bottom: 10px;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--color-gray-800);
   padding-bottom: 10px;
 }
 
 .inventoryItemName {
-  color: #fff;
+  color: var(--color-white);
   font-weight: bold;
   position: relative;
 }
@@ -51,8 +51,8 @@
 .inventoryItemDescription {
   display: none;
   position: absolute;
-  background: #333;
-  color: #fff;
+  background: var(--color-gray-800);
+  color: var(--color-white);
   padding: 4px 8px;
   border-radius: 4px;
   top: 100%;
@@ -75,7 +75,7 @@
   background: linear-gradient(45deg, var(--color-purple), var(--color-purple-dark));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
   margin: 3px;

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -8,7 +8,7 @@
 }
 
 .title {
-  color: #00ff88;
+  color: var(--color-neon);
   margin-bottom: 15px;
   font-size: 1.3rem;
 }
@@ -23,11 +23,11 @@
   padding: 8px 12px;
   margin: 5px 0;
   border-radius: 6px;
-  border-left: 3px solid #00ff88;
+  border-left: 3px solid var(--color-neon);
 }
 
 .equipped {
-  border-left-color: #10b981;
+  border-left-color: var(--color-emerald);
 }
 
 .itemRow {
@@ -57,7 +57,7 @@
   display: none;
   position: absolute;
   background: rgba(0, 0, 0, 0.8);
-  color: #fff;
+  color: var(--color-white);
   padding: 4px 8px;
   border-radius: 4px;
   top: 100%;
@@ -73,19 +73,19 @@
 }
 
 .equippedMark {
-  color: #10b981;
+  color: var(--color-emerald);
   font-size: 0.7rem;
 }
 
 .itemDetails {
   font-size: 0.7rem;
-  color: #aaa;
+  color: var(--color-gray-350);
 }
 
 .useButton {
-  background: linear-gradient(45deg, #10b981, #059669);
+  background: linear-gradient(45deg, var(--color-emerald), var(--color-emerald-dark));
   border: none;
-  color: white;
+  color: var(--color-white);
   padding: 4px 8px;
   border-radius: 4px;
   cursor: pointer;
@@ -100,7 +100,7 @@
 
 .debilitiesTitle {
   font-size: 0.8rem;
-  color: #ef4444;
+  color: var(--color-danger);
   margin-bottom: 5px;
 }
 
@@ -112,8 +112,8 @@
 
 .debilityTag {
   background: rgba(239, 68, 68, 0.2);
-  border: 1px solid #ef4444;
-  color: #fca5a5;
+  border: 1px solid var(--color-danger);
+  color: var(--color-red-light);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 0.7rem;

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -16,8 +16,8 @@
   }
 
   .levelup-modal {
-    background: linear-gradient(135deg, #1a1a2e, #16213e);
-    border: 2px solid #00ff88;
+    background: linear-gradient(135deg, var(--color-modal-bg), var(--color-modal-bg-secondary));
+    border: 2px solid var(--color-neon);
     border-radius: 15px;
     max-width: 700px;
     width: 100%;
@@ -27,7 +27,7 @@
   }
 
   .levelup-header {
-    background: linear-gradient(45deg, #00ff88, #00cc6a);
+    background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
     padding: 20px;
     border-radius: 13px 13px 0 0;
     text-align: center;
@@ -37,12 +37,12 @@
   .levelup-header-title {
     margin: 0;
     font-size: 1.5rem;
-    color: white;
+    color: var(--color-white);
   }
 
   .levelup-header-text {
     margin: 5px 0 0;
-    color: #e0f2fe;
+    color: var(--color-blue-light);
   }
 
   .levelup-close-button {
@@ -51,7 +51,7 @@
     right: 15px;
     background: rgba(255, 255, 255, 0.2);
     border: none;
-    color: white;
+    color: var(--color-white);
     width: 30px;
     height: 30px;
     border-radius: 50%;
@@ -75,11 +75,11 @@
 
   .levelup-progress-step {
     text-align: center;
-    color: #666;
+    color: var(--color-gray-700);
   }
 
   .levelup-progress-step.complete {
-    color: #00ff88;
+    color: var(--color-neon);
   }
 
   .levelup-progress-icon {
@@ -95,13 +95,13 @@
   }
 
   .levelup-step-title {
-    color: #00ff88;
+    color: var(--color-neon);
     margin-bottom: 10px;
     font-size: 1.2rem;
   }
 
   .levelup-step-desc {
-    color: #e0e0e0;
+    color: var(--color-gray-100);
     font-size: 14px;
     margin-bottom: 15px;
   }
@@ -115,10 +115,10 @@
 
   .levelup-stat-button {
     padding: 10px;
-    border: 2px solid #555;
+    border: 2px solid var(--color-gray-750);
     border-radius: 8px;
-    background: #1a1a2e;
-    color: #e0e0e0;
+    background: var(--color-modal-bg);
+    color: var(--color-gray-100);
     cursor: pointer;
     text-align: center;
     transition: all 0.3s ease;
@@ -126,22 +126,22 @@
   }
 
   .levelup-stat-button.selected {
-    border-color: #00ff88;
+    border-color: var(--color-neon);
     background: rgba(0, 255, 136, 0.2);
-    color: #00ff88;
+    color: var(--color-neon);
   }
 
   .levelup-stat-button.maxed {
-    border-color: #666;
-    background: #333;
-    color: #666;
+    border-color: var(--color-gray-700);
+    background: var(--color-gray-800);
+    color: var(--color-gray-700);
     cursor: not-allowed;
   }
 
   .levelup-stat-button.disabled {
-    border-color: #333;
-    background: #222;
-    color: #555;
+    border-color: var(--color-gray-800);
+    background: var(--color-gray-900);
+    color: var(--color-gray-750);
     cursor: not-allowed;
   }
 
@@ -164,7 +164,7 @@
     border: 1px solid rgba(0, 255, 136, 0.3);
     border-radius: 6px;
     font-size: 14px;
-    color: #00ff88;
+    color: var(--color-neon);
   }
 
   .levelup-selected-move {
@@ -174,7 +174,7 @@
   .levelup-move-list {
     max-height: 250px;
     overflow-y: auto;
-    border: 1px solid #555;
+    border: 1px solid var(--color-gray-750);
     border-radius: 8px;
     padding: 8px;
   }
@@ -185,10 +185,10 @@
 
   .levelup-move-button {
     padding: 12px;
-    border: 2px solid #555;
+    border: 2px solid var(--color-gray-750);
     border-radius: 8px;
-    background: #1a1a2e;
-    color: #e0e0e0;
+    background: var(--color-modal-bg);
+    color: var(--color-gray-100);
     cursor: pointer;
     text-align: left;
     transition: all 0.3s ease;
@@ -196,7 +196,7 @@
   }
 
   .levelup-move-button.selected {
-    border-color: #00ff88;
+    border-color: var(--color-neon);
     background: rgba(0, 255, 136, 0.2);
   }
 
@@ -212,7 +212,7 @@
 
   .levelup-move-name {
     margin: 0;
-    color: #00ff88;
+    color: var(--color-neon);
     font-size: 14px;
     font-weight: bold;
   }
@@ -220,14 +220,14 @@
   .levelup-move-desc {
     margin: 4px 0 0;
     font-size: 12px;
-    color: #ccc;
+    color: var(--color-gray-200);
     line-height: 1.3;
   }
 
   .levelup-details-button {
     background: none;
     border: none;
-    color: #00ff88;
+    color: var(--color-neon);
     cursor: pointer;
     font-size: 12px;
     margin-left: 8px;
@@ -243,13 +243,13 @@
   }
 
   .levelup-move-expanded {
-    color: #e0e0e0;
+    color: var(--color-gray-100);
     margin-bottom: 8px;
     line-height: 1.4;
   }
 
   .levelup-move-examples {
-    color: #aaa;
+    color: var(--color-gray-350);
   }
 
   .levelup-hp-container {
@@ -259,13 +259,13 @@
     padding: 15px;
     background: rgba(255, 255, 255, 0.05);
     border-radius: 8px;
-    border: 1px solid #555;
+    border: 1px solid var(--color-gray-750);
   }
 
   .levelup-button {
-    background: linear-gradient(45deg, #00ff88, #00cc6a);
+    background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
     border: none;
-    color: white;
+    color: var(--color-white);
     padding: 10px 20px;
     border-radius: 6px;
     cursor: pointer;
@@ -275,32 +275,32 @@
   }
 
   .levelup-button-rolled {
-    background: linear-gradient(45deg, #00cc6a, #00aa55);
+    background: linear-gradient(45deg, var(--color-neon-dark), var(--color-neon-darker));
   }
 
   .levelup-button-cancel {
-    background: linear-gradient(45deg, #666, #555);
+    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-750));
   }
 
   .levelup-button-complete {
-    background: linear-gradient(45deg, #00ff88, #00cc6a);
+    background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
     font-size: 16px;
     padding: 12px 24px;
   }
 
   .levelup-button-disabled {
-    background: linear-gradient(45deg, #666, #555);
+    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-750));
     opacity: 0.5;
     cursor: not-allowed;
   }
 
   .levelup-hp-text {
-    color: #e0e0e0;
+    color: var(--color-gray-100);
     font-size: 14px;
   }
 
   .levelup-hp-result {
-    color: #00ff88;
+    color: var(--color-neon);
     font-weight: bold;
     margin-top: 4px;
   }
@@ -322,13 +322,13 @@
   }
 
   .levelup-summary-title {
-    color: #00ff88;
+    color: var(--color-neon);
     margin: 0 0 10px;
     font-size: 1.1rem;
   }
 
   .levelup-summary-details {
-    color: #e0e0e0;
+    color: var(--color-gray-100);
     font-size: 14px;
     line-height: 1.4;
   }

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -14,8 +14,8 @@
 }
 
 .modal {
-  background: linear-gradient(135deg, #1a1a2e, #16213e);
-  border: 2px solid #00ff88;
+  background: linear-gradient(135deg, var(--color-modal-bg), var(--color-modal-bg-secondary));
+  border: 2px solid var(--color-neon);
   border-radius: 15px;
   max-width: 500px;
   width: 100%;
@@ -25,7 +25,7 @@
 .header {
   text-align: center;
   padding: 20px;
-  background: linear-gradient(45deg, #0f3460, #533483);
+  background: linear-gradient(45deg, var(--color-blue-deep), var(--color-purple-deep));
   border-radius: 13px 13px 0 0;
 }
 
@@ -37,14 +37,14 @@
 
 .title {
   font-size: 1.5rem;
-  color: #00ff88;
+  color: var(--color-neon);
   margin: 0;
 }
 
 .closeButton {
   background: rgba(239, 68, 68, 0.8);
-  border: 2px solid #ef4444;
-  color: white;
+  border: 2px solid var(--color-danger);
+  color: var(--color-white);
   font-size: 1.2rem;
   cursor: pointer;
   padding: 5px 10px;
@@ -58,39 +58,39 @@
 
 .originalResult {
   font-size: 0.9rem;
-  color: #bbb;
+  color: var(--color-gray-300);
   margin-bottom: 10px;
 }
 
 .result {
   font-size: 1.5rem;
   font-weight: bold;
-  color: #00ff88;
+  color: var(--color-neon);
   margin-bottom: 15px;
 }
 
 .description {
-  color: #e0e0e0;
+  color: var(--color-gray-100);
   margin-bottom: 15px;
 }
 
 .context {
-  color: #aaa;
+  color: var(--color-gray-350);
   font-size: 0.9rem;
   margin-bottom: 20px;
 }
 
 .original {
   font-size: 1rem;
-  color: #aaa;
+  color: var(--color-gray-350);
   margin-bottom: 10px;
 }
 
 .button {
-  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -8,7 +8,7 @@
 }
 
 .title {
-  color: #00ff88;
+  color: var(--color-neon);
   margin-bottom: 15px;
   font-size: 1.3rem;
 }
@@ -19,7 +19,7 @@
   background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(0, 255, 136, 0.3);
   border-radius: 6px;
-  color: #e0e0e0;
+  color: var(--color-gray-100);
   padding: 10px;
   resize: vertical;
   font-family: inherit;
@@ -33,10 +33,10 @@
 }
 
 .button {
-  background: linear-gradient(45deg, #00ff88, #00cc6a);
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
   border-radius: 6px;
-  color: white;
+  color: var(--color-white);
   padding: 8px 15px;
   cursor: pointer;
   font-weight: bold;
@@ -47,11 +47,11 @@
 }
 
 .danger {
-  background: linear-gradient(45deg, #ef4444, #dc2626);
+  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }
 
 .compact {
-  background: linear-gradient(45deg, #6366f1, #4f46e5);
+  background: linear-gradient(45deg, var(--color-indigo), var(--color-indigo-dark));
 }
 
 .icon {

--- a/src/components/StatusModal.module.css
+++ b/src/components/StatusModal.module.css
@@ -41,14 +41,14 @@
 }
 
 .statusLabel {
-  color: #fff;
+  color: var(--color-white);
 }
 
 .statusButton {
   background: linear-gradient(45deg, var(--color-warning), var(--color-warning-dark));
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
   margin-top: 10px;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -30,6 +30,41 @@
   --color-green-dark: #3a8f66;
   --color-green-rgb: 74, 179, 129;
 
+  --color-white: #ffffff;
+
+  --color-neon: #00ff88;
+  --color-neon-dark: #00cc6a;
+  --color-neon-darker: #00aa55;
+
+  --color-indigo: #6366f1;
+  --color-indigo-dark: #4f46e5;
+
+  --color-danger: #ef4444;
+  --color-danger-dark: #dc2626;
+
+  --color-emerald: #10b981;
+  --color-emerald-dark: #059669;
+
+  --color-red-light: #fca5a5;
+
+  --color-blue-deep: #0f3460;
+  --color-purple-deep: #533483;
+
+  --color-modal-bg: #1a1a2e;
+  --color-modal-bg-secondary: #16213e;
+  --color-modal-bg-dark: #0f0f1f;
+
+  --color-gray-100: #e0e0e0;
+  --color-gray-200: #cccccc;
+  --color-gray-300: #bbbbbb;
+  --color-gray-350: #aaaaaa;
+  --color-gray-700: #666666;
+  --color-gray-750: #555555;
+  --color-gray-800: #333333;
+  --color-gray-900: #222222;
+
+  --color-blue-light: #e0f2fe;
+
   --overlay-poison: rgba(var(--color-accent-rgb), 0.1);
   --overlay-burning: rgba(var(--color-red-rgb), 0.15);
   --overlay-shocked-blue: rgba(79, 109, 184, 0.1);


### PR DESCRIPTION
## Summary
- add theme variables for shared colors
- replace hex colors in component styles with variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b31110110833287a059dc7f18b8df