### PR TITLE
fix: recalc xp thresholds after experience updates

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -89,7 +89,7 @@ describe('XP gain on miss', () => {
       fireEvent.click(button);
     });
 
-    expect(screen.getByText(/XP: 1\/5/i)).toBeInTheDocument();
+    expect(screen.getByText(/XP: 1\/11/i)).toBeInTheDocument();
 
     Math.random.mockRestore();
   });

--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -72,13 +72,25 @@ const CharacterStats = ({
       </div>
       <div className={styles.controls}>
         <button
-          onClick={() => setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }))}
+          onClick={() =>
+            setCharacter((prev) => ({
+              ...prev,
+              xp: prev.xp + 1,
+              xpNeeded: prev.level + 7,
+            }))
+          }
           className={styles.button}
         >
           +1 XP
         </button>
         <button
-          onClick={() => setCharacter((prev) => ({ ...prev, xp: Math.max(0, prev.xp - 1) }))}
+          onClick={() =>
+            setCharacter((prev) => ({
+              ...prev,
+              xp: Math.max(0, prev.xp - 1),
+              xpNeeded: prev.level + 7,
+            }))
+          }
           className={`${styles.button} ${styles.buttonRed}`}
         >
           -1 XP

--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -61,11 +61,12 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
       return {
         ...prev,
         xp: newXp,
+        xpNeeded: prev.level + 7,
         bonds: [...remainingBonds, ...newBonds],
       };
     });
 
-    if (newXp >= character.level + 7) {
+    if (newXp >= character.xpNeeded) {
       onLevelUp();
     }
 

--- a/src/components/EndSessionModal.test.jsx
+++ b/src/components/EndSessionModal.test.jsx
@@ -36,7 +36,7 @@ describe('EndSessionModal', () => {
   it('adds XP for positive answers', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const initial = { xp: 0, level: 1, xpNeeded: 8, bonds: [] };
+    const initial = { xp: 0, level: 1, xpNeeded: 10, bonds: [] };
     const { getCharacter } = renderWithCharacter(
       <EndSessionModal isOpen onClose={onClose} onLevelUp={() => {}} />,
       initial,
@@ -49,7 +49,25 @@ describe('EndSessionModal', () => {
     await user.click(screen.getByText(/end session/i));
 
     expect(getCharacter().xp).toBe(4);
+    expect(getCharacter().xpNeeded).toBe(getCharacter().level + 7);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('uses xpNeeded to trigger level up', async () => {
+    const user = userEvent.setup();
+    const onLevelUp = vi.fn();
+    const initial = { xp: 7, level: 1, xpNeeded: 12, bonds: [] };
+    const { getCharacter } = renderWithCharacter(
+      <EndSessionModal isOpen onClose={() => {}} onLevelUp={onLevelUp} />,
+      initial,
+    );
+
+    await user.click(screen.getByLabelText(/learn something new/i));
+    await user.click(screen.getByText(/end session/i));
+
+    expect(onLevelUp).not.toHaveBeenCalled();
+    expect(getCharacter().xp).toBe(8);
+    expect(getCharacter().xpNeeded).toBe(getCharacter().level + 7);
   });
 
   it('does not add XP for negative answers', async () => {

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -208,7 +208,11 @@ export default function useDiceRoller(character, setCharacter) {
       originalInterpretation = interpretation;
 
       if (originalTotal < 7 && autoXpOnMiss) {
-        setCharacter((prev) => ({ ...prev, xp: prev.xp + 1 }));
+        setCharacter((prev) => ({
+          ...prev,
+          xp: prev.xp + 1,
+          xpNeeded: prev.level + 7,
+        }));
       }
 
       if (!isAidMove && window.confirm('Did someone aid or interfere?')) {


### PR DESCRIPTION
## Summary
- replace hard-coded level+7 checks with xpNeeded
- recalc xpNeeded after XP gains and level ups
- update XP-related tests for new xpNeeded behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca08d19c883328ccee5b5f1c9be82