### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zimbo-panel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zimbo-panel",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zimbo-panel",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -16,7 +16,8 @@
     "format:check": "prettier --check .",
     "sync": "bash git-sync-ask.sh",
     "fix-prs": "node fix-prs.mjs",
-    "prepare": "husky"
+    "prepare": "husky",
+    "version": "node update-version.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zimbo-panel"
-version = "0.1.0"
+version = "0.1.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "zimbo-panel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.dan.zimbo-panel",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/update-version.mjs
+++ b/update-version.mjs
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
+const version = pkg.version;
+
+const tauriConfigPath = './src-tauri/tauri.conf.json';
+const tauriConfig = JSON.parse(readFileSync(tauriConfigPath, 'utf8'));
+tauriConfig.version = version;
+writeFileSync(tauriConfigPath, JSON.stringify(tauriConfig, null, 2) + '\n');
+
+const cargoTomlPath = './src-tauri/Cargo.toml';
+let cargoToml = readFileSync(cargoTomlPath, 'utf8');
+cargoToml = cargoToml.replace(/version = "[^"]+"/, `version = "${version}"`);
+writeFileSync(cargoTomlPath, cargoToml);


### PR DESCRIPTION
## Summary
- bump app version to 0.1.1 across frontend and Tauri config
- add script for syncing version in package.json to tauri.conf.json and Cargo.toml

## Testing
- `npm run lint`
- `npm test` *(fails: getStatusEffectImage is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689d6c56f8788332a5c9b6ae48eb75e5