### PR TITLE
feat: persist session notes via fileStorage

### DIFF
--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -26,6 +26,12 @@
   font-size: 0.9rem;
 }
 
+.warning {
+  color: var(--color-danger);
+  margin-top: 10px;
+  font-size: 0.9rem;
+}
+
 .buttons {
   margin-top: 10px;
   display: flex;


### PR DESCRIPTION
## Summary
- replace Tauri `invoke` calls with `saveFile`/`loadFile` utility
- warn users when session note persistence is unavailable
- update SessionNotes tests to mock new file storage interface

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d53eadef88332ad3fe5bd2e61012b