### PR TITLE
fix: guard XP grant when autoXpOnMiss missing

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -1,4 +1,3 @@
-/* global autoXpOnMiss */
 import { useState, useEffect } from 'react';
 import { debilityTypes } from '../state/character';
 import * as diceUtils from '../utils/dice.js';
@@ -114,6 +113,7 @@ export default function useDiceRoller(character, setCharacter) {
 
   const rollDice = (formula, description = '') => {
     const desc = description.toLowerCase();
+    const xpOnMiss = globalThis.autoXpOnMiss ?? false;
     let result = '';
     let total = 0;
     let interpretation = '';
@@ -207,7 +207,7 @@ export default function useDiceRoller(character, setCharacter) {
 
       originalInterpretation = interpretation;
 
-      if (originalTotal < 7 && autoXpOnMiss) {
+      if (originalTotal < 7 && xpOnMiss) {
         setCharacter((prev) => ({
           ...prev,
           xp: prev.xp + 1,

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -182,3 +182,22 @@ describe('useDiceRoller safe localStorage handling', () => {
     expect(result.current.rollHistory).toEqual([]);
   });
 });
+
+describe('useDiceRoller XP on miss handling', () => {
+  const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
+
+  it('does not grant XP when autoXpOnMiss is undefined', () => {
+    localStorage.clear();
+    const setCharacter = vi.fn();
+    const previousSetting = globalThis.autoXpOnMiss;
+    delete globalThis.autoXpOnMiss;
+    const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter));
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    act(() => {
+      result.current.rollDice('2d6', 'test');
+    });
+    randomSpy.mockRestore();
+    expect(setCharacter).not.toHaveBeenCalled();
+    globalThis.autoXpOnMiss = previousSetting;
+  });
+});


### PR DESCRIPTION
## Summary
- default auto XP on miss to `false` when `autoXpOnMiss` global is undefined
- test that no XP is awarded when `autoXpOnMiss` is undefined

## Testing
- `npm run lint`
- `npm test` *(fails: CharacterAvatar > applies poisoned overlay and image when status effect active)*

------
https://chatgpt.com/codex/tasks/task_e_689d5b9a53a88332b9b6810d1f93bec0