### PR TITLE
feat: add animated character HUD

### DIFF
--- a/src/components/CharacterHUD/index.jsx
+++ b/src/components/CharacterHUD/index.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styles from './index.module.css';
+
+export const LOW_HP_THRESHOLD = 0.3;
+
+export default function CharacterHUD({
+  isCasting = false,
+  castPercent = 0,
+  hp = 0,
+  maxHp = 0,
+  effects = [],
+}) {
+  const classes = [];
+
+  if (isCasting) {
+    classes.push(styles.casting);
+    classes.push(castPercent >= 100 ? styles.castComplete : styles.castProgress);
+  }
+
+  if (maxHp > 0 && hp / maxHp < LOW_HP_THRESHOLD) {
+    classes.push(styles.lowHp);
+  }
+
+  const effectClassMap = {
+    poisoned: styles.effectPoisoned,
+    burning: styles.effectBurning,
+    shocked: styles.effectShocked,
+    frozen: styles.effectFrozen,
+    blessed: styles.effectBlessed,
+  };
+
+  effects.forEach((effect) => {
+    const cls = effectClassMap[effect];
+    if (cls) classes.push(cls);
+  });
+
+  const className = [styles.hud, ...classes].join(' ');
+
+  return (
+    <div data-testid="hud" className={className} style={{ '--cast-percent': castPercent }}>
+      <svg className={styles.svg} viewBox="0 0 100 100">
+        <circle className={styles.health} cx="50" cy="50" r="45" />
+        <circle className={styles.castBar} cx="50" cy="50" r="40" />
+      </svg>
+    </div>
+  );
+}

--- a/src/components/CharacterHUD/index.module.css
+++ b/src/components/CharacterHUD/index.module.css
@@ -1,0 +1,113 @@
+.hud {
+  width: 100px;
+  height: 100px;
+  position: relative;
+  display: inline-block;
+}
+
+.svg {
+  width: 100%;
+  height: 100%;
+  transform: rotate(-90deg);
+}
+
+.health {
+  fill: none;
+  stroke: var(--color-success);
+  stroke-width: 10;
+}
+
+.castBar {
+  fill: none;
+  stroke: var(--color-accent);
+  stroke-width: 5;
+  stroke-dasharray: 251;
+  stroke-dashoffset: calc(251 - (var(--cast-percent) / 100) * 251);
+  transition: stroke-dashoffset 0.3s linear;
+  transform-origin: 50% 50%;
+}
+
+.casting .castBar {
+  animation: spin 2s linear infinite;
+}
+
+.castProgress .castBar {
+  stroke: var(--color-accent);
+}
+
+.castComplete .castBar {
+  stroke: var(--color-success);
+  animation: none;
+}
+
+.lowHp .health {
+  stroke: var(--color-danger);
+  animation: lowHpPulse 1s infinite;
+}
+
+.effectPoisoned,
+.effectBurning,
+.effectShocked,
+.effectFrozen,
+.effectBlessed {
+  animation: effectPulse 2s infinite;
+}
+
+.effectPoisoned {
+  --effect-color: var(--overlay-poison);
+}
+
+.effectBurning {
+  --effect-color: var(--overlay-burning);
+}
+
+.effectShocked {
+  --effect-color: var(--overlay-shocked-blue);
+}
+
+.effectFrozen {
+  --effect-color: var(--overlay-frozen);
+}
+
+.effectBlessed {
+  --effect-color: var(--overlay-blessed);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes lowHpPulse {
+  0%,
+  100% {
+    stroke-width: 10;
+  }
+  50% {
+    stroke-width: 8;
+  }
+}
+
+@keyframes effectPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 5px var(--effect-color);
+  }
+  50% {
+    box-shadow: 0 0 15px var(--effect-color);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .casting .castBar,
+  .lowHp .health,
+  .effectPoisoned,
+  .effectBurning,
+  .effectShocked,
+  .effectFrozen,
+  .effectBlessed {
+    animation: none;
+    transition: none;
+  }
+}

--- a/src/components/CharacterHUD/index.test.jsx
+++ b/src/components/CharacterHUD/index.test.jsx
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import CharacterHUD, { LOW_HP_THRESHOLD } from './index.jsx';
+import styles from './index.module.css';
+
+describe('CharacterHUD', () => {
+  it('applies casting and progress classes', () => {
+    render(<CharacterHUD isCasting castPercent={50} hp={10} maxHp={10} effects={[]} />);
+    const hud = screen.getByTestId('hud');
+    expect(hud).toHaveClass(styles.casting);
+    expect(hud).toHaveClass(styles.castProgress);
+  });
+
+  it('applies cast complete class when castPercent is 100', () => {
+    render(<CharacterHUD isCasting castPercent={100} hp={10} maxHp={10} effects={[]} />);
+    const hud = screen.getByTestId('hud');
+    expect(hud).toHaveClass(styles.castComplete);
+  });
+
+  it('applies low hp class when below threshold', () => {
+    const maxHp = 10;
+    const hp = Math.floor(maxHp * LOW_HP_THRESHOLD) - 1;
+    render(<CharacterHUD hp={hp} maxHp={maxHp} />);
+    const hud = screen.getByTestId('hud');
+    expect(hud).toHaveClass(styles.lowHp);
+  });
+
+  it('applies effect classes based on effects array', () => {
+    render(<CharacterHUD effects={['poisoned', 'burning']} />);
+    const hud = screen.getByTestId('hud');
+    expect(hud).toHaveClass(styles.effectPoisoned);
+    expect(hud).toHaveClass(styles.effectBurning);
+  });
+});


### PR DESCRIPTION
## Summary
- map casting, low HP, and status effects to HUD classes
- animate HUD states with CSS/SVG and reduced-motion fallbacks
- test HUD class application for state flags

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5f3f3e58833287a5a858274c0494