### PR TITLE
feat: improve modal button responsiveness

### DIFF
--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -53,6 +53,16 @@
 
 .bondActions {
   margin-top: 5px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+@media (max-width: 360px) {
+  .bondActions {
+    flex-direction: column;
+  }
 }
 
 .button {

--- a/src/components/BondsModal.test.jsx
+++ b/src/components/BondsModal.test.jsx
@@ -5,6 +5,8 @@ import React from 'react';
 import { vi } from 'vitest';
 import CharacterContext from '../state/CharacterContext.jsx';
 import BondsModal from './BondsModal.jsx';
+import fs from 'fs';
+import path from 'path';
 
 function renderWithCharacter(ui) {
   const Wrapper = ({ children }) => {
@@ -47,5 +49,22 @@ describe('BondsModal', () => {
 
     await user.click(screen.getByText('Close'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders action buttons without overflow on narrow screens', () => {
+    const onClose = vi.fn();
+    document.body.style.width = '320px';
+    renderWithCharacter(<BondsModal isOpen onClose={onClose} />);
+    const group = screen.getByText('Add Bond').parentElement;
+    group.style.overflowX = 'auto';
+    expect(group.scrollWidth).toBeLessThanOrEqual(group.clientWidth);
+  });
+
+  it('includes responsive styles for bond actions', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, './BondsModal.module.css'), 'utf8');
+    expect(css).toMatch(/\.bondActions[^}]*width:\s*100%/);
+    expect(css).toMatch(
+      /@media\s*\(max-width:\s*360px\)\s*{[^}]*\.bondActions[^}]*flex-direction:\s*column/,
+    );
   });
 });

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -48,6 +48,13 @@
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  width: 100%;
+}
+
+@media (max-width: 360px) {
+  .buttonGroup {
+    flex-direction: column;
+  }
 }
 
 .button {

--- a/src/components/DamageModal.test.jsx
+++ b/src/components/DamageModal.test.jsx
@@ -92,4 +92,25 @@ describe('DamageModal', () => {
     const css = fs.readFileSync(path.resolve(__dirname, './DamageModal.module.css'), 'utf8');
     expect(css).toMatch(/\.buttonGroup[^}]*flex-wrap:\s*wrap/);
   });
+
+  it('renders action buttons without overflow on narrow screens', () => {
+    const onClose = vi.fn();
+    const onLastBreath = vi.fn();
+    const initial = { hp: 10, armor: 0, inventory: [], actionHistory: [] };
+    document.body.style.width = '320px';
+    renderWithCharacter(<DamageModal isOpen onClose={onClose} onLastBreath={onLastBreath} />, {
+      character: initial,
+    });
+    const group = screen.getByText('Apply').parentElement;
+    group.style.overflowX = 'auto';
+    expect(group.scrollWidth).toBeLessThanOrEqual(group.clientWidth);
+  });
+
+  it('includes responsive styles for button group', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, './DamageModal.module.css'), 'utf8');
+    expect(css).toMatch(/\.buttonGroup[^}]*width:\s*100%/);
+    expect(css).toMatch(
+      /@media\s*\(max-width:\s*360px\)\s*{[^}]*\.buttonGroup[^}]*flex-direction:\s*column/,
+    );
+  });
 });

--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -5,12 +5,20 @@ import { FaFlagCheckered } from 'react-icons/fa6';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './EndSessionModal.module.css';
 
+const defaultAnswers = { q1: false, q2: false, q3: false, drive: false };
+
 export default function EndSessionModal({ isOpen, onClose }) {
   const { character, setCharacter } = useCharacter();
   const [answers, setAnswers] = useState(defaultAnswers);
   const [resolvedBonds, setResolvedBonds] = useState([]);
   const [replacementBonds, setReplacementBonds] = useState({});
   const [recap, setRecap] = useState('');
+  const [inventoryChanges, setInventoryChanges] = useState({});
+  const [clearedStatus, setClearedStatus] = useState([]);
+  const [clearedDebilities, setClearedDebilities] = useState([]);
+  const [shareRecap, setShareRecap] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+  const [error, setError] = useState('');
 
   if (!isOpen) return null;
 
@@ -154,7 +162,7 @@ export default function EndSessionModal({ isOpen, onClose }) {
             </ul>
           </div>
         )}
