### PR TITLE
docs: add end-to-end testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ npm run build
 npm test
 ```
 
+### End-to-end tests
+
+Build a debug bundle for Playwright to target:
+
+```bash
+npx tauri build --debug
+```
+
+Ensure Playwright's browsers are installed:
+
+```bash
+npx playwright install
+```
+
+Run the end-to-end suite:
+
+```bash
+npm run test:e2e
+```
+
 ### Sync with GitHub
 
 ```bash

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -84,9 +84,7 @@ export default function useStatusEffects(character, setCharacter) {
     getActiveVisualEffects,
     getStatusEffectImage: () => getStatusEffectImage(statusEffects),
     getHeaderColor,
-    getStatusEffectImage,
     toggleStatusEffect,
     toggleDebility,
-    getStatusEffectImage: () => getStatusEffectImage(statusEffects),
   };
 }


### PR DESCRIPTION
## Summary
- document building the Tauri app in debug mode for e2e tests
- note Playwright browser prerequisites and command to run e2e suite
- remove duplicate status effect image helper

## Testing
- `npm run lint`
- `npm test` *(fails: ResourceBars undefined ref; multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689eb69087d88332b2f4d6976308c6c3