### PR TITLE
chore: configure ESLint for Vitest globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import importPlugin from 'eslint-plugin-import';
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import vitestPlugin from 'eslint-plugin-vitest';
 import globals from 'globals';
 
 export default [
@@ -27,7 +28,7 @@ export default [
       globals: {
         ...globals.browser,
         ...globals.node,
-        ...globals.jest,
+        ...globals.vitest,
       },
     },
     settings: {
@@ -48,6 +49,15 @@ export default [
           alphabetize: { order: 'asc', caseInsensitive: true },
         },
       ],
+    },
+  },
+  {
+    files: ['**/*.{test,spec}.{js,jsx,ts,tsx}'],
+    plugins: {
+      vitest: vitestPlugin,
+    },
+    rules: {
+      ...vitestPlugin.configs.recommended.rules,
     },
   },
   prettierConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-vitest": "^0.5.4",
         "globals": "^16.3.0",
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
@@ -1342,6 +1343,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2188,6 +2227,124 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2755,6 +2912,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -3874,6 +4041,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -4680,6 +4860,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-vitest": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vitest/-/eslint-plugin-vitest-0.5.4.tgz",
+      "integrity": "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^7.7.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || >= 20.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -4896,6 +5124,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4927,6 +5185,16 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
       }
     },
     "node_modules/fd-slicer": {
@@ -5411,6 +5679,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -6803,6 +7092,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7392,6 +7691,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -7702,6 +8011,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
@@ -7943,6 +8273,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -8022,6 +8363,30 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safaridriver": {
       "version": "1.0.0",
@@ -8367,6 +8732,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/slice-ansi": {
@@ -9064,6 +9439,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9199,6 +9587,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-vitest": "^0.5.4",
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -5,8 +5,8 @@ import App from './App.jsx';
 import Settings from './components/Settings.jsx';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
 import CharacterContext from './state/CharacterContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
 import { SettingsProvider } from './state/SettingsContext.jsx';
+import { ThemeProvider } from './state/ThemeContext.jsx';
 import './styles/theme.css';
 
 beforeEach(() => {
@@ -28,9 +28,8 @@ afterEach(() => {
   confirmSpy.mockRestore();
 });
 
-const createWrapper =
-  (initialCharacter, autoXpOnMiss) =>
-  ({ children }) => {
+const createWrapper = (initialCharacter, autoXpOnMiss) =>
+  function Wrapper({ children }) {
     const [character, setCharacter] = React.useState(initialCharacter);
     return (
       <ThemeProvider>

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import { render } from '@testing-library/react';
+import React from 'react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import App from './App.jsx';
-import styles from './styles/AppStyles.module.css';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
 import CharacterContext from './state/CharacterContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
 import { SettingsProvider } from './state/SettingsContext.jsx';
+import { ThemeProvider } from './state/ThemeContext.jsx';
+import styles from './styles/AppStyles.module.css';
 
 const Wrapper = ({ children }) => {
   const [character, setCharacter] = React.useState(INITIAL_CHARACTER_DATA);

--- a/src/HudAccessibility.test.jsx
+++ b/src/HudAccessibility.test.jsx
@@ -5,8 +5,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import App from './App.jsx';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
 import CharacterContext from './state/CharacterContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
 import { SettingsProvider } from './state/SettingsContext.jsx';
+import { ThemeProvider } from './state/ThemeContext.jsx';
 
 function renderApp(overrides = {}) {
   const initialCharacter = { ...INITIAL_CHARACTER_DATA, ...overrides };

--- a/src/components/AppVersion.test.jsx
+++ b/src/components/AppVersion.test.jsx
@@ -1,3 +1,4 @@
+import { getVersion } from '@tauri-apps/api/app';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
@@ -6,7 +7,6 @@ import AppVersion from './AppVersion.tsx';
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn(),
 }));
-import { getVersion } from '@tauri-apps/api/app';
 
 describe('AppVersion', () => {
   it('renders the retrieved version', async () => {

--- a/src/components/CharacterHUD/CharacterHUD.test.jsx
+++ b/src/components/CharacterHUD/CharacterHUD.test.jsx
@@ -1,9 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
-import CharacterHUD from './CharacterHUD.jsx';
-import CharacterContext from '../../state/CharacterContext.jsx';
 import { statusEffectTypes } from '../../state/character.js';
+import CharacterContext from '../../state/CharacterContext.jsx';
+import CharacterHUD from './CharacterHUD.jsx';
 
 describe('CharacterHUD', () => {
   it('displays character data from context', () => {

--- a/src/components/CharacterHUD/ResourceBars.test.jsx
+++ b/src/components/CharacterHUD/ResourceBars.test.jsx
@@ -1,6 +1,5 @@
-/* eslint-env jest */
-import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
 import { describe, it, expect } from 'vitest';
 import ResourceBars from './ResourceBars.jsx';
 

--- a/src/components/CharacterHUD/index.test.jsx
+++ b/src/components/CharacterHUD/index.test.jsx
@@ -1,6 +1,5 @@
-/* eslint-env jest */
-import React from 'react';
 import { render, screen } from '@testing-library/react';
+import React from 'react';
 import { describe, it, expect } from 'vitest';
 import CharacterHUD, { LOW_HP_THRESHOLD } from './index.jsx';
 import styles from './index.module.css';

--- a/src/components/ExportModal.test.jsx
+++ b/src/components/ExportModal.test.jsx
@@ -1,11 +1,10 @@
-/* eslint-env jest */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 import CharacterContext from '../state/CharacterContext.jsx';
-import ExportModal from './ExportModal.jsx';
 import { loadFile } from '../utils/fileStorage.js';
+import ExportModal from './ExportModal.jsx';
 
 vi.mock('../utils/fileStorage.js', () => ({
   saveFile: vi.fn(),

--- a/src/components/GameModals.test.jsx
+++ b/src/components/GameModals.test.jsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect } from 'vitest';
-import GameModals from './GameModals.jsx';
-import { CharacterProvider, useCharacter } from '../state/CharacterContext.jsx';
 import { statusEffectTypes, debilityTypes } from '../state/character.js';
+import { CharacterProvider, useCharacter } from '../state/CharacterContext.jsx';
+import GameModals from './GameModals.jsx';
 
 function Wrapper(props) {
   const { character, setCharacter } = useCharacter();

--- a/src/components/InventoryPanel.test.jsx
+++ b/src/components/InventoryPanel.test.jsx
@@ -1,10 +1,9 @@
-/* eslint-env jest */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import InventoryPanel from './InventoryPanel.jsx';
 import useUndo from '../hooks/useUndo.js';
+import InventoryPanel from './InventoryPanel.jsx';
 
 describe('InventoryPanel', () => {
   it('uses consumable items and calls handlers', async () => {

--- a/src/components/SessionNotes.test.jsx
+++ b/src/components/SessionNotes.test.jsx
@@ -1,11 +1,10 @@
-/* eslint-env jest */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
+import { saveFile, loadFile } from '../utils/fileStorage.js';
 import SessionNotes from './SessionNotes.jsx';
 import styles from './SessionNotes.module.css';
-import { saveFile, loadFile } from '../utils/fileStorage.js';
 
 vi.mock('../utils/fileStorage.js', () => ({
   saveFile: vi.fn(),

--- a/src/components/Settings.test.jsx
+++ b/src/components/Settings.test.jsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import ThemeContext from '../state/ThemeContext.jsx';
 import SettingsContext from '../state/SettingsContext.jsx';
+import ThemeContext from '../state/ThemeContext.jsx';
 import Settings from './Settings.jsx';
 
 describe('Settings', () => {

--- a/src/components/StatusModal.test.jsx
+++ b/src/components/StatusModal.test.jsx
@@ -1,11 +1,10 @@
-/* eslint-env jest */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import StatusModal from './StatusModal.jsx';
-import useUndo from '../hooks/useUndo.js';
 import useStatusEffects from '../hooks/useStatusEffects.js';
+import useUndo from '../hooks/useUndo.js';
+import StatusModal from './StatusModal.jsx';
 
 function StatusWrapper({ isOpen, ...props }) {
   return isOpen ? <StatusModal {...props} /> : null;

--- a/src/hooks/useDiceRoller.aid.test.jsx
+++ b/src/hooks/useDiceRoller.aid.test.jsx
@@ -1,9 +1,8 @@
-/* eslint-env jest */
 import { renderHook, act } from '@testing-library/react';
 import { vi } from 'vitest';
+import { SettingsProvider } from '../state/SettingsContext.jsx';
 import * as diceUtils from '../utils/dice.js';
 import useDiceRoller from './useDiceRoller.js';
-import { SettingsProvider } from '../state/SettingsContext.jsx';
 
 const wrapper = ({ children }) => (
   <SettingsProvider initialAutoXpOnMiss={false}>{children}</SettingsProvider>

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -1,15 +1,13 @@
-/* eslint-env jest */
 import { renderHook, act } from '@testing-library/react';
 import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
-import useDiceRoller from './useDiceRoller.js';
 import { SettingsProvider } from '../state/SettingsContext.jsx';
 import * as diceUtils from '../utils/dice.js';
+import useDiceRoller from './useDiceRoller.js';
 
-const getWrapper =
-  (autoXpOnMiss) =>
-  ({ children }) => (
-    <SettingsProvider initialAutoXpOnMiss={autoXpOnMiss}>{children}</SettingsProvider>
-  );
+const getWrapper = (autoXpOnMiss) =>
+  function Wrapper({ children }) {
+    return <SettingsProvider initialAutoXpOnMiss={autoXpOnMiss}>{children}</SettingsProvider>;
+  };
 const wrapper = getWrapper(false);
 
 beforeEach(() => {

--- a/src/hooks/usePerformanceMetrics.test.jsx
+++ b/src/hooks/usePerformanceMetrics.test.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
 import { render, waitFor } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
 import usePerformanceMetrics from './usePerformanceMetrics.js';
 
 function TestComponent({ onUpdate }) {
@@ -9,7 +9,7 @@ function TestComponent({ onUpdate }) {
   useEffect(() => {
     onUpdate({ ...metrics.current });
     if (count === 0) setCount(1);
-  });
+  }, [onUpdate, metrics, count]);
 
   return null;
 }

--- a/src/hooks/useStatusEffects.js
+++ b/src/hooks/useStatusEffects.js
@@ -13,18 +13,6 @@ export const statusEffectImageMap = {
 };
 
 export const getStatusEffectImage = (statusEffects = []) => {
-  if (statusEffects.includes('poisoned')) return statusEffectImageMap.poisoned;
-  if (statusEffects.includes('burning')) return statusEffectImageMap.burning;
-  if (statusEffects.includes('shocked')) return statusEffectImageMap.shocked;
-  if (statusEffects.includes('frozen')) return statusEffectImageMap.frozen;
-  if (statusEffects.includes('blessed')) return statusEffectImageMap.blessed;
-  if (statusEffects.includes('lowHp')) return statusEffectImageMap.lowHp;
-  if (statusEffects.includes('stunned')) return statusEffectImageMap.stunned;
-  if (statusEffects.includes('shielded')) return statusEffectImageMap.shielded;
-  return statusEffectImageMap.default;
-};
-
-export const getStatusEffectImage = (statusEffects = []) => {
   const effect = statusEffects.find((e) => statusEffectImageMap[e]);
   return statusEffectImageMap[effect] || statusEffectImageMap.default;
 };

--- a/src/hooks/useStatusEffects.test.jsx
+++ b/src/hooks/useStatusEffects.test.jsx
@@ -1,4 +1,3 @@
-/* eslint-env jest */
 import { renderHook, act } from '@testing-library/react';
 import { useState } from 'react';
 import useStatusEffects from './useStatusEffects.js';

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,12 +1,11 @@
 import { webcrypto } from 'node:crypto';
+import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
 
 // Provide Web Crypto API in test environment if missing
 if (!globalThis.crypto) {
   globalThis.crypto = webcrypto;
 }
-
-import '@testing-library/jest-dom/vitest';
-import { vi } from 'vitest';
 
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn().mockResolvedValue('0.0.0'),

--- a/src/state/SettingsContext.test.jsx
+++ b/src/state/SettingsContext.test.jsx
@@ -1,6 +1,5 @@
-/* eslint-env jest */
-import React from 'react';
 import { renderHook, act } from '@testing-library/react';
+import React from 'react';
 import { SettingsProvider, useSettings } from './SettingsContext.jsx';
 
 describe('SettingsContext', () => {

--- a/src/state/ThemeContext.test.jsx
+++ b/src/state/ThemeContext.test.jsx
@@ -1,7 +1,9 @@
-/* eslint-env jest */
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
+import safeLocalStorage from '../utils/safeLocalStorage.js';
+import { DEFAULT_THEME } from './theme.js';
+import { ThemeProvider, useTheme } from './ThemeContext.jsx';
 
 vi.mock('../utils/safeLocalStorage.js', () => ({
   default: {
@@ -9,10 +11,6 @@ vi.mock('../utils/safeLocalStorage.js', () => ({
     setItem: vi.fn(),
   },
 }));
-
-import safeLocalStorage from '../utils/safeLocalStorage.js';
-import { ThemeProvider, useTheme } from './ThemeContext.jsx';
-import { DEFAULT_THEME } from './theme.js';
 
 describe('ThemeContext', () => {
   let originalDocumentElement;

--- a/tests/e2e/theme-switcher.spec.ts
+++ b/tests/e2e/theme-switcher.spec.ts
@@ -1,7 +1,7 @@
-import { _electron as electron, test, expect } from '@playwright/test';
-import path from 'path';
 import { spawnSync } from 'child_process';
+import path from 'path';
 import { fileURLToPath } from 'url';
+import { _electron as electron, test, expect } from '@playwright/test';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
## Summary
- use eslint-plugin-vitest and vitest globals instead of Jest env
- remove Jest env directives from ResourceBars and other tests
- clean up test import order for lint compliance

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ebbea24008332ac020a7e8aedf2b6