### PR TITLE
test: polyfill requestAnimationFrame in tests

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,12 +1,15 @@
 import { webcrypto } from 'node:crypto';
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
 
 // Provide Web Crypto API in test environment if missing
 if (!globalThis.crypto) {
   globalThis.crypto = webcrypto;
 }
 
-import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
+if (!globalThis.requestAnimationFrame) {
+  globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+}
 
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn().mockResolvedValue('0.0.0'),


### PR DESCRIPTION
## Summary
- polyfill `requestAnimationFrame` in test setup so tests can run in Node

## Testing
- `npm run lint` *(fails: Parsing error in src/hooks/useStatusEffects.js)*
- `npm test` *(fails: Identifier 'getStatusEffectImage' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_689ebbe44b008332843d4fea1d03fd53