### PR TITLE
feat: add moebius theme option

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -268,6 +268,7 @@ describe.skip('localStorage persistence', () => {
 });
 
 describe('Theme switching', () => {
+  beforeEach(() => localStorage.removeItem('theme'));
   it('updates the theme attribute when selecting classic', () => {
     render(
       <ThemeProvider>
@@ -282,6 +283,23 @@ describe('Theme switching', () => {
     }).then(() => {
       fireEvent.change(select, { target: { value: 'classic' } });
       expect(document.documentElement.getAttribute('data-theme')).toBe('classic');
+    });
+  });
+
+  it('updates the theme attribute when selecting moebius', () => {
+    render(
+      <ThemeProvider>
+        <Settings />
+      </ThemeProvider>,
+    );
+
+    const select = screen.getByLabelText(/Theme:/i);
+
+    return waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cosmic');
+    }).then(() => {
+      fireEvent.change(select, { target: { value: 'moebius' } });
+      expect(document.documentElement.getAttribute('data-theme')).toBe('moebius');
     });
   });
 });

--- a/src/state/theme.js
+++ b/src/state/theme.js
@@ -1,4 +1,3 @@
-
-export const THEMES = ['cosmic', 'classic'];
+export const THEMES = ['cosmic', 'classic', 'moebius'];
 
 export const DEFAULT_THEME = 'cosmic';

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -51,7 +51,6 @@
   --color-info-light: #6b8ed6;
   --color-info-rgb: 79, 109, 184;
 
-
   --color-purple: #6e5aa3;
   --color-purple-dark: #59458c;
 
@@ -219,4 +218,45 @@
   --critical-hit-end: var(--color-warning);
   --critical-failure-start: var(--color-danger);
   --critical-failure-end: var(--color-danger-dark);
+}
+
+:root[data-theme='moebius'] {
+  --color-bg-start: #f2e9e4;
+  --color-bg-end: #e4d2cc;
+  --color-text: #2d2a26;
+
+  --color-accent: #27a9a1;
+  --color-accent-dark: #1e827c;
+  --color-accent-darker: #155b58;
+  --color-accent-rgb: 39, 169, 161;
+
+  --color-info: #d2666f;
+  --color-info-dark: #a74e55;
+  --color-info-light: #e88c94;
+  --color-info-rgb: 210, 102, 111;
+
+  --color-purple: #8f6fd6;
+  --color-purple-dark: #6c51aa;
+
+  --color-success: #7bb662;
+  --color-success-dark: #5b8f49;
+  --color-success-light: #97cc79;
+  --color-success-rgb: 123, 182, 98;
+
+  --color-warning: #f1a85a;
+  --color-warning-dark: #c9833e;
+  --color-warning-light: #f5c588;
+  --color-warning-rgb: 241, 168, 90;
+
+  --color-danger: #e36c57;
+  --color-danger-dark: #b25441;
+  --color-danger-light: #e98f7c;
+  --color-danger-rgb: 227, 108, 87;
+
+  --panel-bg: rgba(255, 255, 255, 0.15);
+  --panel-border: rgba(39, 169, 161, 0.3);
+  --panel-shadow: rgba(0, 0, 0, 0.25);
+  --overlay-dark: rgba(0, 0, 0, 0.2);
+  --glow-shadow: rgba(39, 169, 161, 0.35);
+  --glow-shadow-strong: rgba(39, 169, 161, 0.6);
 }


### PR DESCRIPTION
## Summary
- add Moebius-inspired color tokens
- expose "moebius" in theme list and settings
- test switching to the new theme

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4ca007f88332a2eafa44ab19c529