-        
+
         {character.inventory.length > 0 && (
           <div className={styles.section}>
             <h3 className={styles.title}>Item Usage</h3>

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -50,7 +50,6 @@
   color: var(--color-white);
 }
 
-
 .recapInput {
   width: 100%;
   margin-top: 5px;
@@ -73,6 +72,16 @@
 
 .actions {
   margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+@media (max-width: 360px) {
+  .actions {
+    flex-direction: column;
+  }
 }
 
 .error {

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -44,6 +44,13 @@
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  width: 100%;
+}
+
+@media (max-width: 360px) {
+  .buttonGroup {
+    flex-direction: column;
+  }
 }
 
 .button {

--- a/src/components/ExportModal.test.jsx
+++ b/src/components/ExportModal.test.jsx
@@ -4,6 +4,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import CharacterContext from '../state/CharacterContext.jsx';
 import ExportModal from './ExportModal.jsx';
 
@@ -42,5 +44,23 @@ describe('ExportModal', () => {
     renderWithCharacter(<ExportModal isOpen onClose={onClose} />, { character: initial });
     await user.click(screen.getByText('Load'));
     expect(screen.getByTestId('name')).toHaveTextContent('New');
+  });
+
+  it('renders action buttons without overflow on narrow screens', () => {
+    const onClose = vi.fn();
+    const initial = { name: 'Hero' };
+    document.body.style.width = '320px';
+    renderWithCharacter(<ExportModal isOpen onClose={onClose} />, { character: initial });
+    const group = screen.getByText('Save').parentElement;
+    group.style.overflowX = 'auto';
+    expect(group.scrollWidth).toBeLessThanOrEqual(group.clientWidth);
+  });
+
+  it('includes responsive styles for button group', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, './ExportModal.module.css'), 'utf8');
+    expect(css).toMatch(/\.buttonGroup[^}]*width:\s*100%/);
+    expect(css).toMatch(
+      /@media\s*\(max-width:\s*360px\)\s*{[^}]*\.buttonGroup[^}]*flex-direction:\s*column/,
+    );
   });
 });

--- a/src/components/InventoryModal.module.css
+++ b/src/components/InventoryModal.module.css
@@ -69,6 +69,16 @@
 
 .inventoryItemActions {
   margin-top: 5px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+@media (max-width: 360px) {
+  .inventoryItemActions {
+    flex-direction: column;
+  }
 }
 
 .inventoryButton {

--- a/src/components/InventoryModal.test.jsx
+++ b/src/components/InventoryModal.test.jsx
@@ -4,6 +4,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 import InventoryModal from './InventoryModal.jsx';
+import fs from 'fs';
+import path from 'path';
 
 function InventoryWrapper({ isOpen, ...props }) {
   return isOpen ? <InventoryModal {...props} /> : null;
@@ -91,5 +93,30 @@ describe('InventoryModal', () => {
 
     await user.click(screen.getByText('Close'));
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders item action buttons without overflow on narrow screens', () => {
+    const inventory = [{ id: 1, name: 'Sword', type: 'weapon', equipped: false }];
+    document.body.style.width = '320px';
+    render(
+      <InventoryModal
+        inventory={inventory}
+        onEquip={() => {}}
+        onConsume={() => {}}
+        onDrop={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const group = screen.getByText('Drop').parentElement;
+    group.style.overflowX = 'auto';
+    expect(group.scrollWidth).toBeLessThanOrEqual(group.clientWidth);
+  });
+
+  it('includes responsive styles for item actions', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, './InventoryModal.module.css'), 'utf8');
+    expect(css).toMatch(/\.inventoryItemActions[^}]*width:\s*100%/);
+    expect(css).toMatch(
+      /@media\s*\(max-width:\s*360px\)\s*{[^}]*\.inventoryItemActions[^}]*flex-direction:\s*column/,
+    );
   });
 });

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -339,5 +339,12 @@
     gap: 10px;
     justify-content: center;
     flex-wrap: wrap;
+    width: 100%;
+  }
+
+  @media (max-width: 360px) {
+    .levelup-actions {
+      flex-direction: column;
+    }
   }
 }

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -178,4 +178,20 @@ describe('LevelUpModal visibility and closing', () => {
     const css = fs.readFileSync(path.resolve(__dirname, './LevelUpModal.module.css'), 'utf8');
     expect(css).toMatch(/\.levelup-actions[^}]*flex-wrap:\s*wrap/);
   });
+
+  it('renders action buttons without overflow on narrow screens', () => {
+    document.body.style.width = '320px';
+    render(<LevelUpWrapper isOpen {...baseProps} onClose={() => {}} />);
+    const group = screen.getByRole('button', { name: /Cancel/i }).parentElement;
+    group.style.overflowX = 'auto';
+    expect(group.scrollWidth).toBeLessThanOrEqual(group.clientWidth);
+  });
+
+  it('includes responsive styles for action buttons', () => {
+    const css = fs.readFileSync(path.resolve(__dirname, './LevelUpModal.module.css'), 'utf8');
+    expect(css).toMatch(/\.levelup-actions[^}]*width:\s*100%/);
+    expect(css).toMatch(
+      /@media\s*\(max-width:\s*360px\)\s*{[^}]*\.levelup-actions[^}]*flex-direction:\s*column/,
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- ensure modal button groups span full width and stack vertically on screens under 360px
- add missing default state to EndSessionModal
- test that modal actions remain visible at narrow widths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d3a6ba25c8332a80120ce889e8c1c