### PR TITLE
test: add requestAnimationFrame polyfill

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -7,6 +7,10 @@ if (!globalThis.crypto) {
   globalThis.crypto = webcrypto;
 }
 
+if (!globalThis.requestAnimationFrame) {
+  globalThis.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+}
+
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn().mockResolvedValue('0.0.0'),
 }));


### PR DESCRIPTION
## Summary
- polyfill requestAnimationFrame in test setup for environments without it

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected token : at tests/e2e/resource-bars.spec.ts:7:12)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec15d524c83329a74dbee2a36ea3c