### PR TITLE
test: verify SettingsContext auto XP toggle

### DIFF
--- a/src/state/SettingsContext.test.jsx
+++ b/src/state/SettingsContext.test.jsx
@@ -4,20 +4,12 @@ import { renderHook, act } from '@testing-library/react';
 import { SettingsProvider, useSettings } from './SettingsContext.jsx';
 
 describe('SettingsContext', () => {
-  let originalEnv;
-
-  beforeEach(() => {
-    // Save and reset environment variable before each test
-    originalEnv = { ...import.meta.env };
-    import.meta.env.VITE_AUTO_XP_ON_MISS = 'true';
-  });
-
   afterEach(() => {
-    // Restore original environment
-    import.meta.env = { ...originalEnv };
+    delete import.meta.env.VITE_AUTO_XP_ON_MISS;
   });
 
-  it('uses default autoXpOnMiss from env and updates with setAutoXpOnMiss', () => {
+  it('uses env default when initialAutoXpOnMiss is omitted', () => {
+    import.meta.env.VITE_AUTO_XP_ON_MISS = 'true';
     const wrapper = ({ children }) => <SettingsProvider>{children}</SettingsProvider>;
     const { result } = renderHook(() => useSettings(), { wrapper });
 
@@ -28,7 +20,7 @@ describe('SettingsContext', () => {
     expect(result.current.autoXpOnMiss).toBe(false);
   });
 
-  it('honors initialAutoXpOnMiss prop and updates correctly', () => {
+  it('honors initialAutoXpOnMiss prop', () => {
     const wrapper = ({ children }) => (
       <SettingsProvider initialAutoXpOnMiss={false}>{children}</SettingsProvider>
     );


### PR DESCRIPTION
## Summary
- add tests for SettingsProvider autoXpOnMiss default and overrides

## Testing
- `npm run lint`
- `npm test` *(fails: getStatusEffectImage is not a function and others)*

------
https://chatgpt.com/codex/tasks/task_e_689d69b9fb888332b2dbb9cfe535f9ec