### PR TITLE
fix(theme): use safe local storage in context

### DIFF
--- a/src/state/ThemeContext.jsx
+++ b/src/state/ThemeContext.jsx
@@ -1,15 +1,16 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { THEMES, DEFAULT_THEME } from './theme.js';
+import safeLocalStorage from '../utils/safeLocalStorage.js';
 
 const ThemeContext = createContext();
 
 export const ThemeProvider = ({ children }) => {
-  const [theme, setTheme] = useState(() => localStorage.getItem('theme') || DEFAULT_THEME);
+  const [theme, setTheme] = useState(() => safeLocalStorage.getItem('theme', DEFAULT_THEME));
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
 
-    localStorage.setItem('theme', theme);
+    safeLocalStorage.setItem('theme', theme);
   }, [theme]);
 
   const value = { theme, setTheme, themes: THEMES };


### PR DESCRIPTION
## Summary
- use safeLocalStorage for ThemeContext persistence
- mock safeLocalStorage in ThemeContext tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d6090baa88332a7a569f058be5cc4