### PR TITLE
feat: add end session modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import {
   FaUserAstronaut,
   FaSatellite,
   FaArrowRotateLeft,
+  FaFlagCheckered,
 } from 'react-icons/fa6';
 import CharacterStats from './components/CharacterStats.jsx';
 import DiceRoller from './components/DiceRoller.jsx';
@@ -37,6 +38,7 @@ function App() {
   const [showLastBreathModal, setShowLastBreathModal] = useState(false);
   const [showInventoryModal, setShowInventoryModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
+  const [showEndSessionModal, setShowEndSessionModal] = useState(false);
   const [compactMode, setCompactMode] = useState(false);
 
   const getDefaultLevelUpState = () => ({
@@ -163,6 +165,12 @@ function App() {
                 {character.bonds.filter((b) => !b.resolved).length})
               </button>
               <button
+                onClick={() => setShowEndSessionModal(true)}
+                className={`${styles.button} ${styles.endSessionButton}`}
+              >
+                <FaFlagCheckered className={styles.icon} /> End Session
+              </button>
+              <button
                 onClick={() => setShowExportModal(true)}
                 className={`${styles.button} ${styles.exportButton}`}
               >
@@ -241,9 +249,11 @@ function App() {
         handleEquipItem={handleEquipItem}
         handleConsumeItem={handleConsumeItem}
         handleDropItem={handleDropItem}
-        bondsModal={bondsModal}
         showExportModal={showExportModal}
         setShowExportModal={setShowExportModal}
+        showEndSessionModal={showEndSessionModal}
+        setShowEndSessionModal={setShowEndSessionModal}
+        bondsModal={bondsModal}
       />
     </div>
   );

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -130,6 +130,37 @@ describe('XP gain on miss', () => {
   });
 });
 
+describe('End session flow', () => {
+  it('opens EndSessionModal when End Session button is clicked', () => {
+    const initialCharacter = { ...INITIAL_CHARACTER_DATA, xp: 0, xpNeeded: 5, bonds: [] };
+
+    const Wrapper = ({ children }) => {
+      const [character, setCharacter] = React.useState(initialCharacter);
+      return (
+        <ThemeProvider>
+          <CharacterContext.Provider value={{ character, setCharacter }}>
+            {children}
+          </CharacterContext.Provider>
+        </ThemeProvider>
+      );
+    };
+
+    render(
+      <Wrapper>
+        <App />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText(/End of Session/i)).toBeNull();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /End Session/i }));
+    });
+
+    expect(screen.getByText(/End of Session/i)).toBeInTheDocument();
+  });
+});
+
 // Skipped in Vitest environment due to jsdom localStorage limitations
 describe.skip('localStorage persistence', () => {
   const Wrapper = ({ children }) => {

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import BondsModal from './BondsModal.jsx';
 import DamageModal from './DamageModal.jsx';
 import ExportModal from './ExportModal.jsx';
+import EndSessionModal from './EndSessionModal.jsx';
 import InventoryModal from './InventoryModal.jsx';
 import LastBreathModal from './LastBreathModal.jsx';
 import LevelUpModal from './LevelUpModal.jsx';
@@ -35,6 +36,8 @@ const GameModals = ({
   handleDropItem,
   showExportModal,
   setShowExportModal,
+  showEndSessionModal,
+  setShowEndSessionModal,
   bondsModal,
 }) => (
   <>
@@ -86,6 +89,12 @@ const GameModals = ({
 
     <BondsModal isOpen={bondsModal.isOpen} onClose={bondsModal.close} />
 
+    <EndSessionModal
+      isOpen={showEndSessionModal}
+      onClose={() => setShowEndSessionModal(false)}
+      onLevelUp={() => setShowLevelUpModal(true)}
+    />
+
     <ExportModal isOpen={showExportModal} onClose={() => setShowExportModal(false)} />
   </>
 );
@@ -117,6 +126,8 @@ GameModals.propTypes = {
   handleDropItem: PropTypes.func.isRequired,
   showExportModal: PropTypes.bool.isRequired,
   setShowExportModal: PropTypes.func.isRequired,
+  showEndSessionModal: PropTypes.bool.isRequired,
+  setShowEndSessionModal: PropTypes.func.isRequired,
   bondsModal: PropTypes.shape({
     isOpen: PropTypes.bool.isRequired,
     close: PropTypes.func.isRequired,

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -113,6 +113,10 @@
   background: linear-gradient(45deg, var(--color-blue), var(--color-blue-dark));
 }
 
+.endSessionButton {
+  background: linear-gradient(45deg, var(--color-green), var(--color-green-dark));
+}
+
 .exportButton {
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
 }


### PR DESCRIPTION
## Summary
- integrate EndSessionModal into GameModals with open/close and level-up handling
- add End Session control button with styling and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca0c121a0833293892ea18becd3d9