### PR TITLE
test: loosen poisoned avatar image assertion

### DIFF
--- a/src/components/CharacterAvatar.test.jsx
+++ b/src/components/CharacterAvatar.test.jsx
@@ -10,7 +10,7 @@ describe('CharacterAvatar', () => {
     render(<CharacterAvatar character={character} />);
     const img = screen.getByRole('img', { name: /character avatar/i });
     expect(img.parentElement).toHaveClass('poisoned-overlay');
-    expect(img.getAttribute('src')).toBe('/avatars/poisoned.svg');
+    expect(img.src).toContain('/avatars/poisoned.svg');
     expect(img.parentElement).toHaveClass('poisoned-overlay');
   });
 


### PR DESCRIPTION
## Summary
- adjust poisoned avatar image test to assert partial URL instead of exact match

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5f05fc748332a52b9a86180c6bd4