### PR TITLE
chore: add pre-commit hooks and CI validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,5 @@ jobs:
           elif [ -f yarn.lock ]; then yarn install --silent;
           elif [ -f package-lock.json ]; then npm ci;
           else npm i --no-audit --no-fund; fi
-      - run: npm run lint
-      - run: npx prettier --check .
-      - run: npm test
+      - uses: pre-commit/action@v3.0.1
       - run: npm run build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: npx prettier --write
+        language: system
+        types_or: [javascript, jsx, ts, tsx, json, css, scss, markdown, html, yaml]
+      - id: eslint
+        name: eslint
+        entry: npx eslint
+        language: system
+        types_or: [javascript, jsx, ts, tsx]
+        args: ['--fix']
+      - id: vitest
+        name: vitest
+        entry: npm test
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ A cross-platform desktop application for managing tabletop RPG characters. Built
 npm install
 ```
 
+### Install git hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run linters, formatters,
+and tests on each commit. After installing dependencies, set up the hooks with:
+
+```bash
+pre-commit install
+```
+
+Run all checks manually at any time with:
+
+```bash
+pre-commit run --all-files
+```
+
 ### Run in development
 
 ```bash


### PR DESCRIPTION
## Summary
- run prettier, eslint, and vitest via pre-commit
- validate commits in GitHub Actions using pre-commit/action
- document how to install and run pre-commit hooks

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml .github/workflows/test.yml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b35b863d083329f384607c2978c80