### PR TITLE
feat: add browser file storage utility

### DIFF
--- a/src/components/ExportModal.jsx
+++ b/src/components/ExportModal.jsx
@@ -1,4 +1,4 @@
-import { invoke } from '@tauri-apps/api/core';
+import { saveFile, loadFile } from '../utils/fileStorage.js';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { FaSatellite } from 'react-icons/fa6';
@@ -14,10 +14,7 @@ export default function ExportModal({ isOpen, onClose }) {
 
   const handleSave = async () => {
     try {
-      await invoke('write_file', {
-        path: fileName,
-        contents: JSON.stringify(character, null, 2),
-      });
+      await saveFile(fileName, JSON.stringify(character, null, 2));
       setMessage('Character saved!');
     } catch (err) {
       setMessage('Failed to save.');
@@ -26,7 +23,7 @@ export default function ExportModal({ isOpen, onClose }) {
 
   const handleLoad = async () => {
     try {
-      const contents = await invoke('read_file', { path: fileName });
+      const contents = await loadFile(fileName);
       const data = JSON.parse(contents);
       setCharacter(data);
       setMessage('Character loaded!');

--- a/src/components/ExportModal.test.jsx
+++ b/src/components/ExportModal.test.jsx
@@ -1,13 +1,16 @@
 /* eslint-env jest */
-import { invoke } from '@tauri-apps/api/core';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 import CharacterContext from '../state/CharacterContext.jsx';
 import ExportModal from './ExportModal.jsx';
+import { loadFile } from '../utils/fileStorage.js';
 
-vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('../utils/fileStorage.js', () => ({
+  saveFile: vi.fn(),
+  loadFile: vi.fn(),
+}));
 
 function renderWithCharacter(ui, { character }) {
   const Wrapper = ({ children }) => {
@@ -38,7 +41,7 @@ describe('ExportModal', () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
     const initial = { name: 'Hero' };
-    invoke.mockResolvedValueOnce('{"name":"New"}');
+    loadFile.mockResolvedValueOnce('{"name":"New"}');
     renderWithCharacter(<ExportModal isOpen onClose={onClose} />, { character: initial });
     await user.click(screen.getByText('Load'));
     expect(screen.getByTestId('name')).toHaveTextContent('New');

--- a/src/utils/fileStorage.js
+++ b/src/utils/fileStorage.js
@@ -1,0 +1,52 @@
+export async function saveFile(name, contents) {
+  if (window.__TAURI__) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke('write_file', { path: name, contents });
+  }
+
+  try {
+    localStorage.setItem(name, contents);
+  } catch {
+    const blob = new Blob([contents], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = name;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+}
+
+export async function loadFile(name) {
+  if (window.__TAURI__) {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return invoke('read_file', { path: name });
+  }
+
+  try {
+    const item = localStorage.getItem(name);
+    if (item !== null) return item;
+  } catch {
+    // ignore
+  }
+
+  return new Promise((resolve, reject) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json';
+    input.onchange = () => {
+      const file = input.files && input.files[0];
+      if (!file) {
+        reject(new Error('No file selected'));
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(file);
+    };
+    input.click();
+  });
+}


### PR DESCRIPTION
## Summary
- add `fileStorage` helper that uses Tauri invoke when available and falls back to browser storage
- use `fileStorage` in ExportModal instead of direct `invoke`
- update ExportModal tests to mock `fileStorage`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d52d26ffc833281dff5b639238d86