### PR TITLE
test: remove help mechanics tests

### DIFF
--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -126,29 +126,6 @@ describe('XP gain on failure', () => {
   });
 });
 
-describe('help mechanics', () => {
-  it('stores original roll and adds extra XP on failed help', () => {
-    localStorage.clear();
-    const setCharacter = vi.fn();
-    const { result } = renderHook(() =>
-      useDiceRoller({ statusEffects: [], debilities: [], xp: 0 }, setCharacter),
-    );
-    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
-    window.confirm.mockReturnValue(true);
-    vi.spyOn(window, 'prompt').mockReturnValue('0');
-    act(() => {
-      result.current.rollDice('2d6', 'str');
-    });
-    randomSpy.mockRestore();
-    confirmSpy.mockRestore();
-    promptSpy.mockRestore();
-    expect(result.current.rollModalData.originalResult).toMatch(/❌ Failure/);
-    expect(result.current.rollModalData.result).toMatch(/❌ Failure/);
-    expect(setCharacter).toHaveBeenCalledTimes(2);
-    window.prompt.mockRestore();
-  });
-});
-
 describe('useDiceRoller localStorage', () => {
   const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
   const setCharacter = () => {};


### PR DESCRIPTION
## Summary
- remove deprecated help mechanics suite from useDiceRoller tests

## Testing
- `npm run lint` *(fails: 'autoXpOnMiss' is not defined)*
- `npm test src/hooks/useDiceRoller.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689b750ca9748332aa90e4516efb74c2