### PR TITLE
feat: add character avatar with status effect overlays

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import DiceRoller from './components/DiceRoller.jsx';
 import GameModals from './components/GameModals.jsx';
 import InventoryPanel from './components/InventoryPanel.jsx';
 import SessionNotes from './components/SessionNotes.jsx';
+import CharacterAvatar from './components/CharacterAvatar.jsx';
 import Settings from './components/Settings.jsx';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
@@ -184,6 +185,9 @@ function App() {
 
         {/* Main Grid Layout */}
         <div className={styles.grid}>
+          {/* Avatar Panel */}
+          <CharacterAvatar character={character} />
+
           {/* Stats Panel */}
           <CharacterStats
             character={character}

--- a/src/components/CharacterAvatar.jsx
+++ b/src/components/CharacterAvatar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import useStatusEffects from '../hooks/useStatusEffects.js';
+import styles from './CharacterAvatar.module.css';
+
+export default function CharacterAvatar({ character }) {
+  const { getStatusEffectImage, getActiveVisualEffects } =
+    useStatusEffects(character, () => {});
+
+  return (
+    <div className={`${styles.avatarContainer} ${getActiveVisualEffects()}`}>
+      <img
+        src={getStatusEffectImage()}
+        alt="Character avatar"
+        className={styles.avatar}
+      />
+    </div>
+  );
+}

--- a/src/components/CharacterAvatar.module.css
+++ b/src/components/CharacterAvatar.module.css
@@ -1,0 +1,18 @@
+.avatarContainer {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 12px;
+  padding: 20px;
+  border: 1px solid rgba(0, 255, 136, 0.3);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.avatar {
+  width: 100%;
+  max-width: 200px;
+  border-radius: 50%;
+  border: 2px solid var(--color-accent);
+}

--- a/src/components/CharacterAvatar.test.jsx
+++ b/src/components/CharacterAvatar.test.jsx
@@ -1,9 +1,22 @@
 /* eslint-env jest */
-import { statusEffectImageMap } from '../hooks/useStatusEffects.js';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import CharacterAvatar from './CharacterAvatar.jsx';
 
 describe('CharacterAvatar', () => {
-  it('uses SVG images for avatar states', () => {
-    expect(statusEffectImageMap.default).toBe('/avatars/default.svg');
-    expect(statusEffectImageMap.poisoned).toBe('/avatars/poisoned.svg');
+  it('applies poisoned overlay and image when status effect active', () => {
+    const character = { statusEffects: ['poisoned'], debilities: [] };
+    render(<CharacterAvatar character={character} />);
+    const img = screen.getByRole('img', { name: /character avatar/i });
+    expect(img).toHaveClass('poisoned-overlay');
+    expect(img.getAttribute('src')).toBe('/avatars/poisoned.svg');
+  });
+
+  it('uses default image when no status effects', () => {
+    const character = { statusEffects: [], debilities: [] };
+    render(<CharacterAvatar character={character} />);
+    const img = screen.getByRole('img', { name: /character avatar/i });
+    expect(img.getAttribute('src')).toBe('/avatars/default.svg');
   });
 });

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -69,7 +69,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 20px;
   margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- add `CharacterAvatar` component with status effect image swapping and overlays
- integrate avatar panel into app grid layout
- add tests for avatar image and overlay handling

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm test` (fails: vitest: not found)


------
https://chatgpt.com/codex/tasks/task_e_689d581883688332b9dfdb7915a92ecf