### PR TITLE
test: add HUD layout Playwright test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@crabnebula/tauri-driver": "^2.0.5",
+        "@playwright/test": "^1.54.2",
         "@tauri-apps/cli": "^2",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
@@ -1350,6 +1351,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@promptbook/utils": {
@@ -7430,6 +7447,53 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@crabnebula/tauri-driver": "^2.0.5",
+    "@playwright/test": "^1.54.2",
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -46,7 +46,7 @@ export default function useStatusEffects(character, setCharacter) {
       .join(' ');
   };
 
-  const getStatusEffectImage = () => {
+  const getStatusEffectImageLocal = () => {
     const effect = statusEffects.find((e) => statusEffectImageMap[e]);
     return statusEffectImageMap[effect] || statusEffectImageMap.default;
   };
@@ -82,11 +82,9 @@ export default function useStatusEffects(character, setCharacter) {
     statusEffects,
     debilities,
     getActiveVisualEffects,
-    getStatusEffectImage: () => getStatusEffectImage(statusEffects),
+    getStatusEffectImage: getStatusEffectImageLocal,
     getHeaderColor,
-    getStatusEffectImage,
     toggleStatusEffect,
     toggleDebility,
-    getStatusEffectImage: () => getStatusEffectImage(statusEffects),
   };
 }

--- a/tests/e2e/button-layout.spec.ts
+++ b/tests/e2e/button-layout.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+
+test('HUD buttons respect spacing and radius tokens', async ({ page }) => {
+  const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:5173';
+  await page.goto(baseUrl);
+
+  const xpButton = page.getByRole('button', { name: '+1 XP' });
+  await expect(xpButton).toBeVisible();
+
+  const settings = page.locator('#theme-select');
+  await expect(settings).toBeVisible();
+
+  const { hudSpacing, hudRadius } = await page.evaluate(() => {
+    const styles = getComputedStyle(document.documentElement);
+    const fontSize = parseFloat(styles.fontSize);
+    return {
+      hudSpacing: `${parseFloat(styles.getPropertyValue('--hud-spacing')) * fontSize}px`,
+      hudRadius: `${parseFloat(styles.getPropertyValue('--hud-radius-sm')) * fontSize}px`,
+    };
+  });
+
+  const xpPanelPadding = await xpButton.evaluate((el) => {
+    const panel = el.closest('[class*="panel"]');
+    return panel ? getComputedStyle(panel).padding : '';
+  });
+  expect(xpPanelPadding).toBe(hudSpacing);
+
+  const xpRadius = await xpButton.evaluate((el) => getComputedStyle(el).borderRadius);
+  expect(xpRadius).toBe(hudRadius);
+
+  const xpBox = await xpButton.boundingBox();
+  const settingsBox = await settings.boundingBox();
+  if (xpBox && settingsBox) {
+    expect(xpBox.x + xpBox.width).toBeLessThan(settingsBox.x);
+  } else {
+    throw new Error('Could not determine element positions');
+  }
+});


### PR DESCRIPTION
## Summary
- add Playwright e2e test to verify HUD button spacing and border radius
- install Playwright test runner
- dedupe status effect image helper

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot read properties of undefined / timeouts)*
- `npx playwright test tests/e2e/button-layout.spec.ts` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689eb6454a6c8332b7287aae48abd68d