### PR TITLE
feat: add HUD design tokens

### DIFF
--- a/docs/hud-theme.md
+++ b/docs/hud-theme.md
@@ -1,0 +1,29 @@
+# HUD Theme Tokens
+
+The heads-up display (HUD) uses a small set of CSS custom properties to keep spacing,
+radius and animation speeds consistent across components. These tokens live in
+[`src/styles/theme.css`](../src/styles/theme.css) and can be overridden per theme.
+
+| Token                   | Description                                    | Default                 | Classic                 | Moebius                 |
+| ----------------------- | ---------------------------------------------- | ----------------------- | ----------------------- | ----------------------- |
+| `--hud-radius`          | Corner rounding for panels and containers      | `0.75rem`               | `0.5rem`                | `0.75rem`               |
+| `--hud-radius-sm`       | Corner rounding for buttons and small elements | `0.375rem`              | `0.25rem`               | `0.375rem`              |
+| `--hud-spacing`         | Standard padding for panels                    | `1.25rem`               | `1rem`                  | `1.5rem`                |
+| `--hud-spacing-sm`      | Compact padding for inner elements             | `0.625rem`              | `0.5rem`                | `0.75rem`               |
+| `--hud-transition-fast` | Quick animations                               | `all 150ms ease-in-out` | `all 100ms ease-in-out` | `all 200ms ease-in-out` |
+| `--hud-transition`      | Default animations                             | `all 300ms ease-in-out` | `all 250ms ease-in-out` | `all 350ms ease-in-out` |
+| `--hud-transition-slow` | Emphasized animations                          | `all 500ms ease-in-out` | `all 400ms ease-in-out` | `all 600ms ease-in-out` |
+
+Use these tokens within HUD components to guarantee visual consistency:
+
+```css
+.panel {
+  border-radius: var(--hud-radius);
+  padding: var(--hud-spacing);
+  transition: var(--hud-transition);
+}
+```
+
+Light themes such as `classic` and `moebius` override the tokens to provide
+subtle differences in spacing and motion. Custom themes can do the same by
+redefining these variables under their own `[data-theme]` selector.

