### PR TITLE
feat(notes): centralize file name and mock file storage

### DIFF
--- a/src/components/SessionNotes.jsx
+++ b/src/components/SessionNotes.jsx
@@ -12,6 +12,8 @@ import {
 } from 'react-icons/fa6';
 import styles from './SessionNotes.module.css';
 
+const NOTES_FILE = 'session_notes.txt';
+
 const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMode }) => {
   const [warning, setWarning] = useState('');
 
@@ -50,7 +52,7 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
           className={styles.button}
           onClick={async () => {
             try {
-              await saveFile('session_notes.txt', sessionNotes);
+              await saveFile(NOTES_FILE, sessionNotes);
             } catch {
               setWarning('Persistence unavailable; notes may not be saved.');
             }
@@ -62,7 +64,7 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
           className={styles.button}
           onClick={async () => {
             try {
-              const contents = await loadFile('session_notes.txt');
+              const contents = await loadFile(NOTES_FILE);
               setSessionNotes(contents);
             } catch {
               setWarning('Persistence unavailable; notes may not be loaded.');

--- a/src/components/SessionNotes.test.jsx
+++ b/src/components/SessionNotes.test.jsx
@@ -12,6 +12,8 @@ vi.mock('../utils/fileStorage.js', () => ({
   loadFile: vi.fn(),
 }));
 
+const NOTES_FILE = 'session_notes.txt';
+
 describe('SessionNotes', () => {
   it('updates notes when typing', async () => {
     const user = userEvent.setup();
@@ -88,7 +90,7 @@ describe('SessionNotes', () => {
       />,
     );
     await user.click(screen.getByRole('button', { name: /Save/i }));
-    expect(saveFile).toHaveBeenCalledWith('session_notes.txt', 'hello');
+    expect(saveFile).toHaveBeenCalledWith(NOTES_FILE, 'hello');
   });
 
   it('loads notes using fileStorage', async () => {
@@ -104,7 +106,7 @@ describe('SessionNotes', () => {
       />,
     );
     await user.click(screen.getByRole('button', { name: /Load/i }));
-    expect(loadFile).toHaveBeenCalledWith('session_notes.txt');
+    expect(loadFile).toHaveBeenCalledWith(NOTES_FILE);
     expect(setSessionNotes).toHaveBeenCalledWith('loaded');
   });
 


### PR DESCRIPTION
## Summary
- centralize session notes file name constant
- mock file storage in SessionNotes tests

## Testing
- `npm run lint`
- `npm test src/components/SessionNotes.test.jsx`
- `npm test` *(fails: getStatusEffectImage is not a function, useSettings must be used within a SettingsProvider)*

------
https://chatgpt.com/codex/tasks/task_e_689d633606fc83329bf9242fb75e3ba1