### PR TITLE
feat: display app version

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import InventoryPanel from './components/InventoryPanel.jsx';
 import SessionNotes from './components/SessionNotes.jsx';
 import CharacterHUD from './components/CharacterHUD/CharacterHUD.jsx';
 import Settings from './components/Settings.jsx';
+import AppVersion from './components/AppVersion.tsx';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
 import useModal from './hooks/useModal.js';
@@ -279,6 +280,7 @@ function App() {
           <PerformanceHud />
         </Suspense>
       )}
+      <AppVersion />
     </div>
   );
 }

--- a/src/components/AppVersion.test.jsx
+++ b/src/components/AppVersion.test.jsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import AppVersion from './AppVersion.tsx';
+
+vi.mock('@tauri-apps/api/app', () => ({
+  getVersion: vi.fn().mockResolvedValue('1.2.3'),
+}));
+
+describe('AppVersion', () => {
+  it('renders the retrieved version', async () => {
+    render(<AppVersion />);
+    expect(await screen.findByText(/Version: 1.2.3/)).toBeInTheDocument();
+  });
+});

--- a/src/components/AppVersion.tsx
+++ b/src/components/AppVersion.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from 'react';
+import { getVersion } from '@tauri-apps/api/app';
+
+function AppVersion() {
+  const [version, setVersion] = useState<string>('');
+
+  useEffect(() => {
+    let isMounted = true;
+    getVersion().then((v) => {
+      if (isMounted) setVersion(v);
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  if (!version) {
+    return null;
+  }
+
+  return <div>Version: {version}</div>;
+}
+
+export default AppVersion;


### PR DESCRIPTION
## Summary
- show Tauri app version from runtime
- cover version rendering with unit test

## Testing
- `npm run lint`
- `npm test` *(fails: getStatusEffectImage is not a function, etc.)*
- `npx vitest run src/components/AppVersion.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689d6c54b5288332bc38a3a353920657