### PR TITLE
chore: add sync script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ npm run build
 npm test
 ```
 
+### Sync with GitHub
+
+```bash
+npm run sync
+```
+
+This wraps the `git-sync-ask.sh` script to fetch, commit, and push changes with confirmation.
+
 ### Package for production
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "sync": "bash git-sync-ask.sh",
     "prepare": "husky"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `sync` npm script to run git-sync helper
- document `npm run sync` in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b3eec62a48332b47a8bde68140e5b