--- a/src/App.css
+++ b/src/App.css
@@ -150,7 +150,7 @@ select:focus {
 .glass-panel {
   background: var(--panel-bg);
   backdrop-filter: blur(10px);
-  border-radius: 12px;
+  border-radius: var(--hud-radius);
   border: 1px solid var(--panel-border);
 }
 

--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -68,12 +68,12 @@
 .button {
   background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
 }
 
@@ -92,7 +92,7 @@
 .input {
   background: var(--color-modal-bg-dark);
   border: 1px solid var(--color-neon);
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm);
   width: 100%;

--- a/src/components/CharacterAvatar.module.css
+++ b/src/components/CharacterAvatar.module.css
@@ -1,8 +1,8 @@
 .avatarContainer {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
-  border-radius: 12px;
-  padding: 20px;
+  border-radius: var(--hud-radius);
+  padding: var(--hud-spacing);
   border: 1px solid rgba(0, 255, 136, 0.3);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
   display: flex;

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -1,8 +1,8 @@
 .panel {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
-  border-radius: 12px;
-  padding: 20px;
+  border-radius: var(--hud-radius);
+  padding: var(--hud-spacing);
   border: 1px solid rgba(0, 255, 136, 0.3);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
@@ -23,7 +23,7 @@
 .statItem {
   text-align: center;
   background: rgba(0, 0, 0, 0.3);
-  padding: 10px;
+  padding: var(--hud-spacing-sm);
   border-radius: 8px;
   border: 1px solid rgba(0, 255, 136, 0.3);
 }
@@ -43,7 +43,7 @@
   width: 100%;
   height: 25px;
   background: var(--color-gray-800);
-  border-radius: 12px;
+  border-radius: var(--hud-radius);
   overflow: hidden;
   border: 2px solid var(--color-gray-700);
   margin: 10px 0;
@@ -68,12 +68,12 @@
 .button {
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
 }
 
@@ -126,7 +126,7 @@
 .minusButton {
   background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
@@ -138,7 +138,7 @@
 .plusButton {
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
@@ -161,12 +161,12 @@
 .chronoButton {
   background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   width: 100%;
 }
 
@@ -179,8 +179,8 @@
 .warningBox {
   background: var(--overlay-warning);
   border: 1px solid var(--color-warning);
-  border-radius: 6px;
-  padding: 10px;
+  border-radius: var(--hud-radius-sm);
+  padding: var(--hud-spacing-sm);
   text-align: center;
   margin-top: 10px;
 }
@@ -194,12 +194,12 @@
 .resetButton {
   background: linear-gradient(45deg, var(--color-info-light), var(--color-accent));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: 10px 20px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   width: 100%;
   margin-top: var(--space-md);
 }

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -32,7 +32,7 @@
 .input {
   background: var(--color-modal-bg-dark);
   border: 1px solid var(--color-neon);
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm);
   width: 100%;
@@ -60,12 +60,12 @@
 .button {
   background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
 }
 

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -1,8 +1,8 @@
 .panel {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
-  border-radius: 12px;
-  padding: 20px;
+  border-radius: var(--hud-radius);
+  padding: var(--hud-spacing);
   border: 1px solid rgba(0, 255, 136, 0.3);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
@@ -44,12 +44,12 @@
 .button {
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
 }
 
@@ -87,8 +87,8 @@
 
 .resultBox {
   background: rgba(0, 255, 136, 0.2);
-  padding: 10px;
-  border-radius: 6px;
+  padding: var(--hud-spacing-sm);
+  border-radius: var(--hud-radius-sm);
   text-align: center;
   font-weight: bold;
   min-height: 40px;

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -92,12 +92,12 @@
 .button {
   background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
 }
 

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -28,7 +28,7 @@
 .input {
   background: var(--color-modal-bg-dark);
   border: 1px solid var(--color-neon);
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm);
   width: 100%;
@@ -56,11 +56,11 @@
 .button {
   background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
 }

--- a/src/components/InventoryModal.module.css
+++ b/src/components/InventoryModal.module.css
@@ -15,7 +15,7 @@
   background: var(--color-bg-primary);
   border: 2px solid var(--color-accent);
   border-radius: 15px;
-  padding: 20px;
+  padding: var(--hud-spacing);
   max-width: 500px;
   width: 100%;
   max-height: 80vh;
@@ -84,7 +84,7 @@
 .inventoryButton {
   background: linear-gradient(45deg, var(--color-purple), var(--color-purple-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -1,8 +1,8 @@
 .panel {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
-  border-radius: 12px;
-  padding: 20px;
+  border-radius: var(--hud-radius);
+  padding: var(--hud-spacing);
   border: 1px solid rgba(0, 255, 136, 0.3);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
@@ -22,7 +22,7 @@
   background: rgba(0, 0, 0, 0.3);
   padding: var(--space-sm) 12px;
   margin: 5px 0;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   border-left: 3px solid var(--color-neon);
 }
 
@@ -94,7 +94,7 @@
 
 .debilitiesSection {
   margin-top: 15px;
-  padding-top: 10px;
+  padding-top: var(--hud-spacing-sm);
   border-top: 1px solid rgba(0, 255, 136, 0.3);
 }
 

--- a/src/components/LastBreathModal.module.css
+++ b/src/components/LastBreathModal.module.css
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: var(--hud-spacing);
 }
 
 .modal {
@@ -43,10 +43,10 @@
 .button {
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: white;
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
 }

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -11,7 +11,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 20px;
+    padding: var(--hud-spacing);
     overflow-y: auto;
   }
 
@@ -28,7 +28,7 @@
 
   .levelup-header {
     background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
-    padding: 20px;
+    padding: var(--hud-spacing);
     border-radius: 13px 13px 0 0;
     text-align: center;
     position: relative;
@@ -60,14 +60,14 @@
   }
 
   .levelup-content {
-    padding: 20px;
+    padding: var(--hud-spacing);
   }
 
   .levelup-progress {
     display: flex;
     justify-content: space-between;
     margin-bottom: 20px;
-    padding: 10px;
+    padding: var(--hud-spacing-sm);
     background: rgba(0, 255, 136, 0.1);
     border-radius: 8px;
     border: 1px solid rgba(0, 255, 136, 0.3);
@@ -114,14 +114,14 @@
   }
 
   .levelup-stat-button {
-    padding: 10px;
+    padding: var(--hud-spacing-sm);
     border: 2px solid var(--color-gray-700);
     border-radius: 8px;
     background: var(--color-modal-bg);
     color: var(--color-gray-100);
     cursor: pointer;
     text-align: center;
-    transition: all 0.3s ease;
+    transition: var(--hud-transition);
     font-size: 14px;
   }
 
@@ -162,7 +162,7 @@
     padding: var(--space-sm) 12px;
     background: rgba(0, 255, 136, 0.1);
     border: 1px solid rgba(0, 255, 136, 0.3);
-    border-radius: 6px;
+    border-radius: var(--hud-radius-sm);
     font-size: 14px;
     color: var(--color-neon);
   }
@@ -191,7 +191,7 @@
     color: var(--color-gray-100);
     cursor: pointer;
     text-align: left;
-    transition: all 0.3s ease;
+    transition: var(--hud-transition);
     margin-bottom: var(--space-sm);
   }
 
@@ -237,7 +237,7 @@
     padding: 12px;
     background: rgba(0, 255, 136, 0.05);
     border: 1px solid rgba(0, 255, 136, 0.2);
-    border-radius: 6px;
+    border-radius: var(--hud-radius-sm);
     margin-left: 10px;
     font-size: var(--font-size-sm);
   }
@@ -267,10 +267,10 @@
     border: none;
     color: var(--color-white);
     padding: 10px 20px;
-    border-radius: 6px;
+    border-radius: var(--hud-radius-sm);
     cursor: pointer;
     font-weight: bold;
-    transition: all 0.3s ease;
+    transition: var(--hud-transition);
     font-size: 14px;
   }
 

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: var(--hud-spacing);
 }
 
 .modal {
@@ -24,7 +24,7 @@
 
 .header {
   text-align: center;
-  padding: 20px;
+  padding: var(--hud-spacing);
   background: linear-gradient(45deg, var(--color-blue-deep), var(--color-purple-deep));
   border-radius: 13px 13px 0 0;
 }
@@ -89,11 +89,11 @@
 .button {
   background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
 }

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -1,8 +1,8 @@
 .panel {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
-  border-radius: 12px;
-  padding: 20px;
+  border-radius: var(--hud-radius);
+  padding: var(--hud-spacing);
   border: 1px solid rgba(0, 255, 136, 0.3);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
 }
@@ -18,9 +18,9 @@
   height: 120px;
   background: rgba(0, 0, 0, 0.3);
   border: 1px solid rgba(0, 255, 136, 0.3);
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-gray-100);
-  padding: 10px;
+  padding: var(--hud-spacing-sm);
   resize: vertical;
   font-family: inherit;
   font-size: 0.9rem;
@@ -41,12 +41,12 @@
 .button {
   background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   display: flex;
   align-items: center;
   gap: 5px;

--- a/src/components/StatusModal.module.css
+++ b/src/components/StatusModal.module.css
@@ -15,7 +15,7 @@
   background: var(--color-bg-primary);
   border: 2px solid var(--color-accent);
   border-radius: 15px;
-  padding: 20px;
+  padding: var(--hud-spacing);
   max-width: 500px;
   width: 100%;
   max-height: 80vh;
@@ -47,7 +47,7 @@
 .statusButton {
   background: linear-gradient(45deg, var(--color-warning), var(--color-warning-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -2,7 +2,7 @@
   min-height: 100vh;
   background: linear-gradient(135deg, var(--color-bg-start), var(--color-bg-end));
   color: var(--color-text);
-  padding: 20px;
+  padding: var(--hud-spacing);
   font-family: var(--font-body);
   font-size: var(--font-size-body);
   font-weight: var(--font-weight-body);
@@ -16,11 +16,11 @@
 .header {
   text-align: center;
   margin-bottom: 30px;
-  padding: 20px;
+  padding: var(--hud-spacing);
   border-radius: 15px;
   border: 2px solid var(--color-accent);
   box-shadow: 0 0 20px var(--glow-shadow);
-  transition: all 0.5s ease;
+  transition: var(--hud-transition-slow);
 }
 
 .headerTop {
@@ -77,12 +77,12 @@
 .button {
   background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
-  border-radius: 6px;
+  border-radius: var(--hud-radius-sm);
   color: white;
   padding: var(--space-sm) 15px;
   cursor: pointer;
   font-weight: bold;
-  transition: all 0.3s ease;
+  transition: var(--hud-transition);
   margin: 5px;
   display: flex;
   align-items: center;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -15,6 +15,15 @@
   --space-sm: 0.5rem;
   --space-md: 1rem;
 
+  /* HUD layout tokens */
+  --hud-radius: 0.75rem;
+  --hud-radius-sm: 0.375rem;
+  --hud-spacing: 1.25rem;
+  --hud-spacing-sm: 0.625rem;
+  --hud-transition-fast: all 150ms ease-in-out;
+  --hud-transition: all 300ms ease-in-out;
+  --hud-transition-slow: all 500ms ease-in-out;
+
   --color-bg-start: #0b0d17;
   --color-bg-end: #1a1f38;
   --color-text: #d0d7e2;
@@ -125,6 +134,15 @@
   --color-bg-end: #dcdcdc;
   --color-text: #222222;
 
+  /* HUD layout tokens */
+  --hud-radius: 0.5rem;
+  --hud-radius-sm: 0.25rem;
+  --hud-spacing: 1rem;
+  --hud-spacing-sm: 0.5rem;
+  --hud-transition-fast: all 100ms ease-in-out;
+  --hud-transition: all 250ms ease-in-out;
+  --hud-transition-slow: all 400ms ease-in-out;
+
   --color-accent: #0066cc;
   --color-accent-dark: #004a99;
   --color-accent-darker: #003366;
@@ -224,6 +242,15 @@
   --color-bg-start: #f2e9e4;
   --color-bg-end: #e4d2cc;
   --color-text: #2d2a26;
+
+  /* HUD layout tokens */
+  --hud-radius: 0.75rem;
+  --hud-radius-sm: 0.375rem;
+  --hud-spacing: 1.5rem;
+  --hud-spacing-sm: 0.75rem;
+  --hud-transition-fast: all 200ms ease-in-out;
+  --hud-transition: all 350ms ease-in-out;
+  --hud-transition-slow: all 600ms ease-in-out;
 
   --color-accent: #27a9a1;
   --color-accent-dark: #1e827c;


### PR DESCRIPTION
## Summary
- add HUD radius, spacing and transition tokens
- document HUD theme tokens and provide light-theme overrides
- refactor HUD styles to consume the new tokens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5f38db6083329823350d9447743f