### PR TITLE
chore: configure ESLint for Vitest globals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,16 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['node_modules', 'dist', 'build', 'coverage', '.next', '.out', 'storybook-static'],
+    ignores: [
+      'node_modules',
+      'dist',
+      'build',
+      'coverage',
+      '.next',
+      '.out',
+      'storybook-static',
+      'tests',
+    ],
   },
   js.configs.recommended,
   reactPlugin.configs.flat.recommended,
@@ -28,7 +37,6 @@ export default [
       globals: {
         ...globals.browser,
         ...globals.node,
-        ...globals.vitest,
       },
     },
     settings: {
@@ -55,6 +63,9 @@ export default [
     files: ['**/*.{test,spec}.{js,jsx,ts,tsx}'],
     plugins: {
       vitest: vitestPlugin,
+    },
+    languageOptions: {
+      globals: vitestPlugin.configs.env.languageOptions.globals,
     },
     rules: {
       ...vitestPlugin.configs.recommended.rules,


### PR DESCRIPTION
## Summary
- drop Jest env directive from ResourceBars test
- configure ESLint with Vitest globals and ignore e2e tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec15eb13083328e78be56c43c2eeb