### PR TITLE
test: add ThemeContext persistence tests

### DIFF
--- a/src/components/CharacterAvatar.test.jsx
+++ b/src/components/CharacterAvatar.test.jsx
@@ -9,7 +9,7 @@ describe('CharacterAvatar', () => {
     const character = { statusEffects: ['poisoned'], debilities: [] };
     render(<CharacterAvatar character={character} />);
     const img = screen.getByRole('img', { name: /character avatar/i });
-    expect(img).toHaveClass('poisoned-overlay');
+    expect(img.parentElement).toHaveClass('poisoned-overlay');
     expect(img.getAttribute('src')).toBe('/avatars/poisoned.svg');
   });
 

--- a/src/state/ThemeContext.test.jsx
+++ b/src/state/ThemeContext.test.jsx
@@ -1,0 +1,75 @@
+/* eslint-env jest */
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { vi } from 'vitest';
+import { ThemeProvider, useTheme } from './ThemeContext.jsx';
+import { DEFAULT_THEME } from './theme.js';
+
+describe('ThemeContext', () => {
+  let localStorageMock;
+  let originalDocumentElement;
+  let setAttributeMock;
+
+  beforeEach(() => {
+    // Mock localStorage
+    localStorageMock = (() => {
+      let store = {};
+      return {
+        getItem: vi.fn((key) => store[key] ?? null),
+        setItem: vi.fn((key, value) => {
+          store[key] = String(value);
+        }),
+        clear: () => {
+          store = {};
+        },
+      };
+    })();
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      configurable: true,
+    });
+
+    // Mock document.documentElement
+    originalDocumentElement = document.documentElement;
+    setAttributeMock = vi.fn();
+    Object.defineProperty(document, 'documentElement', {
+      value: { setAttribute: setAttributeMock },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    // Restore document.documentElement
+    Object.defineProperty(document, 'documentElement', {
+      value: originalDocumentElement,
+      configurable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  const wrapper = ({ children }) => <ThemeProvider>{children}</ThemeProvider>;
+
+  it('uses the default theme when none is stored', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe(DEFAULT_THEME);
+  });
+
+  it('updates the data-theme attribute when the theme changes', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    act(() => {
+      result.current.setTheme('classic');
+    });
+    expect(setAttributeMock).toHaveBeenCalledWith('data-theme', 'classic');
+  });
+
+  it('persists theme changes to localStorage and loads stored theme', () => {
+    localStorage.setItem('theme', 'classic');
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe('classic');
+
+    act(() => {
+      result.current.setTheme('moebius');
+    });
+    expect(localStorage.setItem).toHaveBeenCalledWith('theme', 'moebius');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ThemeContext covering defaults, DOM attribute updates, and localStorage persistence
- adjust CharacterAvatar tests to check overlay class on container

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5bae70fc8332b5f3dc9eaed40373