### PR TITLE
feat(end-session): flag pending level ups

### DIFF
--- a/src/components/CharacterStats.test.jsx
+++ b/src/components/CharacterStats.test.jsx
@@ -17,6 +17,7 @@ function makeCharacter(overrides = {}) {
     xp: 10,
     xpNeeded: 10,
     level: 1,
+    levelUpPending: false,
     resources: {
       chronoUses: 0,
       paradoxPoints: 0,

--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -4,7 +4,7 @@ import { FaFlagCheckered } from 'react-icons/fa6';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './EndSessionModal.module.css';
 
-export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
+export default function EndSessionModal({ isOpen, onClose }) {
   const { character, setCharacter } = useCharacter();
   const [answers, setAnswers] = useState({
     q1: false,
@@ -43,8 +43,8 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
 
   const handleEnd = () => {
     const xpGained = totalXP;
-    const newXp = character.xp + xpGained;
     setCharacter((prev) => {
+      const newXp = prev.xp + xpGained;
       const remainingBonds = prev.bonds.filter((_, idx) => !resolvedBonds.includes(idx));
       const newBonds = resolvedBonds
         .map((idx) => {
@@ -62,12 +62,9 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
         ...prev,
         xp: newXp,
         bonds: [...remainingBonds, ...newBonds],
+        levelUpPending: newXp >= prev.xpNeeded || prev.levelUpPending,
       };
     });
-
-    if (newXp >= character.level + 7) {
-      onLevelUp();
-    }
 
     onClose();
   };
@@ -154,5 +151,4 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
 EndSessionModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
-  onLevelUp: PropTypes.func.isRequired,
 };

--- a/src/components/EndSessionModal.test.jsx
+++ b/src/components/EndSessionModal.test.jsx
@@ -23,22 +23,22 @@ function renderWithCharacter(ui, initialCharacter) {
 describe('EndSessionModal', () => {
   it('toggles visibility with isOpen prop', () => {
     const onClose = vi.fn();
-    const initial = { xp: 0, level: 1, xpNeeded: 8, bonds: [] };
+    const initial = { xp: 0, level: 1, xpNeeded: 8, bonds: [], levelUpPending: false };
     const { rerender } = renderWithCharacter(
-      <EndSessionModal isOpen={false} onClose={onClose} onLevelUp={() => {}} />,
+      <EndSessionModal isOpen={false} onClose={onClose} />,
       initial,
     );
     expect(screen.queryByText(/End of Session/i)).not.toBeInTheDocument();
-    rerender(<EndSessionModal isOpen onClose={onClose} onLevelUp={() => {}} />);
+    rerender(<EndSessionModal isOpen onClose={onClose} />);
     expect(screen.getByText(/End of Session/i)).toBeInTheDocument();
   });
 
   it('adds XP for positive answers', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const initial = { xp: 0, level: 1, xpNeeded: 8, bonds: [] };
+    const initial = { xp: 0, level: 1, xpNeeded: 8, bonds: [], levelUpPending: false };
     const { getCharacter } = renderWithCharacter(
-      <EndSessionModal isOpen onClose={onClose} onLevelUp={() => {}} />,
+      <EndSessionModal isOpen onClose={onClose} />,
       initial,
     );
 
@@ -54,9 +54,9 @@ describe('EndSessionModal', () => {
 
   it('does not add XP for negative answers', async () => {
     const user = userEvent.setup();
-    const initial = { xp: 0, level: 1, xpNeeded: 8, bonds: [] };
+    const initial = { xp: 0, level: 1, xpNeeded: 8, bonds: [], levelUpPending: false };
     const { getCharacter } = renderWithCharacter(
-      <EndSessionModal isOpen onClose={() => {}} onLevelUp={() => {}} />,
+      <EndSessionModal isOpen onClose={() => {}} />,
       initial,
     );
 
@@ -74,9 +74,10 @@ describe('EndSessionModal', () => {
         { name: 'Alice', relationship: 'Friend', resolved: false },
         { name: 'Bob', relationship: 'Ally', resolved: false },
       ],
+      levelUpPending: false,
     };
     const { getCharacter } = renderWithCharacter(
-      <EndSessionModal isOpen onClose={() => {}} onLevelUp={() => {}} />,
+      <EndSessionModal isOpen onClose={() => {}} />,
       initial,
     );
 
@@ -89,5 +90,20 @@ describe('EndSessionModal', () => {
       { name: 'Bob', relationship: 'Ally', resolved: false },
       { name: 'Alice', relationship: 'Best buds', resolved: false },
     ]);
+  });
+
+  it('flags pending level up when xp threshold is reached', async () => {
+    const user = userEvent.setup();
+    const initial = { xp: 7, level: 1, xpNeeded: 8, bonds: [], levelUpPending: false };
+    const { getCharacter } = renderWithCharacter(
+      <EndSessionModal isOpen onClose={() => {}} />,
+      initial,
+    );
+
+    await user.click(screen.getByLabelText(/learn something new/i));
+    await user.click(screen.getByText(/end session/i));
+
+    expect(getCharacter().xp).toBe(8);
+    expect(getCharacter().levelUpPending).toBe(true);
   });
 });

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -141,6 +141,7 @@ const LevelUpModal = ({
       xp: prev.xp - prev.xpNeeded,
       xpNeeded: levelUpState.newLevel + 7,
       selectedMoves: [...prev.selectedMoves, levelUpState.selectedMove],
+      levelUpPending: false,
       actionHistory: [
         ...prev.actionHistory.slice(-4), // Keep last 4 actions
         {

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -69,6 +69,7 @@ describe('LevelUpModal XP calculation', () => {
       xpNeeded: 8,
       selectedMoves: [],
       actionHistory: [],
+      levelUpPending: true,
     };
 
     const levelUpState = {

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -21,6 +21,7 @@ export const INITIAL_CHARACTER_DATA = {
   maxHp: 25,
   xp: 4,
   xpNeeded: 11, // Formula: level + 7
+  levelUpPending: false,
   armor: 0,
 
   // Attributes


### PR DESCRIPTION
## Summary
- mark level up as pending at end of session instead of forcing immediate modal
- include `levelUpPending` flag on character and clear after leveling up
- test end-session flow for pending level up

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca0a4dff4833287044d7c1a62120c