### PR TITLE
test: add PerformanceHud component test

### DIFF
--- a/src/components/PerformanceHud.test.jsx
+++ b/src/components/PerformanceHud.test.jsx
@@ -1,33 +1,25 @@
-/* eslint-env jest */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
 import PerformanceHud from './PerformanceHud.jsx';
 
 vi.mock('../hooks/usePerformanceMetrics.js', () => ({
-  default: vi.fn(() => ({
+  default: () => ({
     current: { renderDuration: 12.34, updatesPerSecond: 56.78 },
-  })),
+  }),
 }));
 
 describe('PerformanceHud', () => {
-  let originalRAF;
-  let originalCAF;
-
   beforeEach(() => {
-    originalRAF = globalThis.requestAnimationFrame;
-    originalCAF = globalThis.cancelAnimationFrame;
-    globalThis.requestAnimationFrame = () => 0;
-    globalThis.cancelAnimationFrame = () => {};
+    vi.stubGlobal('requestAnimationFrame', () => 0);
+    vi.stubGlobal('cancelAnimationFrame', () => {});
   });
 
   afterEach(() => {
-    globalThis.requestAnimationFrame = originalRAF;
-    globalThis.cancelAnimationFrame = originalCAF;
-    vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
-  it('displays performance metrics from hook', () => {
+  it('displays deterministic performance metrics', () => {
     render(<PerformanceHud />);
     expect(screen.getByText('Render: 12.34 ms')).toBeInTheDocument();
     expect(screen.getByText('Update: 56.78 /s')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add deterministic test for PerformanceHud that mocks performance metrics

## Testing
- `npm run lint`
- `npm test` *(fails: getStatusEffectImage is not a function, others)*

------
https://chatgpt.com/codex/tasks/task_e_689d69bc1a8483328bfb157f12341268