### PR TITLE
feat: add session summary to end session modal

### DIFF
--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -136,6 +136,31 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
           </div>
         )}
 
+        <div className={styles.section}>
+          <h3 className={styles.title}>Summary</h3>
+          <ul className={styles.bondList}>
+            <li className={styles.bondItem}>
+              HP: {character.hp}/{character.maxHp}
+            </li>
+            <li className={styles.bondItem}>XP: {character.xp}</li>
+            <li className={styles.bondItem}>
+              Debilities: {character.debilities?.length ? character.debilities.join(', ') : 'None'}
+            </li>
+            <li className={styles.bondItem}>Holds: {character.holds || 0}</li>
+            <li className={styles.bondItem}>
+              Active Effects:{' '}
+              {character.statusEffects?.length ? character.statusEffects.join(', ') : 'None'}
+            </li>
+            <li className={styles.bondItem}>
+              Inventory Changes:{' '}
+              {character.actionHistory
+                ?.filter((a) => a.action?.toLowerCase().includes('inventory'))
+                .map((a) => a.action)
+                .join(', ') || 'None'}
+            </li>
+          </ul>
+        </div>
+
         <div className={styles.total}>Total XP Gained: {totalXP}</div>
 
         <div className={styles.actions}>

--- a/src/components/EndSessionModal.test.jsx
+++ b/src/components/EndSessionModal.test.jsx
@@ -90,4 +90,36 @@ describe('EndSessionModal', () => {
       { name: 'Alice', relationship: 'Best buds', resolved: false },
     ]);
   });
+
+  it('displays character summary information', () => {
+    const initial = {
+      hp: 10,
+      maxHp: 20,
+      xp: 3,
+      level: 1,
+      xpNeeded: 8,
+      debilities: ['weak'],
+      holds: 2,
+      statusEffects: ['poisoned'],
+      actionHistory: [
+        { action: 'Inventory Added: Sword' },
+        { action: 'Inventory Removed: Potion' },
+      ],
+      bonds: [],
+    };
+
+    renderWithCharacter(
+      <EndSessionModal isOpen onClose={() => {}} onLevelUp={() => {}} />,
+      initial,
+    );
+
+    expect(screen.getByText('HP: 10/20')).toBeInTheDocument();
+    expect(screen.getByText('XP: 3')).toBeInTheDocument();
+    expect(screen.getByText('Debilities: weak')).toBeInTheDocument();
+    expect(screen.getByText('Holds: 2')).toBeInTheDocument();
+    expect(screen.getByText('Active Effects: poisoned')).toBeInTheDocument();
+    const inventorySummary = screen.getByText(/Inventory Changes:/);
+    expect(inventorySummary.textContent).toContain('Inventory Added: Sword');
+    expect(inventorySummary.textContent).toContain('Inventory Removed: Potion');
+  });
 });


### PR DESCRIPTION
## Summary
- show HP, XP, debilities, holds, active effects, and inventory changes in EndSessionModal
- test summary rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca091f7e08332a71a98a5d47379ae