### PR TITLE
feat: log safe local storage errors

### DIFF
--- a/src/utils/safeLocalStorage.js
+++ b/src/utils/safeLocalStorage.js
@@ -4,7 +4,8 @@ const safeLocalStorage = {
       if (typeof localStorage === 'undefined') return fallback;
       const value = localStorage.getItem(key);
       return value === null ? fallback : value;
-    } catch {
+    } catch (error) {
+      console.error('Failed to get localStorage item', key, error);
       return fallback;
     }
   },
@@ -13,8 +14,8 @@ const safeLocalStorage = {
     try {
       if (typeof localStorage === 'undefined') return;
       localStorage.setItem(key, value);
-    } catch {
-      // ignore
+    } catch (error) {
+      console.error('Failed to set localStorage item', key, error);
     }
   },
 
@@ -22,8 +23,8 @@ const safeLocalStorage = {
     try {
       if (typeof localStorage === 'undefined') return;
       localStorage.removeItem(key);
-    } catch {
-      // ignore
+    } catch (error) {
+      console.error('Failed to remove localStorage item', key, error);
     }
   },
 };

--- a/src/utils/safeLocalStorage.test.js
+++ b/src/utils/safeLocalStorage.test.js
@@ -12,30 +12,45 @@ describe('safeLocalStorage', () => {
     global.localStorage = original;
   });
 
-  it('returns fallback when getItem throws', () => {
+  it('returns fallback and logs error when getItem throws', () => {
     const original = global.localStorage;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const err = new Error('fail');
     global.localStorage = {
       getItem: vi.fn(() => {
-        throw new Error('fail');
+        throw err;
       }),
     };
     expect(safeLocalStorage.getItem('key', 'fallback')).toBe('fallback');
+    expect(errorSpy).toHaveBeenCalledWith('Failed to get localStorage item', 'key', err);
+    errorSpy.mockRestore();
     global.localStorage = original;
   });
 
-  it('swallows errors from setItem and removeItem', () => {
+  it('logs errors from setItem and removeItem without throwing', () => {
     const original = global.localStorage;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const setErr = new Error('fail set');
+    const removeErr = new Error('fail remove');
     global.localStorage = {
       getItem: vi.fn(() => null),
       setItem: vi.fn(() => {
-        throw new Error('fail');
+        throw setErr;
       }),
       removeItem: vi.fn(() => {
-        throw new Error('fail');
+        throw removeErr;
       }),
     };
     expect(() => safeLocalStorage.setItem('key', 'value')).not.toThrow();
     expect(() => safeLocalStorage.removeItem('key')).not.toThrow();
+    expect(errorSpy).toHaveBeenNthCalledWith(1, 'Failed to set localStorage item', 'key', setErr);
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      2,
+      'Failed to remove localStorage item',
+      'key',
+      removeErr,
+    );
+    errorSpy.mockRestore();
     global.localStorage = original;
   });
 });


### PR DESCRIPTION
## Summary
- log localStorage failures with the offending key
- test that safeLocalStorage methods log errors instead of throwing

## Testing
- `npm run lint`
- `npm test` *(fails: CharacterAvatar > applies poisoned overlay and image when status effect active)*

------
https://chatgpt.com/codex/tasks/task_e_689d5bad43008332ad15860815e19b32