### PR TITLE
feat: handle file input cancellation

### DIFF
--- a/src/utils/fileStorage.js
+++ b/src/utils/fileStorage.js
@@ -36,7 +36,19 @@ export async function loadFile(name) {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.json';
-    input.onchange = () => {
+
+    const cleanup = () => {
+      input.removeEventListener('change', onChange);
+      input.removeEventListener('cancel', onCancel);
+    };
+
+    const onCancel = () => {
+      cleanup();
+      reject(new Error('File selection cancelled'));
+    };
+
+    const onChange = () => {
+      cleanup();
       const file = input.files && input.files[0];
       if (!file) {
         reject(new Error('No file selected'));
@@ -47,6 +59,9 @@ export async function loadFile(name) {
       reader.onerror = () => reject(reader.error);
       reader.readAsText(file);
     };
+
+    input.addEventListener('change', onChange);
+    input.addEventListener('cancel', onCancel);
     input.click();
   });
 }


### PR DESCRIPTION
## Summary
- reject loadFile promise when user cancels file selection and clean up event listeners
- test cancel event handling for file input

## Testing
- `npm run lint` *(fails: Parsing error in tests/e2e/resource-bars.spec.ts)*
- `npx eslint src/utils/fileStorage.js src/utils/fileStorage.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec12d524c8332be395eb1872396f5