### PR TITLE
feat: add semantic color tokens

### DIFF
--- a/docs/colors.md
+++ b/docs/colors.md
@@ -1,0 +1,9 @@
+# Color Tokens
+
+This project uses semantic color tokens defined in `src/styles/theme.css`.
+When adding or updating colors:
+
+- **Aim for WCAG AA contrast.** Text and interactive elements should meet at least a 4.5:1 contrast ratio against their backgrounds.
+- **Check with tools** such as [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/) or browser devtools.
+- **Use semantic variables** like `--color-success`, `--color-warning`, `--color-danger`, and `--color-info` instead of raw color values.
+- Provide light/dark variants as needed to ensure readability across themes.

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -51,7 +51,7 @@
 
 .hpFill {
   height: 100%;
-  background: linear-gradient(90deg, var(--color-danger), var(--color-amber));
+  background: linear-gradient(90deg, var(--color-danger), var(--color-warning));
   transition: width 0.3s ease;
 }
 
@@ -92,7 +92,7 @@
 
 .xpFill {
   height: 100%;
-  background: linear-gradient(90deg, var(--color-blue-light), var(--color-accent));
+  background: linear-gradient(90deg, var(--color-info-light), var(--color-accent));
   transition: width 0.3s ease;
 }
 
@@ -177,8 +177,8 @@
 }
 
 .warningBox {
-  background: rgba(251, 191, 36, 0.2);
-  border: 1px solid var(--color-amber);
+  background: var(--overlay-warning);
+  border: 1px solid var(--color-warning);
   border-radius: 6px;
   padding: 10px;
   text-align: center;
@@ -186,13 +186,13 @@
 }
 
 .warningText {
-  color: var(--color-amber);
+  color: var(--color-warning);
   font-size: 0.8rem;
   font-weight: bold;
 }
 
 .resetButton {
-  background: linear-gradient(45deg, var(--color-blue-light), var(--color-accent));
+  background: linear-gradient(45deg, var(--color-info-light), var(--color-accent));
   border: none;
   border-radius: 6px;
   color: var(--color-white);
@@ -211,7 +211,7 @@
 }
 
 .levelUpButton {
-  background: linear-gradient(45deg, var(--color-amber), var(--color-warning));
+  background: linear-gradient(45deg, var(--color-warning-light), var(--color-warning));
   width: 100%;
   margin-top: 15px;
   padding: 15px;

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -78,7 +78,7 @@
 }
 
 .amber {
-  background: linear-gradient(45deg, var(--color-amber), var(--color-amber-dark));
+  background: linear-gradient(45deg, var(--color-warning-light), var(--color-warning));
 }
 
 .cyan {

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -111,9 +111,9 @@
 }
 
 .debilityTag {
-  background: rgba(239, 68, 68, 0.2);
+  background: var(--overlay-danger);
   border: 1px solid var(--color-danger);
-  color: var(--color-red-light);
+  color: var(--color-danger-light);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 0.7rem;

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -42,7 +42,7 @@
 
   .levelup-header-text {
     margin: 5px 0 0;
-    color: var(--color-blue-light);
+    color: var(--color-info-light);
   }
 
   .levelup-close-button {

--- a/src/components/Message.module.css
+++ b/src/components/Message.module.css
@@ -9,7 +9,7 @@
 }
 
 .message-warning {
-  color: var(--color-amber);
+  color: var(--color-warning);
 }
 
 .message-success {

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -98,11 +98,11 @@
 }
 
 .damageButton {
-  background: linear-gradient(45deg, var(--color-red), var(--color-red-dark));
+  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }
 
 .statusButton {
-  background: linear-gradient(45deg, var(--color-orange), var(--color-orange-dark));
+  background: linear-gradient(45deg, var(--color-warning), var(--color-warning-dark));
 }
 
 .inventoryButton {
@@ -110,11 +110,11 @@
 }
 
 .bondsButton {
-  background: linear-gradient(45deg, var(--color-blue), var(--color-blue-dark));
+  background: linear-gradient(45deg, var(--color-info), var(--color-info-dark));
 }
 
 .endSessionButton {
-  background: linear-gradient(45deg, var(--color-green), var(--color-green-dark));
+  background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
 }
 
 .exportButton {

--- a/src/styles/colorMap.js
+++ b/src/styles/colorMap.js
@@ -3,10 +3,10 @@ export const baseColors = {
 };
 
 export const resourceColors = {
-  paradoxPoints: 'var(--color-yellow)',
-  bandages: 'var(--color-purple-light)',
-  rations: 'var(--color-orange-light)',
-  advGear: 'var(--color-cyan)',
+  paradoxPoints: 'var(--color-warning-light)',
+  bandages: 'var(--color-purple)',
+  rations: 'var(--color-warning)',
+  advGear: 'var(--color-info-light)',
 };
 
 export const headerGradients = {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,3 +1,8 @@
+/*
+  Semantic color tokens for UI states.
+  Maintain WCAG AA contrast (\u22654.5:1 for text) when updating these values.
+  Verify new combinations with tools like https://webaim.org/resources/contrastchecker/.
+*/
 :root {
   --color-bg-start: #0b0d17;
   --color-bg-end: #1a1f38;
@@ -8,49 +13,49 @@
   --color-accent-darker: #2b6c65;
   --color-accent-rgb: 95, 209, 193;
 
-  --color-gray-400: #6b7280;
-  --color-gray-500: #4b5563;
-  --color-gray-600: #374151;
+  /* base neutrals */
+  --color-neutral-light: #9ca3af;
+  --color-neutral: #6b7280;
+  --color-neutral-dark: #374151;
+  --color-neutral-rgb: 107, 114, 128;
 
-  --color-red: #b84f5e;
-  --color-red-dark: #9b3744;
-  --color-red-rgb: 184, 79, 94;
+  /* semantic tokens */
+  --color-danger: #b84f5e;
+  --color-danger-dark: #9b3744;
+  --color-danger-light: #e07b8a;
+  --color-danger-rgb: 184, 79, 94;
 
-  --color-orange: #c9824a;
-  --color-orange-dark: #a7623c;
-  --color-orange-rgb: 201, 130, 74;
+  --color-warning: #c9824a;
+  --color-warning-dark: #a7623c;
+  --color-warning-light: #e1a76e;
+  --color-warning-rgb: 201, 130, 74;
+
+  --color-success: #4ab381;
+  --color-success-dark: #3a8f66;
+  --color-success-light: #6fd2a0;
+  --color-success-rgb: 74, 179, 129;
+
+  --color-info: #4f6db8;
+  --color-info-dark: #324f99;
+  --color-info-light: #6b8ed6;
+  --color-info-rgb: 79, 109, 184;
 
   --color-purple: #6e5aa3;
   --color-purple-dark: #59458c;
 
-  --color-blue: #4f6db8;
-  --color-blue-dark: #324f99;
-  --color-blue-light: #6b8ed6;
-
-  --color-green: #4ab381;
-  --color-green-dark: #3a8f66;
-  --color-green-rgb: 74, 179, 129;
-
-  --color-danger: var(--color-red);
-  --color-danger-dark: var(--color-red-dark);
-  --color-amber: var(--color-orange);
-  --color-amber-dark: var(--color-orange-dark);
-  --color-warning: #fbbf24;
-  --color-warning-dark: #d97706;
-  --color-success: var(--color-green);
-  --color-success-dark: var(--color-green-dark);
-  --color-gray: var(--color-gray-400);
-  --color-gray-dark: var(--color-gray-600);
-  --color-info: var(--color-blue);
-  --color-info-dark: var(--color-blue-dark);
+  /* overlays */
   --overlay-poison: rgba(var(--color-accent-rgb), 0.1);
-  --overlay-burning: rgba(var(--color-red-rgb), 0.15);
+  --overlay-burning: rgba(var(--color-danger-rgb), 0.15);
   --overlay-shocked-blue: rgba(79, 109, 184, 0.1);
   --overlay-shocked-gold: rgba(169, 142, 98, 0.1);
   --overlay-frozen: rgba(var(--color-accent-rgb), 0.1);
   --overlay-blessed: rgba(251, 191, 36, 0.1);
   --overlay-dark: rgba(0, 0, 0, 0.2);
   --overlay-darker: rgba(0, 0, 0, 0.3);
+  --overlay-success: rgba(var(--color-success-rgb), 0.2);
+  --overlay-warning: rgba(var(--color-warning-rgb), 0.2);
+  --overlay-danger: rgba(var(--color-danger-rgb), 0.2);
+  --overlay-info: rgba(var(--color-info-rgb), 0.2);
 
   --panel-bg: rgba(255, 255, 255, 0.1);
   --panel-border: rgba(var(--color-accent-rgb), 0.3);
@@ -67,33 +72,33 @@
     transparent
   );
 
-  --success-border: var(--color-green);
-  --success-shadow: rgba(var(--color-green-rgb), 0.4);
-  --warning-border: var(--color-orange);
-  --warning-shadow: rgba(var(--color-orange-rgb), 0.4);
-  --error-border: var(--color-red);
-  --error-shadow: rgba(var(--color-red-rgb), 0.4);
+  --success-border: var(--color-success);
+  --success-shadow: rgba(var(--color-success-rgb), 0.4);
+  --warning-border: var(--color-warning);
+  --warning-shadow: rgba(var(--color-warning-rgb), 0.4);
+  --error-border: var(--color-danger);
+  --error-shadow: rgba(var(--color-danger-rgb), 0.4);
 
-  --status-healthy-start: var(--color-green);
-  --status-healthy-end: var(--color-green-dark);
-  --status-healthy-shadow: rgba(var(--color-green-rgb), 0.6);
+  --status-healthy-start: var(--color-success);
+  --status-healthy-end: var(--color-success-dark);
+  --status-healthy-shadow: rgba(var(--color-success-rgb), 0.6);
 
-  --status-injured-start: var(--color-orange);
-  --status-injured-end: var(--color-orange-dark);
-  --status-injured-shadow: rgba(var(--color-orange-rgb), 0.6);
+  --status-injured-start: var(--color-warning);
+  --status-injured-end: var(--color-warning-dark);
+  --status-injured-shadow: rgba(var(--color-warning-rgb), 0.6);
 
-  --status-critical-start: var(--color-red);
-  --status-critical-end: var(--color-red-dark);
-  --status-critical-shadow: rgba(var(--color-red-rgb), 0.6);
+  --status-critical-start: var(--color-danger);
+  --status-critical-end: var(--color-danger-dark);
+  --status-critical-shadow: rgba(var(--color-danger-rgb), 0.6);
 
-  --equipped-item-border: var(--color-green);
-  --equipped-item-bg: rgba(var(--color-green-rgb), 0.1);
-  --unequipped-item-border: var(--color-gray-400);
+  --equipped-item-border: var(--color-success);
+  --equipped-item-bg: rgba(var(--color-success-rgb), 0.1);
+  --unequipped-item-border: var(--color-neutral);
 
   --critical-hit-start: #c0a65a;
-  --critical-hit-end: var(--color-orange);
-  --critical-failure-start: var(--color-red);
-  --critical-failure-end: var(--color-red-dark);
+  --critical-hit-end: var(--color-warning);
+  --critical-failure-start: var(--color-danger);
+  --critical-failure-end: var(--color-danger-dark);
 
   /* legacy variable aliases */
   --background: linear-gradient(135deg, var(--color-bg-start), var(--color-bg-end));
@@ -111,36 +116,49 @@
   --color-accent-darker: #003366;
   --color-accent-rgb: 0, 102, 204;
 
-  --color-gray-400: #9ca3af;
-  --color-gray-500: #6b7280;
-  --color-gray-600: #4b5563;
+  /* base neutrals */
+  --color-neutral-light: #9ca3af;
+  --color-neutral: #6b7280;
+  --color-neutral-dark: #4b5563;
+  --color-neutral-rgb: 107, 114, 128;
 
-  --color-red: #b91c1c;
-  --color-red-dark: #7f1d1d;
-  --color-red-rgb: 185, 28, 28;
+  /* semantic tokens */
+  --color-danger: #b91c1c;
+  --color-danger-dark: #7f1d1d;
+  --color-danger-light: #ef4444;
+  --color-danger-rgb: 185, 28, 28;
 
-  --color-orange: #d97706;
-  --color-orange-dark: #b45309;
-  --color-orange-rgb: 217, 119, 6;
+  --color-warning: #d97706;
+  --color-warning-dark: #b45309;
+  --color-warning-light: #f59e0b;
+  --color-warning-rgb: 217, 119, 6;
+
+  --color-success: #10b981;
+  --color-success-dark: #059669;
+  --color-success-light: #34d399;
+  --color-success-rgb: 16, 185, 129;
+
+  --color-info: #3b82f6;
+  --color-info-dark: #1d4ed8;
+  --color-info-light: #60a5fa;
+  --color-info-rgb: 59, 130, 246;
 
   --color-purple: #7c3aed;
   --color-purple-dark: #6d28d9;
 
-  --color-blue: #3b82f6;
-  --color-blue-dark: #1d4ed8;
-
-  --color-green: #10b981;
-  --color-green-dark: #059669;
-  --color-green-rgb: 16, 185, 129;
-
+  /* overlays */
   --overlay-poison: rgba(var(--color-accent-rgb), 0.1);
-  --overlay-burning: rgba(var(--color-red-rgb), 0.15);
+  --overlay-burning: rgba(var(--color-danger-rgb), 0.15);
   --overlay-shocked-blue: rgba(59, 130, 246, 0.1);
   --overlay-shocked-gold: rgba(234, 179, 8, 0.1);
   --overlay-frozen: rgba(var(--color-accent-rgb), 0.1);
   --overlay-blessed: rgba(251, 191, 36, 0.1);
   --overlay-dark: rgba(0, 0, 0, 0.2);
   --overlay-darker: rgba(0, 0, 0, 0.3);
+  --overlay-success: rgba(var(--color-success-rgb), 0.2);
+  --overlay-warning: rgba(var(--color-warning-rgb), 0.2);
+  --overlay-danger: rgba(var(--color-danger-rgb), 0.2);
+  --overlay-info: rgba(var(--color-info-rgb), 0.2);
 
   --panel-bg: rgba(255, 255, 255, 0.7);
   --panel-border: rgba(var(--color-accent-rgb), 0.3);
@@ -156,31 +174,31 @@
     transparent
   );
 
-  --success-border: var(--color-green);
-  --success-shadow: rgba(var(--color-green-rgb), 0.4);
-  --warning-border: var(--color-orange);
-  --warning-shadow: rgba(var(--color-orange-rgb), 0.4);
-  --error-border: var(--color-red);
-  --error-shadow: rgba(var(--color-red-rgb), 0.4);
+  --success-border: var(--color-success);
+  --success-shadow: rgba(var(--color-success-rgb), 0.4);
+  --warning-border: var(--color-warning);
+  --warning-shadow: rgba(var(--color-warning-rgb), 0.4);
+  --error-border: var(--color-danger);
+  --error-shadow: rgba(var(--color-danger-rgb), 0.4);
 
-  --status-healthy-start: var(--color-green);
-  --status-healthy-end: var(--color-green-dark);
-  --status-healthy-shadow: rgba(var(--color-green-rgb), 0.6);
+  --status-healthy-start: var(--color-success);
+  --status-healthy-end: var(--color-success-dark);
+  --status-healthy-shadow: rgba(var(--color-success-rgb), 0.6);
 
-  --status-injured-start: var(--color-orange);
-  --status-injured-end: var(--color-orange-dark);
-  --status-injured-shadow: rgba(var(--color-orange-rgb), 0.6);
+  --status-injured-start: var(--color-warning);
+  --status-injured-end: var(--color-warning-dark);
+  --status-injured-shadow: rgba(var(--color-warning-rgb), 0.6);
 
-  --status-critical-start: var(--color-red);
-  --status-critical-end: var(--color-red-dark);
-  --status-critical-shadow: rgba(var(--color-red-rgb), 0.6);
+  --status-critical-start: var(--color-danger);
+  --status-critical-end: var(--color-danger-dark);
+  --status-critical-shadow: rgba(var(--color-danger-rgb), 0.6);
 
-  --equipped-item-border: var(--color-green);
-  --equipped-item-bg: rgba(var(--color-green-rgb), 0.1);
-  --unequipped-item-border: var(--color-gray-400);
+  --equipped-item-border: var(--color-success);
+  --equipped-item-bg: rgba(var(--color-success-rgb), 0.1);
+  --unequipped-item-border: var(--color-neutral-light);
 
   --critical-hit-start: #c0a65a;
-  --critical-hit-end: var(--color-orange);
-  --critical-failure-start: var(--color-red);
-  --critical-failure-end: var(--color-red-dark);
+  --critical-hit-end: var(--color-warning);
+  --critical-failure-start: var(--color-danger);
+  --critical-failure-end: var(--color-danger-dark);
 }


### PR DESCRIPTION
## Summary
- add semantic color tokens with WCAG guidance
- migrate components to use success/warning/info/danger tokens
- document color token usage and contrast guidelines

## Testing
- `npm run lint`
- `npm test` *(fails: defaultAnswers is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d3c5cb1d88332afa0d0771603968a