### PR TITLE
feat: add Aid/Interfere combat roll

### DIFF
--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -61,6 +61,12 @@ const DiceRoller = ({
           >
             Taunt Enemy
           </button>
+          <button
+            onClick={() => rollDice('2d6', 'Aid/Interfere')}
+            className={`${styles.button} ${styles.purple} ${styles.small}`}
+          >
+            Aid/Interfere
+          </button>
         </div>
       </div>
 

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -37,6 +37,25 @@ describe('DiceRoller', () => {
     expect(rollDice).toHaveBeenCalledWith('d6');
   });
 
+  it('calls rollDice for combat rolls', async () => {
+    const user = userEvent.setup();
+    const rollDice = vi.fn();
+    render(
+      <DiceRoller
+        character={minimalCharacter}
+        rollDice={rollDice}
+        equippedWeaponDamage="d8"
+        rollResult="d20: 9 = 9"
+        rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
+      />,
+    );
+
+    await user.click(screen.getByText('Aid/Interfere'));
+    expect(rollDice).toHaveBeenCalledWith('2d6', 'Aid/Interfere');
+  });
+
   it('shows roll result and history', () => {
     const rollDice = vi.fn();
     render(


### PR DESCRIPTION
## Summary
- add Aid/Interfere button to combat roll options
- test Aid/Interfere button triggers expected dice roll

## Testing
- `npm run lint` *(fails: autoXpOnMiss is not defined)*
- `npm test src/components/DiceRoller.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689b750b83cc83329810d4aa55812fd2