### PR TITLE
feat: add character HUD components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,7 @@ import DiceRoller from './components/DiceRoller.jsx';
 import GameModals from './components/GameModals.jsx';
 import InventoryPanel from './components/InventoryPanel.jsx';
 import SessionNotes from './components/SessionNotes.jsx';
-import CharacterAvatar from './components/CharacterAvatar.jsx';
+import CharacterHUD from './components/CharacterHUD/CharacterHUD.jsx';
 import Settings from './components/Settings.jsx';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
@@ -186,7 +186,7 @@ function App() {
         {/* Main Grid Layout */}
         <div className={styles.grid}>
           {/* Avatar Panel */}
-          <CharacterAvatar character={character} />
+          <CharacterHUD />
 
           {/* Stats Panel */}
           <CharacterStats

--- a/src/components/CharacterHUD/CastIndicator.jsx
+++ b/src/components/CharacterHUD/CastIndicator.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useCharacter } from '../../state/CharacterContext.jsx';
+import styles from './CastIndicator.module.css';
+
+export default function CastIndicator() {
+  const { character } = useCharacter();
+  const { castName, castProgress } = character;
+  if (!castName) return null;
+  return (
+    <div className={styles.container}>
+      <span>{castName}</span>
+      {typeof castProgress === 'number' && <progress value={castProgress} max="100" />}
+    </div>
+  );
+}

--- a/src/components/CharacterHUD/CastIndicator.module.css
+++ b/src/components/CharacterHUD/CastIndicator.module.css
@@ -1,0 +1,3 @@
+.container {
+  text-align: center;
+}

--- a/src/components/CharacterHUD/CharacterHUD.jsx
+++ b/src/components/CharacterHUD/CharacterHUD.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Nameplate from './Nameplate.jsx';
+import Portrait from './Portrait.jsx';
+import ResourceBars from './ResourceBars.jsx';
+import StatusTray from './StatusTray.jsx';
+import CastIndicator from './CastIndicator.jsx';
+import styles from './CharacterHUD.module.css';
+
+export default function CharacterHUD() {
+  return (
+    <div className={styles.hud}>
+      <Nameplate />
+      <Portrait />
+      <ResourceBars />
+      <StatusTray />
+      <CastIndicator />
+    </div>
+  );
+}

--- a/src/components/CharacterHUD/CharacterHUD.module.css
+++ b/src/components/CharacterHUD/CharacterHUD.module.css
@@ -1,0 +1,6 @@
+.hud {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/components/CharacterHUD/CharacterHUD.test.jsx
+++ b/src/components/CharacterHUD/CharacterHUD.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import CharacterHUD from './CharacterHUD.jsx';
+import CharacterContext from '../../state/CharacterContext.jsx';
+import { statusEffectTypes } from '../../state/character.js';
+
+describe('CharacterHUD', () => {
+  it('displays character data from context', () => {
+    const character = {
+      name: 'Zimbo',
+      hp: 10,
+      maxHp: 20,
+      secondaryResource: 5,
+      maxSecondaryResource: 10,
+      shield: 3,
+      statusEffects: ['poisoned'],
+      castName: 'Fireball',
+      castProgress: 50,
+    };
+
+    render(
+      <CharacterContext.Provider value={{ character, setCharacter: () => {} }}>
+        <CharacterHUD />
+      </CharacterContext.Provider>,
+    );
+
+    expect(screen.getByText('Zimbo')).toBeInTheDocument();
+    expect(screen.getByText('HP: 10/20')).toBeInTheDocument();
+    expect(screen.getByText('Resource: 5/10')).toBeInTheDocument();
+    expect(screen.getByText('Shield: 3')).toBeInTheDocument();
+    expect(screen.getByTitle(statusEffectTypes.poisoned.name)).toBeInTheDocument();
+    expect(screen.getByText('Fireball')).toBeInTheDocument();
+  });
+});

--- a/src/components/CharacterHUD/Nameplate.jsx
+++ b/src/components/CharacterHUD/Nameplate.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { useCharacter } from '../../state/CharacterContext.jsx';
+import styles from './Nameplate.module.css';
+
+export default function Nameplate() {
+  const { character } = useCharacter();
+  return <div className={styles.name}>{character.name || 'Unnamed Adventurer'}</div>;
+}

--- a/src/components/CharacterHUD/Nameplate.module.css
+++ b/src/components/CharacterHUD/Nameplate.module.css
@@ -1,0 +1,4 @@
+.name {
+  font-weight: bold;
+  text-align: center;
+}

--- a/src/components/CharacterHUD/Portrait.jsx
+++ b/src/components/CharacterHUD/Portrait.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useCharacter } from '../../state/CharacterContext.jsx';
+import useStatusEffects from '../../hooks/useStatusEffects.js';
+import styles from './Portrait.module.css';
+
+export default function Portrait() {
+  const { character } = useCharacter();
+  const { getStatusEffectImage, getActiveVisualEffects } = useStatusEffects(character, () => {});
+  return (
+    <div className={`${styles.avatarContainer} ${getActiveVisualEffects()}`}>
+      <img src={getStatusEffectImage()} alt="Character portrait" className={styles.avatar} />
+    </div>
+  );
+}

