### PR TITLE
feat: add cloneDeep fallback and update undo hook

### DIFF
--- a/src/hooks/useUndo.js
+++ b/src/hooks/useUndo.js
@@ -1,4 +1,5 @@
 import { useRef, useEffect } from 'react';
+import cloneDeep from '../utils/cloneDeep.js';
 
 export default function useUndo(character, setCharacter, setRollResult) {
   const timeoutRef = useRef(null);
@@ -15,7 +16,7 @@ export default function useUndo(character, setCharacter, setRollResult) {
     setCharacter((prev) => ({
       ...prev,
       actionHistory: [
-        { action, state: structuredClone(prev), timestamp: Date.now() },
+        { action, state: cloneDeep(prev), timestamp: Date.now() },
         ...prev.actionHistory.slice(0, 4),
       ],
     }));
@@ -24,7 +25,7 @@ export default function useUndo(character, setCharacter, setRollResult) {
   const undoLastAction = () => {
     if (character.actionHistory.length > 0) {
       const lastAction = character.actionHistory[0];
-      setCharacter(structuredClone(lastAction.state));
+      setCharacter(cloneDeep(lastAction.state));
       if (setRollResult) {
         setRollResult(`\u21B6 Undid: ${lastAction.action}`);
         timeoutRef.current = setTimeout(() => setRollResult('Ready to roll!'), 2000);

--- a/src/hooks/useUndo.test.jsx
+++ b/src/hooks/useUndo.test.jsx
@@ -30,4 +30,34 @@ describe('useUndo', () => {
     expect(setRollResult).toHaveBeenNthCalledWith(2, 'Ready to roll!');
     vi.useRealTimers();
   });
+
+  it('restores previous state on undo without structuredClone', () => {
+    vi.useFakeTimers();
+    const setRollResult = vi.fn();
+    const original = globalThis.structuredClone;
+    // Simulate environment without native structuredClone
+    globalThis.structuredClone = undefined;
+    const { result } = renderHook(() => {
+      const [character, setCharacter] = useState({ value: 1, actionHistory: [] });
+      const undo = useUndo(character, setCharacter, setRollResult);
+      return { character, setCharacter, ...undo };
+    });
+
+    act(() => {
+      result.current.saveToHistory('increment');
+      result.current.setCharacter((prev) => ({ ...prev, value: prev.value + 1 }));
+    });
+    expect(result.current.character.value).toBe(2);
+
+    act(() => {
+      result.current.undoLastAction();
+      vi.runAllTimers();
+    });
+
+    expect(result.current.character.value).toBe(1);
+    expect(setRollResult).toHaveBeenNthCalledWith(1, '\u21B6 Undid: increment');
+    expect(setRollResult).toHaveBeenNthCalledWith(2, 'Ready to roll!');
+    globalThis.structuredClone = original;
+    vi.useRealTimers();
+  });
 });

--- a/src/utils/cloneDeep.js
+++ b/src/utils/cloneDeep.js
@@ -1,0 +1,6 @@
+export default function cloneDeep(value) {
+  if (typeof globalThis.structuredClone === 'function') {
+    return globalThis.structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}


### PR DESCRIPTION
## Summary
- add `cloneDeep` utility with JSON fallback
- use `cloneDeep` in undo hook instead of `structuredClone`
- test undo behavior when `structuredClone` is unavailable

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token : in tests/e2e/resource-bars.spec.ts)*
- `npx eslint src/utils/cloneDeep.js src/hooks/useUndo.js src/hooks/useUndo.test.jsx && echo 'eslint: no lint errors'`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec12eafac8332a8d14879be2e942a