### PR TITLE
fix: define missing color tokens

### DIFF
--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -27,7 +27,7 @@
 }
 
 .empty {
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
   margin: 20px 0;
 }
 

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -30,7 +30,7 @@
 
 .statName {
   font-size: 0.8rem;
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
 }
 
 .statValue {
@@ -45,7 +45,7 @@
   background: var(--color-gray-800);
   border-radius: 12px;
   overflow: hidden;
-  border: 2px solid var(--color-gray-750);
+  border: 2px solid var(--color-gray-700);
   margin: 10px 0;
 }
 

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -40,7 +40,7 @@
 }
 
 .summary {
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
   margin-bottom: 20px;
 }
 

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -108,7 +108,7 @@
 }
 
 .historyItem {
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
   margin-bottom: 2px;
 }
 

--- a/src/components/InventoryModal.module.css
+++ b/src/components/InventoryModal.module.css
@@ -28,7 +28,7 @@
 }
 
 .inventoryEmpty {
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
 }
 
 .inventoryList {

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -79,7 +79,7 @@
 
 .itemDetails {
   font-size: 0.7rem;
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
 }
 
 .useButton {

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -115,7 +115,7 @@
 
   .levelup-stat-button {
     padding: 10px;
-    border: 2px solid var(--color-gray-750);
+    border: 2px solid var(--color-gray-700);
     border-radius: 8px;
     background: var(--color-modal-bg);
     color: var(--color-gray-100);
@@ -141,7 +141,7 @@
   .levelup-stat-button.disabled {
     border-color: var(--color-gray-800);
     background: var(--color-gray-900);
-    color: var(--color-gray-750);
+    color: var(--color-gray-700);
     cursor: not-allowed;
   }
 
@@ -174,7 +174,7 @@
   .levelup-move-list {
     max-height: 250px;
     overflow-y: auto;
-    border: 1px solid var(--color-gray-750);
+    border: 1px solid var(--color-gray-700);
     border-radius: 8px;
     padding: 8px;
   }
@@ -185,7 +185,7 @@
 
   .levelup-move-button {
     padding: 12px;
-    border: 2px solid var(--color-gray-750);
+    border: 2px solid var(--color-gray-700);
     border-radius: 8px;
     background: var(--color-modal-bg);
     color: var(--color-gray-100);
@@ -249,7 +249,7 @@
   }
 
   .levelup-move-examples {
-    color: var(--color-gray-350);
+    color: var(--color-gray-400);
   }
 
   .levelup-hp-container {
@@ -259,7 +259,7 @@
     padding: 15px;
     background: rgba(255, 255, 255, 0.05);
     border-radius: 8px;
-    border: 1px solid var(--color-gray-750);
+    border: 1px solid var(--color-gray-700);
   }
 
   .levelup-button {
@@ -279,7 +279,7 @@
   }
 
   .levelup-button-cancel {
-    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-750));
+    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-700));
   }
 
   .levelup-button-complete {
@@ -289,7 +289,7 @@
   }
 
   .levelup-button-disabled {
-    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-750));
+    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-700));
     opacity: 0.5;
     cursor: not-allowed;
   }

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -75,14 +75,14 @@
 }
 
 .context {
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
   font-size: 0.9rem;
   margin-bottom: 20px;
 }
 
 .original {
   font-size: 1rem;
-  color: var(--color-gray-350);
+  color: var(--color-gray-400);
   margin-bottom: 10px;
 }
 

