### PR TITLE
feat: use scoreToMod for level-up modifiers

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { useState, useEffect, useRef } from 'react';
 import './LevelUpModal.module.css';
 import { advancedMoves } from '../data/advancedMoves.js';
+import { scoreToMod } from '../utils/score.js';
 import Message from './Message.jsx';
 
 const LevelUpModal = ({
@@ -127,7 +128,7 @@ const LevelUpModal = ({
     levelUpState.selectedStats.forEach((stat) => {
       newStats[stat] = {
         score: newStats[stat].score + 1,
-        mod: Math.floor((newStats[stat].score + 1 - 10) / 2),
+        mod: scoreToMod(newStats[stat].score + 1),
       };
     });
 

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -103,6 +103,59 @@ describe('LevelUpModal XP calculation', () => {
   });
 });
 
+describe('LevelUpModal stat modifier', () => {
+  it('sets modifier to +3 when increasing score from 17 to 18', () => {
+    let character = {
+      name: 'Test',
+      level: 1,
+      stats: {
+        STR: { score: 17, mod: 2 },
+        DEX: { score: 10, mod: 0 },
+        CON: { score: 10, mod: 0 },
+        INT: { score: 10, mod: 0 },
+        WIS: { score: 10, mod: 0 },
+        CHA: { score: 10, mod: 0 },
+      },
+      maxHp: 10,
+      hp: 10,
+      xp: 8,
+      xpNeeded: 8,
+      selectedMoves: [],
+      actionHistory: [],
+      levelUpPending: true,
+    };
+
+    const levelUpState = {
+      selectedStats: ['STR'],
+      selectedMove: 'appetite',
+      hpIncrease: 1,
+      newLevel: 2,
+      expandedMove: '',
+    };
+
+    const setCharacter = (fn) => {
+      character = fn(character);
+    };
+
+    render(
+      <LevelUpModal
+        character={character}
+        setCharacter={setCharacter}
+        levelUpState={levelUpState}
+        setLevelUpState={() => {}}
+        onClose={() => {}}
+        rollDie={() => 1}
+        setRollResult={() => {}}
+      />,
+    );
+
+    const completeButton = screen.getByRole('button', { name: /Complete Level Up/i });
+    fireEvent.click(completeButton);
+
+    expect(character.stats.STR.mod).toBe(3);
+  });
+});
+
 describe('LevelUpModal visibility and closing', () => {
   const character = {
     name: 'Test',


### PR DESCRIPTION
## Summary
- use scoreToMod when increasing stats in LevelUpModal
- test +3 modifier when raising score 17→18

## Testing
- `npm run lint` (fails: Parsing error: Unexpected token : in tests/e2e/resource-bars.spec.ts)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec12842b08332bad8e8db292d76c2