### PR TITLE
test: add theme switcher e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@crabnebula/tauri-driver": "^2.0.5",
+        "@playwright/test": "^1.54.2",
         "@tauri-apps/cli": "^2",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -1350,6 +1351,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@promptbook/utils": {
@@ -7430,6 +7447,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@crabnebula/tauri-driver": "^2.0.5",
+    "@playwright/test": "^1.54.2",
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -84,9 +84,7 @@ export default function useStatusEffects(character, setCharacter) {
     getActiveVisualEffects,
     getStatusEffectImage: () => getStatusEffectImage(statusEffects),
     getHeaderColor,
-    getStatusEffectImage,
     toggleStatusEffect,
     toggleDebility,
-    getStatusEffectImage: () => getStatusEffectImage(statusEffects),
   };
 }

--- a/tests/e2e/theme-switcher.spec.ts
+++ b/tests/e2e/theme-switcher.spec.ts
@@ -1,0 +1,41 @@
+import { _electron as electron, test, expect } from '@playwright/test';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let app;
+let page;
+
+test.beforeAll(async () => {
+  const tauriDir = path.resolve(__dirname, '../../src-tauri');
+  spawnSync('npx', ['tauri', 'build', '--debug'], {
+    cwd: tauriDir,
+    stdio: 'inherit',
+  });
+  app = await electron.launch({
+    executablePath: path.resolve(tauriDir, 'target/debug/zimbo-panel'),
+  });
+  page = await app.firstWindow();
+});
+
+test.afterAll(async () => {
+  if (app) {
+    await app.close();
+  }
+});
+
+test('changes theme via dropdown', async () => {
+  const themeSelect = await page.$('#theme-select');
+  const initialBg = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue('--color-bg-start'),
+  );
+  await themeSelect.selectOption('classic');
+  const theme = await page.evaluate(() => document.documentElement.dataset.theme);
+  expect(theme).toBe('classic');
+  const updatedBg = await page.evaluate(() =>
+    getComputedStyle(document.documentElement).getPropertyValue('--color-bg-start'),
+  );
+  expect(updatedBg.trim()).not.toBe(initialBg.trim());
+});


### PR DESCRIPTION
## Summary
- add Playwright-based theme switcher end-to-end test
- include Playwright test dependency
- remove duplicate key in status effects hook

## Testing
- `npm run lint`
- `npm test` *(fails: multiple existing tests fail)*
- `npx playwright test tests/e2e/theme-switcher.spec.ts` *(interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_689eb63b1e808332b1410413e674e296