### PR TITLE
feat: handle version retrieval errors

### DIFF
--- a/src/components/AppVersion.test.jsx
+++ b/src/components/AppVersion.test.jsx
@@ -4,12 +4,20 @@ import { describe, it, expect, vi } from 'vitest';
 import AppVersion from './AppVersion.tsx';
 
 vi.mock('@tauri-apps/api/app', () => ({
-  getVersion: vi.fn().mockResolvedValue('1.2.3'),
+  getVersion: vi.fn(),
 }));
+import { getVersion } from '@tauri-apps/api/app';
 
 describe('AppVersion', () => {
   it('renders the retrieved version', async () => {
+    getVersion.mockResolvedValueOnce('1.2.3');
     render(<AppVersion />);
     expect(await screen.findByText(/Version: 1.2.3/)).toBeInTheDocument();
+  });
+
+  it('shows a fallback message when version retrieval fails', async () => {
+    getVersion.mockRejectedValueOnce(new Error('fail'));
+    render(<AppVersion />);
+    expect(await screen.findByText(/Version: Version unavailable/)).toBeInTheDocument();
   });
 });

--- a/src/components/AppVersion.tsx
+++ b/src/components/AppVersion.tsx
@@ -2,21 +2,23 @@ import React, { useEffect, useState } from 'react';
 import { getVersion } from '@tauri-apps/api/app';
 
 function AppVersion() {
-  const [version, setVersion] = useState<string>('');
+  const [version, setVersion] = useState<string>('Version unavailable');
 
   useEffect(() => {
     let isMounted = true;
-    getVersion().then((v) => {
-      if (isMounted) setVersion(v);
-    });
+    const fetchVersion = async () => {
+      try {
+        const v = await getVersion();
+        if (isMounted) setVersion(v);
+      } catch {
+        if (isMounted) setVersion('Version unavailable');
+      }
+    };
+    fetchVersion();
     return () => {
       isMounted = false;
     };
   }, []);
-
-  if (!version) {
-    return null;
-  }
 
   return <div>Version: {version}</div>;
 }


### PR DESCRIPTION
## Summary
- show a default "Version unavailable" message if Tauri version retrieval fails
- expand AppVersion tests to cover fallback and success

## Testing
- `npm run lint` *(fails: Duplicate key 'getStatusEffectImage')*
- `npm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689dc22d82f88332bbe0cdabb73e66e5