### PR TITLE
fix: use import.meta.env.MODE for env check

### DIFF
--- a/src/utils/dice.js
+++ b/src/utils/dice.js
@@ -4,7 +4,7 @@ export const rollDie = (sides) => {
   if (!Number.isInteger(sides) || sides <= 0) {
     throw new Error('sides must be a positive integer');
   }
-  if (process.env.NODE_ENV === 'test') {
+  if (import.meta.env.MODE === 'test') {
     if (typeof crypto?.getRandomValues === 'function' && crypto.getRandomValues.mock) {
       const array = new Uint32Array(1);
       crypto.getRandomValues(array);

--- a/src/utils/dice.test.js
+++ b/src/utils/dice.test.js
@@ -1,7 +1,15 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { rollDie, rollDice } from './dice.js';
 const MAX_COUNT = 1000; // should match value in dice.js
+
+beforeEach(() => {
+  vi.stubEnv('MODE', 'test');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('rollDie', () => {
   it('returns a value within 1..sides', () => {


### PR DESCRIPTION
## Summary
- use `import.meta.env.MODE` instead of `process.env.NODE_ENV` in dice utility
- stub `MODE` env var in dice tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d59062adc833298a1f4ee6f4faf0f