### PR TITLE
feat: add status tray component with timer hook

### DIFF
--- a/src/components/StatusTray.jsx
+++ b/src/components/StatusTray.jsx
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import { statusEffectTypes } from '../state/character.js';
+import useThrottledTimer from '../hooks/useThrottledTimer.js';
+import styles from './StatusTray.module.css';
+
+const StatusTray = ({ statusEffects, onEffectClick }) => {
+  const now = useThrottledTimer();
+  const sorted = [...statusEffects].sort((a, b) => (b.priority || 0) - (a.priority || 0));
+
+  return (
+    <div className={styles.tray} role="list">
+      {sorted.map((effect) => {
+        const type = statusEffectTypes[effect.type] || {};
+        const Icon = type.icon;
+        const remaining = effect.expiresAt
+          ? Math.max(0, Math.ceil((effect.expiresAt - now) / 1000))
+          : null;
+        return (
+          <button
+            key={effect.id}
+            type="button"
+            className={styles.chip}
+            aria-label={type.name || effect.type}
+            onClick={() => onEffectClick(effect.id)}
+          >
+            {Icon && <Icon className={styles.icon} aria-hidden="true" />}
+            {effect.stacks > 1 && <span className={styles.badge}>{effect.stacks}</span>}
+            {remaining !== null && <span className={styles.countdown}>{remaining}</span>}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+StatusTray.propTypes = {
+  statusEffects: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+      stacks: PropTypes.number,
+      expiresAt: PropTypes.number,
+      priority: PropTypes.number,
+    }),
+  ).isRequired,
+  onEffectClick: PropTypes.func.isRequired,
+};
+
+export default StatusTray;

--- a/src/components/StatusTray.module.css
+++ b/src/components/StatusTray.module.css
@@ -1,0 +1,38 @@
+.tray {
+  display: flex;
+  overflow-x: auto;
+  gap: 8px;
+  padding: 4px;
+}
+
+.chip {
+  position: relative;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.icon {
+  width: 24px;
+  height: 24px;
+}
+
+.badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: red;
+  color: white;
+  border-radius: 50%;
+  font-size: 10px;
+  padding: 2px 4px;
+}
+
+.countdown {
+  margin-left: 4px;
+  font-size: 12px;
+}

--- a/src/components/StatusTray.test.jsx
+++ b/src/components/StatusTray.test.jsx
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import StatusTray from './StatusTray.jsx';
+
+vi.useFakeTimers();
+
+const baseNow = Date.now();
+vi.setSystemTime(baseNow);
+
+const effects = [
+  {
+    id: '1',
+    type: 'poisoned',
+    stacks: 2,
+    expiresAt: baseNow + 3000,
+    priority: 1,
+  },
+  {
+    id: '2',
+    type: 'burning',
+    stacks: 1,
+    expiresAt: baseNow + 5000,
+    priority: 2,
+  },
+];
+
+test('orders effects by priority and handles clicks', () => {
+  const onEffectClick = vi.fn();
+  render(<StatusTray statusEffects={effects} onEffectClick={onEffectClick} />);
+
+  const buttons = screen.getAllByRole('button');
+  expect(buttons[0]).toHaveAccessibleName('Burning');
+  expect(buttons[1]).toHaveAccessibleName('Poisoned');
+
+  fireEvent.click(buttons[0]);
+  expect(onEffectClick).toHaveBeenCalledWith('2');
+});
+
+test('updates countdown over time', () => {
+  render(<StatusTray statusEffects={effects} onEffectClick={() => {}} />);
+  const burning = screen.getByLabelText('Burning');
+  const initial = burning.textContent;
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  expect(burning.textContent).not.toBe(initial);
+});

--- a/src/hooks/useThrottledTimer.js
+++ b/src/hooks/useThrottledTimer.js
@@ -1,0 +1,36 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useThrottledTimer(intervalMs = 1000) {
+  const [now, setNow] = useState(Date.now());
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    const start = () => {
+      clearInterval(timerRef.current);
+      timerRef.current = setInterval(() => {
+        setNow(Date.now());
+      }, intervalMs);
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        clearInterval(timerRef.current);
+      } else {
+        start();
+      }
+    };
+
+    if (!document.hidden) {
+      start();
+    }
+
+    window.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      clearInterval(timerRef.current);
+      window.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [intervalMs]);
+
+  return now;
+}

--- a/src/hooks/useThrottledTimer.test.jsx
+++ b/src/hooks/useThrottledTimer.test.jsx
@@ -1,0 +1,16 @@
+/* eslint-env jest */
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import useThrottledTimer from './useThrottledTimer.js';
+
+vi.useFakeTimers();
+
+it('updates time on interval', () => {
+  const { result } = renderHook(() => useThrottledTimer(1000));
+  const first = result.current;
+  act(() => {
+    vi.advanceTimersByTime(1000);
+  });
+  const second = result.current;
+  expect(second).toBeGreaterThan(first);
+});


### PR DESCRIPTION
## Summary
- render status effects as focusable chips with icons, stack counts and live countdowns
- throttle status countdown updates with a visibility-aware timer hook
- add tests for status tray ordering/clicks and timer ticks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d5f32e47483328382af0332761f97