### PR TITLE
feat: add status effect image resolver

### DIFF
--- a/src/hooks/statusEffectImageMap.test.jsx
+++ b/src/hooks/statusEffectImageMap.test.jsx
@@ -1,6 +1,9 @@
 /* eslint-env jest */
 import { describe, it, expect } from 'vitest';
-import useStatusEffects, { statusEffectImageMap } from './useStatusEffects.js';
+import useStatusEffects, {
+  statusEffectImageMap,
+  getStatusEffectImage as getStatusEffectImageFromMap,
+} from './useStatusEffects.js';
 
 describe('statusEffectImageMap', () => {
   it('returns poisoned image and overlay when status effect active', () => {
@@ -9,6 +12,9 @@ describe('statusEffectImageMap', () => {
 
     expect(getStatusEffectImage()).toBe(statusEffectImageMap.poisoned);
     expect(getActiveVisualEffects()).toBe('poisoned-overlay');
+    expect(getStatusEffectImageFromMap(character.statusEffects)).toBe(
+      statusEffectImageMap.poisoned,
+    );
   });
 
   it('uses default image when no status effects', () => {
@@ -17,5 +23,6 @@ describe('statusEffectImageMap', () => {
 
     expect(getStatusEffectImage()).toBe(statusEffectImageMap.default);
     expect(getActiveVisualEffects()).toBe('');
+    expect(getStatusEffectImageFromMap(character.statusEffects)).toBe(statusEffectImageMap.default);
   });
 });

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -1,5 +1,29 @@
 import { headerGradients } from '../styles/colorMap.js';
 
+export const statusEffectImageMap = {
+  default: '/avatars/default.svg',
+  poisoned: '/avatars/poisoned.svg',
+  burning: '/avatars/default.svg',
+  shocked: '/avatars/default.svg',
+  frozen: '/avatars/default.svg',
+  blessed: '/avatars/default.svg',
+  lowHp: '/avatars/default.svg',
+  stunned: '/avatars/default.svg',
+  shielded: '/avatars/default.svg',
+};
+
+export const getStatusEffectImage = (statusEffects = []) => {
+  if (statusEffects.includes('poisoned')) return statusEffectImageMap.poisoned;
+  if (statusEffects.includes('burning')) return statusEffectImageMap.burning;
+  if (statusEffects.includes('shocked')) return statusEffectImageMap.shocked;
+  if (statusEffects.includes('frozen')) return statusEffectImageMap.frozen;
+  if (statusEffects.includes('blessed')) return statusEffectImageMap.blessed;
+  if (statusEffects.includes('lowHp')) return statusEffectImageMap.lowHp;
+  if (statusEffects.includes('stunned')) return statusEffectImageMap.stunned;
+  if (statusEffects.includes('shielded')) return statusEffectImageMap.shielded;
+  return statusEffectImageMap.default;
+};
+
 export default function useStatusEffects(character, setCharacter) {
   const statusEffects = character.statusEffects;
   const debilities = character.debilities;
@@ -53,6 +77,7 @@ export default function useStatusEffects(character, setCharacter) {
     statusEffects,
     debilities,
     getActiveVisualEffects,
+    getStatusEffectImage: () => getStatusEffectImage(statusEffects),
     getHeaderColor,
     toggleStatusEffect,
     toggleDebility,


### PR DESCRIPTION
## Summary
- expose a status effect image map and lookup helper
- return image resolver from `useStatusEffects`
- cover status effect image mapping in tests

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined (reading 'current'), ReferenceError: diceUtils is not defined, and others)*

------
https://chatgpt.com/codex/tasks/task_e_689d6a6d81388332866306495f3fd114