### PR TITLE
docs: explain browser-only development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,14 @@ Thank you for your interest in contributing to Zimbo Tauri Character Sheet.
    npm run tauri dev
    ```
 
+6. For browser-only development, start Vite without Tauri:
+
+   ```bash
+   npm run dev
+   ```
+
+   This mode lacks Tauri features like local file I/O.
+
 ## Common Pitfalls
 
 - **Node version**: The project requires Node ≥20. Use a version manager like `nvm` if needed.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ pre-commit run --all-files
 npm run tauri dev
 ```
 
+### Browser development
+
+Start Vite's dev server in the browser without Tauri:
+
+```bash
+npm run dev
+```
+
+Features that rely on Tauri APIs, such as local file I/O, are limited in this mode.
+
 ### Build web assets
 
 ```bash
@@ -98,7 +108,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup, linting, and testing 
 ## Development scripts
 
 Optional helper scripts can be kept in a local `scripts/` directory. This folder is ignored by Git and is not required for building or running the project.
-
 
 ## License
 


### PR DESCRIPTION
## Summary
- document browser-only dev mode and its limitations
- add npm run dev note to setup steps

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5902828c83329bdd04af985e81cc