### PR TITLE
fix: handle missing secondary resource

### DIFF
--- a/src/components/CharacterHUD/CharacterHUD.jsx
+++ b/src/components/CharacterHUD/CharacterHUD.jsx
@@ -21,11 +21,15 @@ export default function CharacterHUD({ onMountChange = () => {} }) {
       <Portrait />
       <ResourceBars
         primary={{ current: character.hp, max: character.maxHp }}
-        secondary={{
-          current: character.secondaryResource,
-          max: character.maxSecondaryResource,
-        }}
-        shield={{ current: character.shield, max: character.maxHp }}
+        secondary={
+          character.maxSecondaryResource > 0
+            ? {
+                current: character.secondaryResource,
+                max: character.maxSecondaryResource,
+              }
+            : null
+        }
+        shield={character.shield > 0 ? { current: character.shield, max: character.maxHp } : null}
       />
       <StatusTray />
       <CastIndicator />

--- a/src/components/CharacterHUD/CharacterHUD.test.jsx
+++ b/src/components/CharacterHUD/CharacterHUD.test.jsx
@@ -33,6 +33,29 @@ describe('CharacterHUD', () => {
     expect(screen.getByText('Fireball')).toBeInTheDocument();
   });
 
+  it('omits secondary resource bar when secondary values are zero', () => {
+    const character = {
+      name: 'Zimbo',
+      hp: 10,
+      maxHp: 20,
+      secondaryResource: 0,
+      maxSecondaryResource: 0,
+      shield: 0,
+      statusEffects: [],
+      castName: '',
+      castProgress: 0,
+    };
+
+    render(
+      <CharacterContext.Provider value={{ character, setCharacter: () => {} }}>
+        <CharacterHUD />
+      </CharacterContext.Provider>,
+    );
+
+    expect(screen.getAllByRole('progressbar')).toHaveLength(1);
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+
   it('calls onMountChange when mounted', async () => {
     const onMountChange = vi.fn();
     const character = {

--- a/src/components/CharacterHUD/ResourceBars.jsx
+++ b/src/components/CharacterHUD/ResourceBars.jsx
@@ -6,10 +6,10 @@ export default function ResourceBars({ primary, secondary, shield }) {
   const [showPercent, setShowPercent] = useState(false);
 
   const prevPrimary = useRef(primary.current);
-  const prevSecondary = useRef(secondary.current);
+  const prevSecondary = useRef(secondary?.current ?? 0);
 
   const primaryPercent = Math.min(100, (primary.current / primary.max) * 100);
-  const secondaryPercent = Math.min(100, (secondary.current / secondary.max) * 100);
+  const secondaryPercent = secondary ? Math.min(100, (secondary.current / secondary.max) * 100) : 0;
   const shieldPercent = shield ? Math.min(100, (shield.current / primary.max) * 100) : 0;
 
   const [primaryChip, setPrimaryChip] = useState(primaryPercent);
@@ -29,6 +29,8 @@ export default function ResourceBars({ primary, secondary, shield }) {
   }, [primary.current, primary.max, primaryPercent]);
 
   useEffect(() => {
+    if (!secondary) return;
+
     if (secondary.current < prevSecondary.current) {
       setSecondaryChip((prevSecondary.current / secondary.max) * 100);
       requestAnimationFrame(() => setSecondaryChip(secondaryPercent));
@@ -39,7 +41,7 @@ export default function ResourceBars({ primary, secondary, shield }) {
       setSecondaryChip(secondaryPercent);
     }
     prevSecondary.current = secondary.current;
-  }, [secondary.current, secondary.max, secondaryPercent]);
+  }, [secondary?.current, secondary?.max, secondaryPercent, secondary]);
 
   const renderBar = (percent, chip, prev, current, max, type, includeShield) => (
     <div
@@ -85,15 +87,16 @@ export default function ResourceBars({ primary, secondary, shield }) {
         'primary',
         true,
       )}
-      {renderBar(
-        secondaryPercent,
-        secondaryChip,
-        prevSecondary,
-        secondary.current,
-        secondary.max,
-        'secondary',
-        false,
-      )}
+      {secondary &&
+        renderBar(
+          secondaryPercent,
+          secondaryChip,
+          prevSecondary,
+          secondary.current,
+          secondary.max,
+          'secondary',
+          false,
+        )}
     </div>
   );
 }
@@ -106,7 +109,7 @@ ResourceBars.propTypes = {
   secondary: PropTypes.shape({
     current: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
-  }).isRequired,
+  }),
   shield: PropTypes.shape({
     current: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
@@ -114,5 +117,6 @@ ResourceBars.propTypes = {
 };
 
 ResourceBars.defaultProps = {
+  secondary: null,
   shield: null,
 };

--- a/src/components/CharacterHUD/ResourceBars.test.jsx
+++ b/src/components/CharacterHUD/ResourceBars.test.jsx
@@ -29,4 +29,10 @@ describe('ResourceBars', () => {
     render(<ResourceBars {...defaultProps} />);
     expect(screen.getByTestId('shield-bar')).toBeInTheDocument();
   });
+
+  it('renders without NaN when secondary resource is absent', () => {
+    render(<ResourceBars primary={{ current: 50, max: 100 }} />);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(1);
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
 });

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -25,6 +25,8 @@ export const INITIAL_CHARACTER_DATA = {
   xpNeeded: 11, // Formula: level + 7
   levelUpPending: false,
   armor: 0,
+  secondaryResource: 0,
+  maxSecondaryResource: 0,
 
   // Attributes
   stats: {


### PR DESCRIPTION
## Summary
- add secondaryResource defaults to character state
- hide secondary bar when secondary resource is zero or undefined
- test ResourceBars without secondary resource

## Testing
- `npm run lint` *(fails: Parsing error in tests/e2e/resource-bars.spec.ts)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec11fca008332a21c513383426beb