--- a/src/components/CharacterHUD/Portrait.module.css
+++ b/src/components/CharacterHUD/Portrait.module.css
@@ -1,0 +1,18 @@
+.avatarContainer {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(10px);
+  border-radius: 12px;
+  padding: 20px;
+  border: 1px solid rgba(0, 255, 136, 0.3);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.avatar {
+  width: 100%;
+  max-width: 200px;
+  border-radius: 50%;
+  border: 2px solid var(--color-accent);
+}

--- a/src/components/CharacterHUD/ResourceBars.jsx
+++ b/src/components/CharacterHUD/ResourceBars.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useCharacter } from '../../state/CharacterContext.jsx';
+import styles from './ResourceBars.module.css';
+
+export default function ResourceBars() {
+  const { character } = useCharacter();
+  const { hp, maxHp, secondaryResource = 0, maxSecondaryResource = 0, shield = 0 } = character;
+  return (
+    <div className={styles.container}>
+      <div className={styles.bar}>{`HP: ${hp}/${maxHp}`}</div>
+      {maxSecondaryResource > 0 && (
+        <div className={styles.bar}>{`Resource: ${secondaryResource}/${maxSecondaryResource}`}</div>
+      )}
+      {shield > 0 && <div className={styles.bar}>{`Shield: ${shield}`}</div>}
+    </div>
+  );
+}

--- a/src/components/CharacterHUD/ResourceBars.module.css
+++ b/src/components/CharacterHUD/ResourceBars.module.css
@@ -1,0 +1,13 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+
+.bar {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  padding: 4px 8px;
+  text-align: center;
+}

--- a/src/components/CharacterHUD/StatusTray.jsx
+++ b/src/components/CharacterHUD/StatusTray.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useCharacter } from '../../state/CharacterContext.jsx';
+import { statusEffectTypes } from '../../state/character.js';
+import styles from './StatusTray.module.css';
+
+export default function StatusTray() {
+  const { character } = useCharacter();
+  return (
+    <div className={styles.container}>
+      {character.statusEffects?.map((effect) => {
+        const Icon = statusEffectTypes[effect]?.icon;
+        return (
+          <span key={effect} title={statusEffectTypes[effect]?.name} className={styles.icon}>
+            {Icon && <Icon />}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/CharacterHUD/StatusTray.module.css
+++ b/src/components/CharacterHUD/StatusTray.module.css
@@ -1,0 +1,8 @@
+.container {
+  display: flex;
+  gap: 4px;
+}
+
+.icon {
+  display: inline-flex;
+}


### PR DESCRIPTION
## Summary
- add composite CharacterHUD with portrait, resource bars, status tray, nameplate, and cast indicator
- read HP, secondary resource, shield, and status effects from CharacterContext
- replace CharacterAvatar usage with CharacterHUD and add coverage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5e0ffccc8332aa9199f6ba7d21f5