### PR TITLE
test: add settings context tests

### DIFF
--- a/src/state/SettingsContext.test.jsx
+++ b/src/state/SettingsContext.test.jsx
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { SettingsProvider, useSettings } from './SettingsContext.jsx';
+
+describe('SettingsContext', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    // Save and reset environment variable before each test
+    originalEnv = { ...import.meta.env };
+    import.meta.env.VITE_AUTO_XP_ON_MISS = 'true';
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    import.meta.env = { ...originalEnv };
+  });
+
+  it('uses default autoXpOnMiss from env and updates with setAutoXpOnMiss', () => {
+    const wrapper = ({ children }) => <SettingsProvider>{children}</SettingsProvider>;
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    expect(result.current.autoXpOnMiss).toBe(true);
+    act(() => {
+      result.current.setAutoXpOnMiss(false);
+    });
+    expect(result.current.autoXpOnMiss).toBe(false);
+  });
+
+  it('honors initialAutoXpOnMiss prop and updates correctly', () => {
+    const wrapper = ({ children }) => (
+      <SettingsProvider initialAutoXpOnMiss={false}>{children}</SettingsProvider>
+    );
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    expect(result.current.autoXpOnMiss).toBe(false);
+    act(() => {
+      result.current.setAutoXpOnMiss(true);
+    });
+    expect(result.current.autoXpOnMiss).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for SettingsProvider defaults and updates

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError: getStatusEffectImage is not a function, ReferenceError: diceUtils is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689d6724b1948332a057a4a471329f6d