### PR TITLE
feat: add session recap sharing

### DIFF
--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -14,6 +14,8 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
   });
   const [resolvedBonds, setResolvedBonds] = useState([]);
   const [replacementBonds, setReplacementBonds] = useState({});
+  const [recap, setRecap] = useState('');
+  const [shareRecap, setShareRecap] = useState(false);
 
   if (!isOpen) return null;
 
@@ -58,11 +60,16 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
         })
         .filter(Boolean);
 
-      return {
+      const updated = {
         ...prev,
         xp: newXp,
         bonds: [...remainingBonds, ...newBonds],
+        sessionNotes: recap,
       };
+      if (shareRecap) {
+        updated.sessionRecapPublic = recap;
+      }
+      return updated;
     });
 
     if (newXp >= character.level + 7) {
@@ -135,6 +142,25 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
             </ul>
           </div>
         )}
+
+        <div className={styles.section}>
+          <label htmlFor="session-recap">Session Recap</label>
+          <textarea
+            id="session-recap"
+            className={styles.recapTextarea}
+            placeholder="What happened this session?"
+            value={recap}
+            onChange={(e) => setRecap(e.target.value)}
+          />
+          <label className={styles.shareLabel}>
+            <input
+              type="checkbox"
+              checked={shareRecap}
+              onChange={(e) => setShareRecap(e.target.checked)}
+            />{' '}
+            Share recap publicly
+          </label>
+        </div>
 
         <div className={styles.total}>Total XP Gained: {totalXP}</div>
 

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -50,6 +50,22 @@
   color: var(--color-white);
 }
 
+.recapTextarea {
+  width: 100%;
+  margin-top: 5px;
+  padding: 5px;
+  border-radius: 4px;
+  border: 1px solid var(--color-neon);
+  background: var(--color-modal-bg-dark);
+  color: var(--color-white);
+  min-height: 80px;
+}
+
+.shareLabel {
+  display: block;
+  margin-top: 8px;
+}
+
 .total {
   margin-top: 10px;
   color: var(--color-white);

--- a/src/components/EndSessionModal.test.jsx
+++ b/src/components/EndSessionModal.test.jsx
@@ -90,4 +90,49 @@ describe('EndSessionModal', () => {
       { name: 'Alice', relationship: 'Best buds', resolved: false },
     ]);
   });
+
+  it('saves recap privately when not shared', async () => {
+    const user = userEvent.setup();
+    const initial = {
+      xp: 0,
+      level: 1,
+      xpNeeded: 8,
+      bonds: [],
+      sessionNotes: '',
+      sessionRecapPublic: '',
+    };
+    const { getCharacter } = renderWithCharacter(
+      <EndSessionModal isOpen onClose={() => {}} onLevelUp={() => {}} />,
+      initial,
+    );
+
+    await user.type(screen.getByPlaceholderText(/what happened this session/i), 'Private recap');
+    await user.click(screen.getByText(/end session/i));
+
+    expect(getCharacter().sessionNotes).toBe('Private recap');
+    expect(getCharacter().sessionRecapPublic).toBe('');
+  });
+
+  it('saves recap publicly when shared', async () => {
+    const user = userEvent.setup();
+    const initial = {
+      xp: 0,
+      level: 1,
+      xpNeeded: 8,
+      bonds: [],
+      sessionNotes: '',
+      sessionRecapPublic: '',
+    };
+    const { getCharacter } = renderWithCharacter(
+      <EndSessionModal isOpen onClose={() => {}} onLevelUp={() => {}} />,
+      initial,
+    );
+
+    await user.type(screen.getByPlaceholderText(/what happened this session/i), 'Public recap');
+    await user.click(screen.getByLabelText(/share recap publicly/i));
+    await user.click(screen.getByText(/end session/i));
+
+    expect(getCharacter().sessionNotes).toBe('Public recap');
+    expect(getCharacter().sessionRecapPublic).toBe('Public recap');
+  });
 });

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -100,6 +100,7 @@ export const INITIAL_CHARACTER_DATA = {
 
   // Session Data
   sessionNotes: '', // Campaign notes and events
+  sessionRecapPublic: '', // Shareable session recap
   rollHistory: [], // Recent dice rolls (last 10)
 };
 


### PR DESCRIPTION
## Summary
- allow players to write a session recap at end of session
- optionally share recap publicly via `sessionRecapPublic`
- test private and public recap persistence

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca09707608332b76ebf516e2c4dd4