--- a/src/styles/colorMap.js
+++ b/src/styles/colorMap.js
@@ -1,5 +1,9 @@
 export const baseColors = {
   white: 'var(--color-white)',
+  yellow: 'var(--color-yellow)',
+  purpleLight: 'var(--color-purple-light)',
+  orangeLight: 'var(--color-orange-light)',
+  cyan: 'var(--color-cyan)',
 };
 
 export const resourceColors = {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -8,9 +8,22 @@
   --color-accent-darker: #2b6c65;
   --color-accent-rgb: 95, 209, 193;
 
+  --color-white: #ffffff;
+
+  --color-yellow: #fbbf24;
+  --color-purple-light: #a78bfa;
+  --color-orange-light: #fb923c;
+  --color-cyan: #06b6d4;
+
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
   --color-gray-400: #6b7280;
   --color-gray-500: #4b5563;
   --color-gray-600: #374151;
+  --color-gray-700: #1f2937;
+  --color-gray-800: #111827;
+  --color-gray-900: #030712;
 
   --color-red: #b84f5e;
   --color-red-dark: #9b3744;
@@ -26,10 +39,13 @@
   --color-blue: #4f6db8;
   --color-blue-dark: #324f99;
   --color-blue-light: #6b8ed6;
+  --color-blue-deep: var(--color-blue-dark);
 
   --color-green: #4ab381;
   --color-green-dark: #3a8f66;
   --color-green-rgb: 74, 179, 129;
+  --color-emerald: var(--color-green);
+  --color-emerald-dark: var(--color-green-dark);
 
   --color-danger: var(--color-red);
   --color-danger-dark: var(--color-red-dark);
@@ -43,6 +59,13 @@
   --color-gray-dark: var(--color-gray-600);
   --color-info: var(--color-blue);
   --color-info-dark: var(--color-blue-dark);
+  --color-indigo: var(--color-purple);
+  --color-indigo-dark: var(--color-purple-dark);
+  --color-neon: var(--color-accent);
+  --color-neon-dark: var(--color-accent-dark);
+  --color-neon-darker: var(--color-accent-darker);
+  --color-purple-deep: var(--color-purple-dark);
+  --color-red-light: #e57373;
   --overlay-poison: rgba(var(--color-accent-rgb), 0.1);
   --overlay-burning: rgba(var(--color-red-rgb), 0.15);
   --overlay-shocked-blue: rgba(79, 109, 184, 0.1);
@@ -56,6 +79,9 @@
   --panel-border: rgba(var(--color-accent-rgb), 0.3);
   --panel-shadow: rgba(0, 0, 0, 0.3);
   --color-bg-primary: var(--panel-bg);
+  --color-modal-bg: var(--panel-bg);
+  --color-modal-bg-secondary: rgba(255, 255, 255, 0.05);
+  --color-modal-bg-dark: rgba(0, 0, 0, 0.6);
 
   --glow-shadow: rgba(var(--color-accent-rgb), 0.3);
   --glow-shadow-strong: rgba(var(--color-accent-rgb), 0.6);
@@ -111,9 +137,22 @@
   --color-accent-darker: #003366;
   --color-accent-rgb: 0, 102, 204;
 
+  --color-white: #ffffff;
+
+  --color-yellow: #fbbf24;
+  --color-purple-light: #c4b5fd;
+  --color-orange-light: #fb923c;
+  --color-cyan: #06b6d4;
+
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
   --color-gray-400: #9ca3af;
   --color-gray-500: #6b7280;
   --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
+  --color-gray-800: #1f2937;
+  --color-gray-900: #111827;
 
   --color-red: #b91c1c;
   --color-red-dark: #7f1d1d;
@@ -126,12 +165,26 @@
   --color-purple: #7c3aed;
   --color-purple-dark: #6d28d9;
 
+  --color-info: var(--color-blue);
+  --color-info-dark: var(--color-blue-dark);
+  --color-indigo: var(--color-purple);
+  --color-indigo-dark: var(--color-purple-dark);
+  --color-neon: var(--color-accent);
+  --color-neon-dark: var(--color-accent-dark);
+  --color-neon-darker: var(--color-accent-darker);
+  --color-purple-deep: var(--color-purple-dark);
+  --color-red-light: #fca5a5;
+
   --color-blue: #3b82f6;
   --color-blue-dark: #1d4ed8;
+  --color-blue-light: #60a5fa;
+  --color-blue-deep: var(--color-blue-dark);
 
   --color-green: #10b981;
   --color-green-dark: #059669;
   --color-green-rgb: 16, 185, 129;
+  --color-emerald: var(--color-green);
+  --color-emerald-dark: var(--color-green-dark);
 
   --overlay-poison: rgba(var(--color-accent-rgb), 0.1);
   --overlay-burning: rgba(var(--color-red-rgb), 0.15);
@@ -145,6 +198,9 @@
   --panel-bg: rgba(255, 255, 255, 0.7);
   --panel-border: rgba(var(--color-accent-rgb), 0.3);
   --panel-shadow: rgba(0, 0, 0, 0.2);
+  --color-modal-bg: var(--panel-bg);
+  --color-modal-bg-secondary: rgba(255, 255, 255, 0.5);
+  --color-modal-bg-dark: rgba(0, 0, 0, 0.1);
 
   --glow-shadow: rgba(var(--color-accent-rgb), 0.3);
   --glow-shadow-strong: rgba(var(--color-accent-rgb), 0.6);


### PR DESCRIPTION
## Summary
- define missing color variables for both themes
- map new base colors in colorMap
- replace undefined gray variables in component styles

## Testing
- `npm run lint`
- `npm test` *(fails: defaultAnswers is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d3c4603a4833299a70d9ddb36ab8b