### PR TITLE
test: inject settings context for dice roller

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -29,7 +29,7 @@ afterEach(() => {
 });
 
 const createWrapper =
-  (initialCharacter, autoXpOnMiss = true) =>
+  (initialCharacter, autoXpOnMiss) =>
   ({ children }) => {
     const [character, setCharacter] = React.useState(initialCharacter);
     return (
@@ -52,7 +52,7 @@ describe('App level up auto-detection', () => {
       return (
         <ThemeProvider>
           <CharacterContext.Provider value={{ character, setCharacter: setChar }}>
-            <SettingsProvider initialAutoXpOnMiss>{children}</SettingsProvider>
+            <SettingsProvider initialAutoXpOnMiss={true}>{children}</SettingsProvider>
           </CharacterContext.Provider>
         </ThemeProvider>
       );
@@ -125,7 +125,7 @@ describe('XP gain on miss', () => {
 describe('End session flow', () => {
   it('opens EndSessionModal when End Session button is clicked', () => {
     const initialCharacter = { ...INITIAL_CHARACTER_DATA, xp: 0, xpNeeded: 5, bonds: [] };
-    const Wrapper = createWrapper(initialCharacter);
+    const Wrapper = createWrapper(initialCharacter, true);
 
     render(
       <Wrapper>
@@ -144,7 +144,7 @@ describe('End session flow', () => {
 });
 
 describe('Rulebook display', () => {
-  const Wrapper = createWrapper(INITIAL_CHARACTER_DATA);
+  const Wrapper = createWrapper(INITIAL_CHARACTER_DATA, true);
 
   it('renders the rulebook name in the header', () => {
     render(
@@ -159,7 +159,7 @@ describe('Rulebook display', () => {
 
 // Skipped in Vitest environment due to jsdom localStorage limitations
 describe.skip('localStorage persistence', () => {
-  const Wrapper = createWrapper(INITIAL_CHARACTER_DATA);
+  const Wrapper = createWrapper(INITIAL_CHARACTER_DATA, true);
 
   beforeEach(() => {
     localStorage.clear();
@@ -236,7 +236,7 @@ describe('Theme switching', () => {
   it('updates the theme attribute when selecting classic', () => {
     render(
       <ThemeProvider>
-        <SettingsProvider initialAutoXpOnMiss>
+        <SettingsProvider initialAutoXpOnMiss={true}>
           <Settings />
         </SettingsProvider>
       </ThemeProvider>,
@@ -255,7 +255,7 @@ describe('Theme switching', () => {
   it('updates the theme attribute when selecting moebius', () => {
     render(
       <ThemeProvider>
-        <SettingsProvider initialAutoXpOnMiss>
+        <SettingsProvider initialAutoXpOnMiss={true}>
           <Settings />
         </SettingsProvider>
       </ThemeProvider>,
@@ -279,7 +279,7 @@ describe('App header', () => {
         <CharacterContext.Provider
           value={{ character: INITIAL_CHARACTER_DATA, setCharacter: () => {} }}
         >
-          <SettingsProvider initialAutoXpOnMiss>
+          <SettingsProvider initialAutoXpOnMiss={true}>
             <App />
           </SettingsProvider>
         </CharacterContext.Provider>

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -13,7 +13,7 @@ const Wrapper = ({ children }) => {
   return (
     <ThemeProvider>
       <CharacterContext.Provider value={{ character, setCharacter }}>
-        <SettingsProvider initialAutoXpOnMiss>{children}</SettingsProvider>
+        <SettingsProvider initialAutoXpOnMiss={true}>{children}</SettingsProvider>
       </CharacterContext.Provider>
     </ThemeProvider>
   );

--- a/src/HudAccessibility.test.jsx
+++ b/src/HudAccessibility.test.jsx
@@ -6,6 +6,7 @@ import App from './App.jsx';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
 import CharacterContext from './state/CharacterContext.jsx';
 import { ThemeProvider } from './state/ThemeContext.jsx';
+import { SettingsProvider } from './state/SettingsContext.jsx';
 
 function renderApp(overrides = {}) {
   const initialCharacter = { ...INITIAL_CHARACTER_DATA, ...overrides };
@@ -14,7 +15,7 @@ function renderApp(overrides = {}) {
     return (
       <ThemeProvider>
         <CharacterContext.Provider value={{ character, setCharacter }}>
-          {children}
+          <SettingsProvider initialAutoXpOnMiss={true}>{children}</SettingsProvider>
         </CharacterContext.Provider>
       </ThemeProvider>
     );

--- a/src/hooks/useDiceRoller.aid.test.jsx
+++ b/src/hooks/useDiceRoller.aid.test.jsx
@@ -12,7 +12,7 @@ const wrapper = ({ children }) => (
 describe('useDiceRoller aid/interfere', () => {
   const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
 
-  it('applies modifiers and enforces helper consequences on 7-9', () => {
+  it('applies modifiers and enforces helper consequences on 7-9', async () => {
     const setCharacter = vi.fn();
     const confirmSpy = vi.spyOn(window, 'confirm');
     confirmSpy.mockReturnValueOnce(true); // someone aids or interferes
@@ -27,8 +27,8 @@ describe('useDiceRoller aid/interfere', () => {
       .mockReturnValueOnce(4); // aid roll: 7
 
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter), { wrapper });
-    act(() => {
-      result.current.rollDice('2d6', 'test');
+    await act(async () => {
+      await result.current.rollDice('2d6', 'test');
     });
 
     expect(confirmSpy).toHaveBeenCalledTimes(2);

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -248,7 +248,7 @@ describe('useDiceRoller safe localStorage handling', () => {
 describe('useDiceRoller XP on miss handling', () => {
   const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
 
-  it('does not grant XP when autoXpOnMiss is false', () => {
+  it('does not grant XP when autoXpOnMiss is false', async () => {
     localStorage.clear();
     const setCharacter = vi.fn();
     const noXpWrapper = getWrapper(false);

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -6,6 +6,3 @@ if (!globalThis.crypto) {
 }
 
 import '@testing-library/jest-dom/vitest';
-
-// Enable automatic XP gain on a miss during tests
-globalThis.autoXpOnMiss = true;


### PR DESCRIPTION
## Summary
- remove legacy global autoXpOnMiss test hook
- pass autoXpOnMiss through SettingsProvider in component and hook tests
- fix dice roller tests to await async operations

## Testing
- `npm run lint`
- `npm test` *(fails: transform errors and missing functions in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_689d633a3b148332bbb30f043766bf1d