### PR TITLE
feat: replace avatar pngs with svg placeholders

### DIFF
--- a/public/avatars/default.svg
+++ b/public/avatars/default.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#ccc"/>
+</svg>

--- a/public/avatars/poisoned.svg
+++ b/public/avatars/poisoned.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <circle cx="32" cy="32" r="30" fill="#2f9e44"/>
+  <line x1="20" y1="20" x2="44" y2="44" stroke="#fff" stroke-width="4"/>
+  <line x1="44" y1="20" x2="20" y2="44" stroke="#fff" stroke-width="4"/>
+</svg>

--- a/src/components/CharacterAvatar.test.jsx
+++ b/src/components/CharacterAvatar.test.jsx
@@ -1,0 +1,9 @@
+/* eslint-env jest */
+import { statusEffectImageMap } from '../hooks/useStatusEffects.js';
+
+describe('CharacterAvatar', () => {
+  it('uses SVG images for avatar states', () => {
+    expect(statusEffectImageMap.default).toBe('/avatars/default.svg');
+    expect(statusEffectImageMap.poisoned).toBe('/avatars/poisoned.svg');
+  });
+});

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -1,5 +1,10 @@
 import { headerGradients } from '../styles/colorMap.js';
 
+export const statusEffectImageMap = {
+  default: '/avatars/default.svg',
+  poisoned: '/avatars/poisoned.svg',
+};
+
 export default function useStatusEffects(character, setCharacter) {
   const statusEffects = character.statusEffects;
   const debilities = character.debilities;
@@ -48,11 +53,21 @@ export default function useStatusEffects(character, setCharacter) {
     return headerGradients.default;
   };
 
+  const getStatusEffectImage = () => {
+    for (const effect of Object.keys(statusEffectImageMap)) {
+      if (effect !== 'default' && statusEffects.includes(effect)) {
+        return statusEffectImageMap[effect];
+      }
+    }
+    return statusEffectImageMap.default;
+  };
+
   return {
     statusEffects,
     debilities,
     getActiveVisualEffects,
     getHeaderColor,
+    getStatusEffectImage,
     toggleStatusEffect,
     toggleDebility,
   };


### PR DESCRIPTION
## Summary
- add SVG avatar placeholders for default and poisoned states
- map status effects to new SVG images
- update avatar tests to assert SVG paths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4cb2ed4483328e975a4865084cd1