### PR TITLE
chore: remove husky init lines from pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
## Summary
- simplify husky pre-commit to run lint-staged directly
- keep hook script executable

## Testing
- `npm run lint`
- `npm test` *(fails: getStatusEffectImage is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689d68cf7a288332a616785b958b6fde