### PR TITLE
feat: add performance metrics hud

### DIFF
--- a/docs/hud-performance.md
+++ b/docs/hud-performance.md
@@ -1,0 +1,39 @@
+# Performance HUD
+
+A development-only performance monitor is available for tracking render
+metrics of React components.
+
+## Enabling the HUD
+
+1. Create a `.env` file and set the flag:
+
+```bash
+VITE_SHOW_PERFORMANCE_HUD=true
+```
+
+2. Start the dev server:
+
+```bash
+npm run dev
+```
+
+The overlay will appear in the bottom-right corner showing the latest
+render duration and approximate update frequency.
+
+## Hook Usage
+
+The HUD uses the `usePerformanceMetrics` hook, which you can also use
+within components to access the same metrics:
+
+```js
+import usePerformanceMetrics from '../hooks/usePerformanceMetrics.js';
+
+function MyComponent() {
+  const metrics = usePerformanceMetrics();
+  // metrics.current.renderDuration and metrics.current.updatesPerSecond
+}
+```
+
+This hook measures how long the component took to render and how often
+it updates. It is designed for development diagnostics and is excluded
+from production builds.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, lazy, Suspense } from 'react';
 import './App.css';
 import {
   FaMeteor,
@@ -24,6 +24,11 @@ import useUndo from './hooks/useUndo.js';
 import { statusEffectTypes, debilityTypes, RULEBOOK } from './state/character';
 import { useCharacter } from './state/CharacterContext.jsx';
 import styles from './styles/AppStyles.module.css';
+
+const PerformanceHud =
+  import.meta.env.DEV && import.meta.env.VITE_SHOW_PERFORMANCE_HUD === 'true'
+    ? lazy(() => import('./components/PerformanceHud.jsx'))
+    : null;
 
 function App() {
   const { character, setCharacter } = useCharacter();
@@ -260,6 +265,11 @@ function App() {
         setShowEndSessionModal={setShowEndSessionModal}
         bondsModal={bondsModal}
       />
+      {PerformanceHud && (
+        <Suspense fallback={null}>
+          <PerformanceHud />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/src/components/PerformanceHud.jsx
+++ b/src/components/PerformanceHud.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import usePerformanceMetrics from '../hooks/usePerformanceMetrics.js';
+
+const styles = {
+  position: 'fixed',
+  bottom: '10px',
+  right: '10px',
+  background: 'rgba(0, 0, 0, 0.7)',
+  color: '#0f0',
+  padding: '8px',
+  fontFamily: 'monospace',
+  fontSize: '12px',
+  zIndex: 9999,
+};
+
+export default function PerformanceHud() {
+  const metrics = usePerformanceMetrics();
+  const [, forceUpdate] = useState(0);
+
+  useEffect(() => {
+    let frame;
+    const update = () => {
+      forceUpdate((n) => n + 1);
+      frame = requestAnimationFrame(update);
+    };
+    frame = requestAnimationFrame(update);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  return (
+    <div style={styles}>
+      <div>Render: {metrics.current.renderDuration.toFixed(2)} ms</div>
+      <div>Update: {metrics.current.updatesPerSecond.toFixed(2)} /s</div>
+    </div>
+  );
+}

--- a/src/hooks/usePerformanceMetrics.js
+++ b/src/hooks/usePerformanceMetrics.js
@@ -1,0 +1,21 @@
+import { useRef, useEffect } from 'react';
+
+export default function usePerformanceMetrics() {
+  const metricsRef = useRef({ renderDuration: 0, updatesPerSecond: 0 });
+  const startRef = useRef(performance.now());
+  const lastRenderRef = useRef(performance.now());
+
+  startRef.current = performance.now();
+
+  useEffect(() => {
+    const now = performance.now();
+    const renderDuration = now - startRef.current;
+    const delta = now - lastRenderRef.current;
+    const updatesPerSecond = delta > 0 ? 1000 / delta : 0;
+
+    metricsRef.current = { renderDuration, updatesPerSecond };
+    lastRenderRef.current = now;
+  });
+
+  return metricsRef;
+}

--- a/src/hooks/usePerformanceMetrics.test.jsx
+++ b/src/hooks/usePerformanceMetrics.test.jsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import usePerformanceMetrics from './usePerformanceMetrics.js';
+
+function TestComponent({ onUpdate }) {
+  const metrics = usePerformanceMetrics();
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    onUpdate({ ...metrics.current });
+    if (count === 0) setCount(1);
+  });
+
+  return null;
+}
+
+describe('usePerformanceMetrics', () => {
+  it('records render metrics', async () => {
+    const calls = [];
+    render(<TestComponent onUpdate={(m) => calls.push(m)} />);
+
+    await waitFor(() => {
+      expect(calls.length).toBeGreaterThan(1);
+    });
+
+    const last = calls.at(-1);
+    expect(last.renderDuration).toBeGreaterThanOrEqual(0);
+    expect(last.updatesPerSecond).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add `usePerformanceMetrics` hook for render duration and update frequency
- show metrics in dev-only PerformanceHud overlay toggled by `VITE_SHOW_PERFORMANCE_HUD`
- document HUD usage in `docs/hud-performance.md`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5f446f708332b393bc4bcc29062c