### PR TITLE
refactor: centralize color usage

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { resourceColors } from '../styles/colorMap.js';
 import styles from './CharacterStats.module.css';
 
 const CharacterStats = ({
@@ -157,15 +158,15 @@ const CharacterStats = ({
         </button>
       </div>
       {[
-        { key: 'paradoxPoints', label: 'Paradox Points', max: 3, color: '#fbbf24' },
-        { key: 'bandages', label: 'Bandages', max: 3, color: '#8b5cf6' },
-        { key: 'rations', label: 'Rations', max: 5, color: '#f97316' },
-        { key: 'advGear', label: 'Adventuring Gear', max: 5, color: '#06b6d4' },
-      ].map(({ key, label, max, color }) => (
+        { key: 'paradoxPoints', label: 'Paradox Points', max: 3 },
+        { key: 'bandages', label: 'Bandages', max: 3 },
+        { key: 'rations', label: 'Rations', max: 5 },
+        { key: 'advGear', label: 'Adventuring Gear', max: 5 },
+      ].map(({ key, label, max }) => (
         <div key={key} className={styles.resourceRow}>
           <div className={styles.resourceHeader}>
             <span className={styles.resourceLabel}>{label}:</span>
-            <span className={styles.resourceValue} style={{ color }}>
+            <span className={styles.resourceValue} style={{ color: resourceColors[key] }}>
               {character.resources[key]}/{max}
             </span>
           </div>

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -1,3 +1,5 @@
+import { baseColors } from '../styles/colorMap.js';
+
 export const panelStyle = {
   background: 'var(--panel-bg)',
   backdropFilter: 'blur(10px)',
@@ -11,7 +13,7 @@ export const buttonStyle = {
   background: 'linear-gradient(45deg, var(--color-accent), var(--color-accent-dark))',
   border: 'none',
   borderRadius: '6px',
-  color: 'white',
+  color: baseColors.white,
   padding: '8px 15px',
   cursor: 'pointer',
   fontWeight: 'bold',

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -1,3 +1,5 @@
+import { headerGradients } from '../styles/colorMap.js';
+
 export default function useStatusEffects(character, setCharacter) {
   const statusEffects = character.statusEffects;
   const debilities = character.debilities;
@@ -38,17 +40,12 @@ export default function useStatusEffects(character, setCharacter) {
   };
 
   const getHeaderColor = () => {
-    if (statusEffects.includes('poisoned'))
-      return 'linear-gradient(45deg, #22c55e, #059669, #00d4aa)';
-    if (statusEffects.includes('burning'))
-      return 'linear-gradient(45deg, #ef4444, #f97316, #fbbf24)';
-    if (statusEffects.includes('shocked'))
-      return 'linear-gradient(45deg, #3b82f6, #eab308, #00d4aa)';
-    if (statusEffects.includes('frozen'))
-      return 'linear-gradient(45deg, #06b6d4, #3b82f6, #6366f1)';
-    if (statusEffects.includes('blessed'))
-      return 'linear-gradient(45deg, #fbbf24, #f59e0b, #00d4aa)';
-    return 'linear-gradient(45deg, #6366f1, #8b5cf6, #00d4aa)';
+    if (statusEffects.includes('poisoned')) return headerGradients.poisoned;
+    if (statusEffects.includes('burning')) return headerGradients.burning;
+    if (statusEffects.includes('shocked')) return headerGradients.shocked;
+    if (statusEffects.includes('frozen')) return headerGradients.frozen;
+    if (statusEffects.includes('blessed')) return headerGradients.blessed;
+    return headerGradients.default;
   };
 
   return {

--- a/src/styles/colorMap.js
+++ b/src/styles/colorMap.js
@@ -1,0 +1,19 @@
+export const baseColors = {
+  white: 'var(--color-white)',
+};
+
+export const resourceColors = {
+  paradoxPoints: 'var(--color-yellow)',
+  bandages: 'var(--color-purple-light)',
+  rations: 'var(--color-orange-light)',
+  advGear: 'var(--color-cyan)',
+};
+
+export const headerGradients = {
+  default: 'var(--gradient-header-default)',
+  poisoned: 'var(--gradient-header-poisoned)',
+  burning: 'var(--gradient-header-burning)',
+  shocked: 'var(--gradient-header-shocked)',
+  frozen: 'var(--gradient-header-frozen)',
+  blessed: 'var(--gradient-header-blessed)',
+};

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -80,4 +80,34 @@
   --critical-hit-end: var(--color-orange);
   --critical-failure-start: var(--color-red);
   --critical-failure-end: var(--color-red-dark);
+
+  /* Shared color map extensions */
+  --color-white: #ffffff;
+  --color-yellow: #fbbf24;
+  --color-purple-light: #8b5cf6;
+  --color-orange-light: #f97316;
+  --color-cyan: #06b6d4;
+
+  /* Header gradients for status effects */
+  --gradient-header-default: linear-gradient(
+    45deg,
+    #6366f1,
+    var(--color-purple-light),
+    var(--color-cyan)
+  );
+  --gradient-header-poisoned: linear-gradient(45deg, #22c55e, #059669, var(--color-cyan));
+  --gradient-header-burning: linear-gradient(
+    45deg,
+    #ef4444,
+    var(--color-orange-light),
+    var(--color-yellow)
+  );
+  --gradient-header-shocked: linear-gradient(45deg, #3b82f6, #eab308, var(--color-cyan));
+  --gradient-header-frozen: linear-gradient(45deg, var(--color-cyan), #3b82f6, #6366f1);
+  --gradient-header-blessed: linear-gradient(
+    45deg,
+    var(--color-yellow),
+    #f59e0b,
+    var(--color-cyan)
+  );
 }


### PR DESCRIPTION
## Summary
- centralize resource colors and status gradients using shared theme variables
- expose color mappings via colorMap module and theme.css
- replace inline color literals across components and hooks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b3111e33c83329ea7c2f015e2609f