### PR TITLE
feat: wrap modal action buttons

### DIFF
--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -47,6 +47,7 @@
 .buttonGroup {
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .button {

--- a/src/components/DamageModal.test.jsx
+++ b/src/components/DamageModal.test.jsx
@@ -3,6 +3,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import CharacterContext from '../state/CharacterContext.jsx';
 import DamageModal from './DamageModal.jsx';
 
@@ -84,5 +86,10 @@ describe('DamageModal', () => {
     await user.click(screen.getByText('Apply'));
 
     await waitFor(() => expect(onLastBreath).toHaveBeenCalled());
+  });
+
+  it('includes flex-wrap styling for action buttons', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, './DamageModal.module.css'), 'utf8');
+    expect(css).toMatch(/\.buttonGroup[^}]*flex-wrap:\s*wrap/);
   });
 });

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -338,5 +338,6 @@
     display: flex;
     gap: 10px;
     justify-content: center;
+    flex-wrap: wrap;
   }
 }

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import { advancedMoves } from '../data/advancedMoves.js';
 import LevelUpModal from './LevelUpModal.jsx';
 
@@ -170,5 +172,10 @@ describe('LevelUpModal visibility and closing', () => {
     render(<LevelUpWrapper isOpen {...baseProps} onClose={onClose} />);
     await user.click(screen.getByLabelText('Close modal'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('includes flex-wrap styling for action buttons', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, './LevelUpModal.module.css'), 'utf8');
+    expect(css).toMatch(/\.levelup-actions[^}]*flex-wrap:\s*wrap/);
   });
 });


### PR DESCRIPTION
## Summary
- wrap DamageModal and LevelUpModal button groups to avoid overflow
- add tests confirming flex-wrap is defined for action buttons

## Testing
- `npm run lint`
- `npm test` *(fails: defaultAnswers is not defined in EndSessionModal tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cd5e878848332b6f9a04117059266