### PR TITLE
feat: display rulebook name in header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ import useInventory from './hooks/useInventory';
 import useModal from './hooks/useModal.js';
 import useStatusEffects from './hooks/useStatusEffects.js';
 import useUndo from './hooks/useUndo.js';
-import { statusEffectTypes, debilityTypes } from './state/character';
+import { statusEffectTypes, debilityTypes, RULEBOOK } from './state/character';
 import { useCharacter } from './state/CharacterContext.jsx';
 import styles from './styles/AppStyles.module.css';
 
@@ -111,6 +111,7 @@ function App() {
               <h1 className={styles.title}>ZIMBO – The Time-Bound Juggernaut</h1>
               <div className={styles.subHeader}>
                 <p>Barbarian-Wizard Hybrid | Level {character.level} | Neutral Good</p>
+                <p>Rulebook: {RULEBOOK}</p>
                 {character.statusEffects.length > 0 && (
                   <div className={styles.statusEffectsContainer}>
                     {character.statusEffects.map((effect) => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -161,6 +161,29 @@ describe('End session flow', () => {
   });
 });
 
+describe('Rulebook display', () => {
+  const Wrapper = ({ children }) => {
+    const [character, setCharacter] = React.useState(INITIAL_CHARACTER_DATA);
+    return (
+      <ThemeProvider>
+        <CharacterContext.Provider value={{ character, setCharacter }}>
+          {children}
+        </CharacterContext.Provider>
+      </ThemeProvider>
+    );
+  };
+
+  it('renders the rulebook name in the header', () => {
+    render(
+      <Wrapper>
+        <App />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText(/Rulebook: Dungeon World/i)).toBeInTheDocument();
+  });
+});
+
 // Skipped in Vitest environment due to jsdom localStorage limitations
 describe.skip('localStorage persistence', () => {
   const Wrapper = ({ children }) => {

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -14,6 +14,8 @@ import {
   FaFaceFrownOpen,
 } from 'react-icons/fa6';
 
+export const RULEBOOK = 'Dungeon World';
+
 export const INITIAL_CHARACTER_DATA = {
   // Basic Info
   level: 4,


### PR DESCRIPTION
## Summary
- define `RULEBOOK` constant for centralized rulebook configuration
- show rulebook name in main header to maintain cyber-future theme
- cover rulebook display with a unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d42e4247c83328ee3f8cca76e9a32