### PR TITLE
feat: add session recap to end session modal

### DIFF
--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -12,8 +12,15 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
     q3: false,
     alignment: false,
   });
+  const [recapAnswers, setRecapAnswers] = useState({
+    highlights: { text: '', isPublic: false },
+    npcEncounters: { text: '', isPublic: false },
+    looseEnds: { text: '', isPublic: false },
+    nextSteps: { text: '', isPublic: false },
+  });
   const [resolvedBonds, setResolvedBonds] = useState([]);
   const [replacementBonds, setReplacementBonds] = useState({});
+  const [error, setError] = useState('');
 
   if (!isOpen) return null;
 
@@ -39,9 +46,29 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
     setReplacementBonds((prev) => ({ ...prev, [index]: text }));
   };
 
+  const handleRecapTextChange = (key, text) => {
+    setRecapAnswers((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], text },
+    }));
+  };
+
+  const toggleRecapPublic = (key) => {
+    setRecapAnswers((prev) => ({
+      ...prev,
+      [key]: { ...prev[key], isPublic: !prev[key].isPublic },
+    }));
+  };
+
   const totalXP = Object.values(answers).filter(Boolean).length + resolvedBonds.length;
 
   const handleEnd = () => {
+    const missingRecap = Object.values(recapAnswers).some(({ text }) => !text.trim());
+    if (missingRecap) {
+      setError('Please complete all recap fields.');
+      return;
+    }
+
     const xpGained = totalXP;
     const newXp = character.xp + xpGained;
     setCharacter((prev) => {
@@ -58,10 +85,22 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
         })
         .filter(Boolean);
 
+      const sessionRecap = Object.fromEntries(
+        Object.entries(recapAnswers).map(([key, { text }]) => [key, text.trim()]),
+      );
+
+      const sessionRecapPublic = Object.fromEntries(
+        Object.entries(recapAnswers)
+          .filter(([, { isPublic, text }]) => isPublic && text.trim())
+          .map(([key, { text }]) => [key, text.trim()]),
+      );
+
       return {
         ...prev,
         xp: newXp,
         bonds: [...remainingBonds, ...newBonds],
+        sessionRecap,
+        ...(Object.keys(sessionRecapPublic).length > 0 && { sessionRecapPublic }),
       };
     });
 
@@ -136,7 +175,84 @@ export default function EndSessionModal({ isOpen, onClose, onLevelUp }) {
           </div>
         )}
 
+        <div className={styles.section}>
+          <h3 className={styles.title}>Session Recap</h3>
+          <div className={styles.recapItem}>
+            <label className={styles.recapLabel}>
+              Highlights
+              <textarea
+                value={recapAnswers.highlights.text}
+                onChange={(e) => handleRecapTextChange('highlights', e.target.value)}
+                className={styles.textarea}
+              />
+            </label>
+            <label className={styles.shareLabel}>
+              <input
+                type="checkbox"
+                checked={recapAnswers.highlights.isPublic}
+                onChange={() => toggleRecapPublic('highlights')}
+              />{' '}
+              Share publicly
+            </label>
+          </div>
+          <div className={styles.recapItem}>
+            <label className={styles.recapLabel}>
+              NPC Encounters
+              <textarea
+                value={recapAnswers.npcEncounters.text}
+                onChange={(e) => handleRecapTextChange('npcEncounters', e.target.value)}
+                className={styles.textarea}
+              />
+            </label>
+            <label className={styles.shareLabel}>
+              <input
+                type="checkbox"
+                checked={recapAnswers.npcEncounters.isPublic}
+                onChange={() => toggleRecapPublic('npcEncounters')}
+              />{' '}
+              Share publicly
+            </label>
+          </div>
+          <div className={styles.recapItem}>
+            <label className={styles.recapLabel}>
+              Loose Ends
+              <textarea
+                value={recapAnswers.looseEnds.text}
+                onChange={(e) => handleRecapTextChange('looseEnds', e.target.value)}
+                className={styles.textarea}
+              />
+            </label>
+            <label className={styles.shareLabel}>
+              <input
+                type="checkbox"
+                checked={recapAnswers.looseEnds.isPublic}
+                onChange={() => toggleRecapPublic('looseEnds')}
+              />{' '}
+              Share publicly
+            </label>
+          </div>
+          <div className={styles.recapItem}>
+            <label className={styles.recapLabel}>
+              Next Steps
+              <textarea
+                value={recapAnswers.nextSteps.text}
+                onChange={(e) => handleRecapTextChange('nextSteps', e.target.value)}
+                className={styles.textarea}
+              />
+            </label>
+            <label className={styles.shareLabel}>
+              <input
+                type="checkbox"
+                checked={recapAnswers.nextSteps.isPublic}
+                onChange={() => toggleRecapPublic('nextSteps')}
+              />{' '}
+              Share publicly
+            </label>
+          </div>
+        </div>
+
         <div className={styles.total}>Total XP Gained: {totalXP}</div>
+        {error && <div className={styles.error}>{error}</div>}
 
         <div className={styles.actions}>
           <button onClick={handleEnd} className={styles.button}>

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -50,9 +50,38 @@
   color: var(--color-white);
 }
 
+.recapItem {
+  margin-bottom: 15px;
+}
+
+.recapLabel {
+  display: block;
+}
+
+.shareLabel {
+  display: block;
+  margin-top: 5px;
+}
+
+.textarea {
+  width: 100%;
+  height: 60px;
+  margin-top: 5px;
+  padding: 5px;
+  border-radius: 4px;
+  border: 1px solid var(--color-neon);
+  background: var(--color-modal-bg-dark);
+  color: var(--color-white);
+}
+
 .total {
   margin-top: 10px;
   color: var(--color-white);
+}
+
+.error {
+  color: var(--color-danger);
+  margin-top: 10px;
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- introduce session recap fields with optional public sharing
- persist recap answers alongside XP and bond updates
- validate recap completion before finalizing session

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ca1314da88332882ec4bbb6292f11