### PR TITLE
test(fileStorage): verify tauri and browser storage

### DIFF
--- a/src/utils/fileStorage.test.js
+++ b/src/utils/fileStorage.test.js
@@ -1,5 +1,3 @@
-/* eslint-env jest */
-import { invoke } from '@tauri-apps/api/core';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { saveFile, loadFile } from './fileStorage.js';
 
@@ -15,12 +13,17 @@ afterEach(() => {
 describe('fileStorage tauri integration', () => {
   it('calls invoke to save file when Tauri is available', async () => {
     window.__TAURI__ = {};
+    const { invoke } = await import('@tauri-apps/api/core');
     await saveFile('test.json', '{"a":1}');
-    expect(invoke).toHaveBeenCalledWith('write_file', { path: 'test.json', contents: '{"a":1}' });
+    expect(invoke).toHaveBeenCalledWith('write_file', {
+      path: 'test.json',
+      contents: '{"a":1}',
+    });
   });
 
   it('calls invoke to load file when Tauri is available', async () => {
     window.__TAURI__ = {};
+    const { invoke } = await import('@tauri-apps/api/core');
     invoke.mockResolvedValueOnce('content');
     await expect(loadFile('test.json')).resolves.toBe('content');
     expect(invoke).toHaveBeenCalledWith('read_file', { path: 'test.json' });
@@ -32,8 +35,10 @@ describe('fileStorage browser fallback', () => {
     const original = global.localStorage;
     const setItem = vi.fn();
     global.localStorage = { setItem };
+
     await saveFile('key', 'value');
     expect(setItem).toHaveBeenCalledWith('key', 'value');
+
     global.localStorage = original;
   });
 
@@ -41,8 +46,10 @@ describe('fileStorage browser fallback', () => {
     const original = global.localStorage;
     const getItem = vi.fn(() => 'stored');
     global.localStorage = { getItem };
+
     await expect(loadFile('key')).resolves.toBe('stored');
     expect(getItem).toHaveBeenCalledWith('key');
+
     global.localStorage = original;
   });
 
@@ -50,21 +57,22 @@ describe('fileStorage browser fallback', () => {
     const originalStorage = global.localStorage;
     const getItem = vi.fn(() => null);
     global.localStorage = { getItem };
+
     const fileContent = '{"foo":"bar"}';
-    const file = new File([fileContent], 'test.json', { type: 'application/json' });
+    const file = new File([fileContent], 'test.json', {
+      type: 'application/json',
+    });
 
     const input = document.createElement('input');
     Object.defineProperty(input, 'files', { value: [file] });
-    input.click = () => {
-      input.onchange();
-    };
+    input.click = () => input.onchange();
 
     const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
       if (tag === 'input') return input;
       return document.createElement(tag);
     });
 
-    const OriginalFileReader = global.FileReader;
+    const originalReader = global.FileReader;
     class MockReader {
       readAsText() {
         this.result = fileContent;
@@ -77,6 +85,6 @@ describe('fileStorage browser fallback', () => {
 
     global.localStorage = originalStorage;
     createSpy.mockRestore();
-    global.FileReader = OriginalFileReader;
+    global.FileReader = originalReader;
   });
 });


### PR DESCRIPTION
## Summary
- add unit tests for fileStorage tauri integration and browser fallbacks

## Testing
- `npm run lint`
- `npm test` *(fails: getStatusEffectImage is not a function, diceUtils not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689d69bcfbb48332b2854a97058b464d