### PR TITLE
refactor: scope LevelUpModal styles with CSS modules

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useState, useEffect, useRef } from 'react';
-import './LevelUpModal.module.css';
+import styles from './LevelUpModal.module.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import { scoreToMod } from '../utils/score.js';
 import Message from './Message.jsx';
@@ -191,10 +191,10 @@ const LevelUpModal = ({
         isSelected);
 
     return [
-      'levelup-stat-button',
-      isSelected && 'selected',
-      isMaxed && 'maxed',
-      !isSelected && !canSelect && 'disabled',
+      styles.statButton,
+      isSelected && styles.selected,
+      isMaxed && styles.maxed,
+      !isSelected && !canSelect && styles.disabled,
     ]
       .filter(Boolean)
       .join(' ');
@@ -202,7 +202,7 @@ const LevelUpModal = ({
 
   const moveButtonClass = (moveId) => {
     const isSelected = levelUpState.selectedMove === moveId;
-    return ['levelup-move-button', isSelected && 'selected'].filter(Boolean).join(' ');
+    return [styles.moveButton, isSelected && styles.selected].filter(Boolean).join(' ');
   };
 
   const handleOverlayClick = (e) => {
@@ -224,7 +224,7 @@ const LevelUpModal = ({
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
     <div
-      className="levelup-overlay"
+      className={styles.overlay}
       onClick={handleOverlayClick}
       onKeyDown={handleOverlayKeyDown}
       aria-label="Close"
@@ -232,56 +232,56 @@ const LevelUpModal = ({
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/click-events-have-key-events */}
       <div
         ref={modalRef}
-        className="levelup-modal"
+        className={styles.modal}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         tabIndex={-1}
       >
         {/* Header */}
-        <div className="levelup-header">
-          <h2 className="levelup-header-title">LEVEL UP!</h2>
-          <p className="levelup-header-text">
+        <div className={styles.header}>
+          <h2 className={styles.headerTitle}>LEVEL UP!</h2>
+          <p className={styles.headerText}>
             {character.name} advances to Level {levelUpState.newLevel}
           </p>
-          <button onClick={onClose} className="levelup-close-button" aria-label="Close modal">
+          <button onClick={onClose} className={styles.closeButton} aria-label="Close modal">
             ×
           </button>
         </div>
 
-        <div className="levelup-content">
+        <div className={styles.content}>
           {/* Progress Indicator */}
-          <div className="levelup-progress">
+          <div className={styles.progress}>
             <div
-              className={`levelup-progress-step ${levelUpState.selectedStats.length > 0 ? 'complete' : ''}`}
+              className={`${styles.progressStep} ${levelUpState.selectedStats.length > 0 ? styles.complete : ''}`}
             >
-              <div className="levelup-progress-icon">
+              <div className={styles.progressIcon}>
                 {levelUpState.selectedStats.length > 0 ? '✅' : '1️⃣'}
               </div>
-              <div className="levelup-progress-label">Stats</div>
-            </div>
-            <div className={`levelup-progress-step ${levelUpState.selectedMove ? 'complete' : ''}`}>
-              <div className="levelup-progress-icon">{levelUpState.selectedMove ? '✅' : '2️⃣'}</div>
-              <div className="levelup-progress-label">Move</div>
+              <div className={styles.progressLabel}>Stats</div>
             </div>
             <div
-              className={`levelup-progress-step ${levelUpState.hpIncrease > 0 ? 'complete' : ''}`}
+              className={`${styles.progressStep} ${levelUpState.selectedMove ? styles.complete : ''}`}
             >
-              <div className="levelup-progress-icon">
-                {levelUpState.hpIncrease > 0 ? '✅' : '3️⃣'}
-              </div>
-              <div className="levelup-progress-label">HP</div>
+              <div className={styles.progressIcon}>{levelUpState.selectedMove ? '✅' : '2️⃣'}</div>
+              <div className={styles.progressLabel}>Move</div>
+            </div>
+            <div
+              className={`${styles.progressStep} ${levelUpState.hpIncrease > 0 ? styles.complete : ''}`}
+            >
+              <div className={styles.progressIcon}>{levelUpState.hpIncrease > 0 ? '✅' : '3️⃣'}</div>
+              <div className={styles.progressLabel}>HP</div>
             </div>
           </div>
 
           {/* Step 1: Stat Selection */}
-          <div className="levelup-step">
-            <h3 className="levelup-step-title">📊 Step 1: Increase Ability Scores</h3>
-            <p className="levelup-step-desc">
+          <div className={styles.step}>
+            <h3 className={styles.stepTitle}>📊 Step 1: Increase Ability Scores</h3>
+            <p className={styles.stepDesc}>
               Choose 1 stat (max 18) or 2 stats if both are under 16:
             </p>
 
-            <div className="levelup-stat-grid">
+            <div className={styles.statGrid}>
               {Object.entries(character.stats).map(([stat, data]) => (
                 <button
                   key={stat}
@@ -293,12 +293,12 @@ const LevelUpModal = ({
                       levelUpState.selectedStats.length >= 2)
                   }
                 >
-                  <div className="levelup-stat-name">{stat}</div>
-                  <div className="levelup-stat-score">
+                  <div className={styles.statName}>{stat}</div>
+                  <div className={styles.statScore}>
                     {data.score} → {data.score >= 18 ? data.score : data.score + 1}
                     {data.score >= 18 && ' (MAX)'}
                   </div>
-                  <div className="levelup-stat-mod">
+                  <div className={styles.statMod}>
                     ({data.mod >= 0 ? '+' : ''}
                     {data.mod} →{' '}
                     {Math.floor((Math.min(18, data.score + 1) - 10) / 2) >= 0 ? '+' : ''}
@@ -309,20 +309,20 @@ const LevelUpModal = ({
             </div>
 
             {levelUpState.selectedStats.length > 0 && (
-              <div className="levelup-selected-box">
+              <div className={styles.selectedBox}>
                 Selected: {levelUpState.selectedStats.join(', ')}
               </div>
             )}
           </div>
 
           {/* Step 2: Advanced Move Selection */}
-          <div className="levelup-step">
-            <h3 className="levelup-step-title">⚔️ Step 2: Choose Advanced Move</h3>
-            <div className="levelup-move-list">
+          <div className={styles.step}>
+            <h3 className={styles.stepTitle}>⚔️ Step 2: Choose Advanced Move</h3>
+            <div className={styles.moveList}>
               {Object.entries(advancedMoves)
                 .filter(([id]) => !character.selectedMoves.includes(id))
                 .map(([id, move]) => (
-                  <div key={id} className="levelup-move-wrapper">
+                  <div key={id} className={styles.moveWrapper}>
                     <div
                       onClick={() => setLevelUpState((prev) => ({ ...prev, selectedMove: id }))}
                       className={moveButtonClass(id)}
@@ -333,10 +333,10 @@ const LevelUpModal = ({
                         setLevelUpState((prev) => ({ ...prev, selectedMove: id }))
                       }
                     >
-                      <div className="levelup-move-header">
-                        <div className="levelup-move-text">
-                          <h4 className="levelup-move-name">{move.name}</h4>
-                          <p className="levelup-move-desc">{move.desc}</p>
+                      <div className={styles.moveHeader}>
+                        <div className={styles.moveText}>
+                          <h4 className={styles.moveName}>{move.name}</h4>
+                          <p className={styles.moveDesc}>{move.desc}</p>
                         </div>
                         <button
                           type="button"
@@ -344,7 +344,7 @@ const LevelUpModal = ({
                             e.stopPropagation();
                             setShowMoveDetails(showMoveDetails === id ? '' : id);
                           }}
-                          className="levelup-details-button"
+                          className={styles.detailsButton}
                         >
                           {showMoveDetails === id ? '▲' : '▼'}
                         </button>
@@ -353,9 +353,9 @@ const LevelUpModal = ({
 
                     {/* Expanded move details */}
                     {showMoveDetails === id && (
-                      <div className="levelup-move-details">
-                        <p className="levelup-move-expanded">{move.expanded}</p>
-                        <div className="levelup-move-examples">
+                      <div className={styles.moveDetails}>
+                        <p className={styles.moveExpanded}>{move.expanded}</p>
+                        <div className={styles.moveExamples}>
                           <strong>Examples:</strong>
                           <br />
                           {move.examples}
@@ -367,38 +367,38 @@ const LevelUpModal = ({
             </div>
 
             {levelUpState.selectedMove && (
-              <div className="levelup-selected-box levelup-selected-move">
+              <div className={`${styles.selectedBox} ${styles.selectedMove}`}>
                 Selected: {advancedMoves[levelUpState.selectedMove].name}
               </div>
             )}
           </div>
 
           {/* Step 3: HP Rolling */}
-          <div className="levelup-step">
-            <h3 className="levelup-step-title">❤️ Step 3: Roll for Hit Points</h3>
-            <div className="levelup-hp-container">
+          <div className={styles.step}>
+            <h3 className={styles.stepTitle}>❤️ Step 3: Roll for Hit Points</h3>
+            <div className={styles.hpContainer}>
               <button
                 onClick={rollHPIncrease}
-                className={`levelup-button ${levelUpState.hpIncrease > 0 ? 'levelup-button-rolled' : ''}`}
+                className={`${styles.button} ${levelUpState.hpIncrease > 0 ? styles.buttonRolled : ''}`}
                 disabled={levelUpState.hpIncrease > 0}
               >
                 {levelUpState.hpIncrease > 0 ? '✅ HP Rolled' : '🎲 Roll d10 + CON'}
               </button>
 
-              <div className="levelup-hp-text">
+              <div className={styles.hpText}>
                 Roll d10 + CON ({character.stats.CON.mod >= 0 ? '+' : ''}
                 {character.stats.CON.mod}) for HP increase
                 {levelUpState.hpIncrease > 0 && (
-                  <div className="levelup-hp-result">Result: +{levelUpState.hpIncrease} HP</div>
+                  <div className={styles.hpResult}>Result: +{levelUpState.hpIncrease} HP</div>
                 )}
               </div>
             </div>
           </div>
 
           {/* Summary & Complete Button */}
-          <div className={`levelup-summary ${isComplete ? 'complete' : 'incomplete'}`}>
-            <h4 className="levelup-summary-title">Level Up Summary</h4>
-            <div className="levelup-summary-details">
+          <div className={`${styles.summary} ${isComplete ? styles.complete : styles.incomplete}`}>
+            <h4 className={styles.summaryTitle}>Level Up Summary</h4>
+            <div className={styles.summaryDetails}>
               <div>
                 Level: {character.level} → {levelUpState.newLevel}
               </div>
@@ -419,15 +419,15 @@ const LevelUpModal = ({
               </div>
             </div>
 
-            <div className="levelup-actions">
-              <button onClick={onClose} className="levelup-button levelup-button-cancel">
+            <div className={styles.actions}>
+              <button onClick={onClose} className={`${styles.button} ${styles.buttonCancel}`}>
                 Cancel
               </button>
 
               <button
                 onClick={completeLevelUp}
                 disabled={!isComplete}
-                className={`levelup-button levelup-button-complete ${!isComplete ? 'levelup-button-disabled' : ''}`}
+                className={`${styles.button} ${styles.buttonComplete} ${!isComplete ? styles.buttonDisabled : ''}`}
               >
                 🚀 Complete Level Up!
               </button>

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -1,350 +1,348 @@
-:global {
-  .levelup-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.9);
-    backdrop-filter: blur(8px);
-    z-index: 1000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--hud-spacing);
-    overflow-y: auto;
-  }
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.9);
+  backdrop-filter: blur(8px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--hud-spacing);
+  overflow-y: auto;
+}
 
-  .levelup-modal {
-    background: linear-gradient(135deg, var(--color-modal-bg), var(--color-modal-bg-secondary));
-    border: 2px solid var(--color-neon);
-    border-radius: 15px;
-    max-width: 700px;
-    width: 100%;
-    max-height: 90vh;
-    overflow-y: auto;
-    box-shadow: 0 20px 40px rgba(0, 255, 136, 0.3);
-  }
+.modal {
+  background: linear-gradient(135deg, var(--color-modal-bg), var(--color-modal-bg-secondary));
+  border: 2px solid var(--color-neon);
+  border-radius: 15px;
+  max-width: 700px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 40px rgba(0, 255, 136, 0.3);
+}
 
-  .levelup-header {
-    background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
-    padding: var(--hud-spacing);
-    border-radius: 13px 13px 0 0;
-    text-align: center;
-    position: relative;
-  }
+.header {
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  padding: var(--hud-spacing);
+  border-radius: 13px 13px 0 0;
+  text-align: center;
+  position: relative;
+}
 
-  .levelup-header-title {
-    margin: 0;
-    font-size: 1.5rem;
-    color: var(--color-white);
-  }
+.headerTitle {
+  margin: 0;
+  font-size: 1.5rem;
+  color: var(--color-white);
+}
 
-  .levelup-header-text {
-    margin: 5px 0 0;
-    color: var(--color-info-light);
-  }
+.headerText {
+  margin: 5px 0 0;
+  color: var(--color-info-light);
+}
 
-  .levelup-close-button {
-    position: absolute;
-    top: 15px;
-    right: 15px;
-    background: rgba(255, 255, 255, 0.2);
-    border: none;
-    color: var(--color-white);
-    width: 30px;
-    height: 30px;
-    border-radius: 50%;
-    cursor: pointer;
-    font-size: 18px;
-  }
+.closeButton {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  color: var(--color-white);
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 18px;
+}
 
-  .levelup-content {
-    padding: var(--hud-spacing);
-  }
+.content {
+  padding: var(--hud-spacing);
+}
 
-  .levelup-progress {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 20px;
-    padding: var(--hud-spacing-sm);
-    background: rgba(0, 255, 136, 0.1);
-    border-radius: 8px;
-    border: 1px solid rgba(0, 255, 136, 0.3);
-  }
+.progress {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+  padding: var(--hud-spacing-sm);
+  background: rgba(0, 255, 136, 0.1);
+  border-radius: 8px;
+  border: 1px solid rgba(0, 255, 136, 0.3);
+}
 
-  .levelup-progress-step {
-    text-align: center;
-    color: var(--color-gray-700);
-  }
+.progressStep {
+  text-align: center;
+  color: var(--color-gray-700);
+}
 
-  .levelup-progress-step.complete {
-    color: var(--color-neon);
-  }
+.progressStep.complete {
+  color: var(--color-neon);
+}
 
-  .levelup-progress-icon {
-    font-size: 20px;
-  }
+.progressIcon {
+  font-size: 20px;
+}
 
-  .levelup-progress-label {
-    font-size: var(--font-size-sm);
-  }
+.progressLabel {
+  font-size: var(--font-size-sm);
+}
 
-  .levelup-step {
-    margin-bottom: 20px;
-  }
+.step {
+  margin-bottom: 20px;
+}
 
-  .levelup-step-title {
-    color: var(--color-neon);
-    margin-bottom: 10px;
-    font-size: 1.2rem;
-  }
+.stepTitle {
+  color: var(--color-neon);
+  margin-bottom: 10px;
+  font-size: 1.2rem;
+}
 
-  .levelup-step-desc {
-    color: var(--color-gray-100);
-    font-size: 14px;
-    margin-bottom: var(--space-md);
-  }
+.stepDesc {
+  color: var(--color-gray-100);
+  font-size: 14px;
+  margin-bottom: var(--space-md);
+}
 
-  .levelup-stat-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 10px;
-    margin-bottom: 10px;
-  }
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 10px;
+}
 
-  .levelup-stat-button {
-    padding: var(--hud-spacing-sm);
-    border: 2px solid var(--color-gray-700);
-    border-radius: 8px;
-    background: var(--color-modal-bg);
-    color: var(--color-gray-100);
-    cursor: pointer;
-    text-align: center;
-    transition: var(--hud-transition);
-    font-size: 14px;
-  }
+.statButton {
+  padding: var(--hud-spacing-sm);
+  border: 2px solid var(--color-gray-700);
+  border-radius: 8px;
+  background: var(--color-modal-bg);
+  color: var(--color-gray-100);
+  cursor: pointer;
+  text-align: center;
+  transition: var(--hud-transition);
+  font-size: 14px;
+}
 
-  .levelup-stat-button.selected {
-    border-color: var(--color-neon);
-    background: rgba(0, 255, 136, 0.2);
-    color: var(--color-neon);
-  }
+.statButton.selected {
+  border-color: var(--color-neon);
+  background: rgba(0, 255, 136, 0.2);
+  color: var(--color-neon);
+}
 
-  .levelup-stat-button.maxed {
-    border-color: var(--color-gray-700);
-    background: var(--color-gray-800);
-    color: var(--color-gray-700);
-    cursor: not-allowed;
-  }
+.statButton.maxed {
+  border-color: var(--color-gray-700);
+  background: var(--color-gray-800);
+  color: var(--color-gray-700);
+  cursor: not-allowed;
+}
 
-  .levelup-stat-button.disabled {
-    border-color: var(--color-gray-800);
-    background: var(--color-gray-900);
-    color: var(--color-gray-700);
-    cursor: not-allowed;
-  }
+.statButton.disabled {
+  border-color: var(--color-gray-800);
+  background: var(--color-gray-900);
+  color: var(--color-gray-700);
+  cursor: not-allowed;
+}
 
-  .levelup-stat-name {
-    font-weight: bold;
-  }
+.statName {
+  font-weight: bold;
+}
 
-  .levelup-stat-score {
-    font-size: var(--font-size-sm);
-  }
+.statScore {
+  font-size: var(--font-size-sm);
+}
 
-  .levelup-stat-mod {
-    font-size: 10px;
-    opacity: 0.8;
-  }
+.statMod {
+  font-size: 10px;
+  opacity: 0.8;
+}
 
-  .levelup-selected-box {
-    padding: var(--space-sm) 12px;
-    background: rgba(0, 255, 136, 0.1);
-    border: 1px solid rgba(0, 255, 136, 0.3);
-    border-radius: var(--hud-radius-sm);
-    font-size: 14px;
-    color: var(--color-neon);
-  }
+.selectedBox {
+  padding: var(--space-sm) 12px;
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.3);
+  border-radius: var(--hud-radius-sm);
+  font-size: 14px;
+  color: var(--color-neon);
+}
 
-  .levelup-selected-move {
-    margin-top: var(--space-sm);
-  }
+.selectedMove {
+  margin-top: var(--space-sm);
+}
 
-  .levelup-move-list {
-    max-height: 250px;
-    overflow-y: auto;
-    border: 1px solid var(--color-gray-700);
-    border-radius: 8px;
-    padding: var(--space-sm);
-  }
+.moveList {
+  max-height: 250px;
+  overflow-y: auto;
+  border: 1px solid var(--color-gray-700);
+  border-radius: 8px;
+  padding: var(--space-sm);
+}
 
-  .levelup-move-wrapper {
-    margin-bottom: var(--space-sm);
-  }
+.moveWrapper {
+  margin-bottom: var(--space-sm);
+}
 
-  .levelup-move-button {
-    padding: 12px;
-    border: 2px solid var(--color-gray-700);
-    border-radius: 8px;
-    background: var(--color-modal-bg);
-    color: var(--color-gray-100);
-    cursor: pointer;
-    text-align: left;
-    transition: var(--hud-transition);
-    margin-bottom: var(--space-sm);
-  }
+.moveButton {
+  padding: 12px;
+  border: 2px solid var(--color-gray-700);
+  border-radius: 8px;
+  background: var(--color-modal-bg);
+  color: var(--color-gray-100);
+  cursor: pointer;
+  text-align: left;
+  transition: var(--hud-transition);
+  margin-bottom: var(--space-sm);
+}
 
-  .levelup-move-button.selected {
-    border-color: var(--color-neon);
-    background: rgba(0, 255, 136, 0.2);
-  }
+.moveButton.selected {
+  border-color: var(--color-neon);
+  background: rgba(0, 255, 136, 0.2);
+}
 
-  .levelup-move-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-  }
+.moveHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
 
-  .levelup-move-text {
-    flex: 1;
-  }
+.moveText {
+  flex: 1;
+}
 
-  .levelup-move-name {
-    margin: 0;
-    color: var(--color-neon);
-    font-size: 14px;
-    font-weight: bold;
-  }
+.moveName {
+  margin: 0;
+  color: var(--color-neon);
+  font-size: 14px;
+  font-weight: bold;
+}
 
-  .levelup-move-desc {
-    margin: 4px 0 0;
-    font-size: var(--font-size-sm);
-    color: var(--color-gray-200);
-    line-height: 1.3;
-  }
+.moveDesc {
+  margin: 4px 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-gray-200);
+  line-height: 1.3;
+}
 
-  .levelup-details-button {
-    background: none;
-    border: none;
-    color: var(--color-neon);
-    cursor: pointer;
-    font-size: var(--font-size-sm);
-    margin-left: var(--space-sm);
-  }
+.detailsButton {
+  background: none;
+  border: none;
+  color: var(--color-neon);
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  margin-left: var(--space-sm);
+}
 
-  .levelup-move-details {
-    padding: 12px;
-    background: rgba(0, 255, 136, 0.05);
-    border: 1px solid rgba(0, 255, 136, 0.2);
-    border-radius: var(--hud-radius-sm);
-    margin-left: 10px;
-    font-size: var(--font-size-sm);
-  }
+.moveDetails {
+  padding: 12px;
+  background: rgba(0, 255, 136, 0.05);
+  border: 1px solid rgba(0, 255, 136, 0.2);
+  border-radius: var(--hud-radius-sm);
+  margin-left: 10px;
+  font-size: var(--font-size-sm);
+}
 
-  .levelup-move-expanded {
-    color: var(--color-gray-100);
-    margin-bottom: var(--space-sm);
-    line-height: 1.4;
-  }
+.moveExpanded {
+  color: var(--color-gray-100);
+  margin-bottom: var(--space-sm);
+  line-height: 1.4;
+}
 
-  .levelup-move-examples {
-    color: var(--color-gray-400);
-  }
+.moveExamples {
+  color: var(--color-gray-400);
+}
 
-  .levelup-hp-container {
-    display: flex;
-    align-items: center;
-    gap: 15px;
-    padding: 15px;
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 8px;
-    border: 1px solid var(--color-gray-700);
-  }
+.hpContainer {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  padding: 15px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  border: 1px solid var(--color-gray-700);
+}
 
-  .levelup-button {
-    background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
-    border: none;
-    color: var(--color-white);
-    padding: 10px 20px;
-    border-radius: var(--hud-radius-sm);
-    cursor: pointer;
-    font-weight: bold;
-    transition: var(--hud-transition);
-    font-size: 14px;
-  }
+.button {
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  border: none;
+  color: var(--color-white);
+  padding: 10px 20px;
+  border-radius: var(--hud-radius-sm);
+  cursor: pointer;
+  font-weight: bold;
+  transition: var(--hud-transition);
+  font-size: 14px;
+}
 
-  .levelup-button-rolled {
-    background: linear-gradient(45deg, var(--color-neon-dark), var(--color-neon-darker));
-  }
+.buttonRolled {
+  background: linear-gradient(45deg, var(--color-neon-dark), var(--color-neon-darker));
+}
 
-  .levelup-button-cancel {
-    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-700));
-  }
+.buttonCancel {
+  background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-700));
+}
 
-  .levelup-button-complete {
-    background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
-    font-size: 16px;
-    padding: 12px 24px;
-  }
+.buttonComplete {
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  font-size: 16px;
+  padding: 12px 24px;
+}
 
-  .levelup-button-disabled {
-    background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-700));
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+.buttonDisabled {
+  background: linear-gradient(45deg, var(--color-gray-700), var(--color-gray-700));
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
-  .levelup-hp-text {
-    color: var(--color-gray-100);
-    font-size: 14px;
-  }
+.hpText {
+  color: var(--color-gray-100);
+  font-size: 14px;
+}
 
-  .levelup-hp-result {
-    color: var(--color-neon);
-    font-weight: bold;
-    margin-top: 4px;
-  }
+.hpResult {
+  color: var(--color-neon);
+  font-weight: bold;
+  margin-top: 4px;
+}
 
-  .levelup-summary {
-    padding: 15px;
-    border-radius: 8px;
-    text-align: center;
-  }
+.summary {
+  padding: 15px;
+  border-radius: 8px;
+  text-align: center;
+}
 
-  .levelup-summary.complete {
-    background: rgba(0, 255, 136, 0.1);
-    border: 1px solid rgba(0, 255, 136, 0.3);
-  }
+.summary.complete {
+  background: rgba(0, 255, 136, 0.1);
+  border: 1px solid rgba(0, 255, 136, 0.3);
+}
 
-  .levelup-summary.incomplete {
-    background: rgba(255, 170, 68, 0.1);
-    border: 1px solid rgba(255, 170, 68, 0.3);
-  }
+.summary.incomplete {
+  background: rgba(255, 170, 68, 0.1);
+  border: 1px solid rgba(255, 170, 68, 0.3);
+}
 
-  .levelup-summary-title {
-    color: var(--color-neon);
-    margin: 0 0 10px;
-    font-size: 1.1rem;
-  }
+.summaryTitle {
+  color: var(--color-neon);
+  margin: 0 0 10px;
+  font-size: 1.1rem;
+}
 
-  .levelup-summary-details {
-    color: var(--color-gray-100);
-    font-size: 14px;
-    line-height: 1.4;
-  }
+.summaryDetails {
+  color: var(--color-gray-100);
+  font-size: 14px;
+  line-height: 1.4;
+}
 
-  .levelup-actions {
-    margin-top: var(--space-md);
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-    flex-wrap: wrap;
-    width: 100%;
-  }
+.actions {
+  margin-top: var(--space-md);
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: 100%;
+}
 
-  @media (max-width: 360px) {
-    .levelup-actions {
-      flex-direction: column;
-    }
+@media (max-width: 360px) {
+  .actions {
+    flex-direction: column;
   }
 }

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -1,10 +1,12 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import React, { useState } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect, vi } from 'vitest';
 import { advancedMoves } from '../data/advancedMoves.js';
+import CharacterStats from './CharacterStats.jsx';
 import LevelUpModal from './LevelUpModal.jsx';
+import styles from './LevelUpModal.module.css';
 
 function LevelUpWrapper({ isOpen, ...props }) {
   return isOpen ? <LevelUpModal {...props} /> : null;
@@ -248,5 +250,69 @@ describe('LevelUpModal visibility and closing', () => {
     const group = screen.getByRole('button', { name: /Cancel/i }).parentElement;
     group.style.overflowX = 'auto';
     expect(group.scrollWidth).toBeLessThanOrEqual(group.clientWidth);
+  });
+
+  it('opens via level up trigger with overlay and modal styles', async () => {
+    const character = {
+      name: 'Test',
+      level: 1,
+      stats: {
+        STR: { score: 10, mod: 0 },
+        DEX: { score: 10, mod: 0 },
+        CON: { score: 10, mod: 0 },
+        INT: { score: 10, mod: 0 },
+        WIS: { score: 10, mod: 0 },
+        CHA: { score: 10, mod: 0 },
+      },
+      hp: 10,
+      maxHp: 10,
+      xp: 8,
+      xpNeeded: 8,
+      resources: { chronoUses: 0 },
+      selectedMoves: [],
+    };
+
+    const levelUpState = {
+      selectedStats: [],
+      selectedMove: '',
+      hpIncrease: 0,
+      newLevel: 2,
+      expandedMove: '',
+    };
+
+    function Wrapper() {
+      const [showLevelUpModal, setShowLevelUpModal] = useState(false);
+      return (
+        <>
+          <CharacterStats
+            character={character}
+            setCharacter={() => {}}
+            saveToHistory={() => {}}
+            totalArmor={0}
+            setShowLevelUpModal={setShowLevelUpModal}
+            setRollResult={() => {}}
+          />
+          {showLevelUpModal && (
+            <LevelUpModal
+              character={character}
+              setCharacter={() => {}}
+              levelUpState={levelUpState}
+              setLevelUpState={() => {}}
+              onClose={() => setShowLevelUpModal(false)}
+              rollDie={() => 1}
+              setRollResult={() => {}}
+            />
+          )}
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    await user.click(screen.getByRole('button', { name: /LEVEL UP AVAILABLE!/i }));
+    const modal = screen.getByRole('dialog');
+    expect(modal).toBeInTheDocument();
+    expect(modal).toHaveClass(styles.modal);
+    expect(modal.parentElement).toHaveClass(styles.overlay);
   });
 });


### PR DESCRIPTION
## Summary
- scope LevelUpModal styles via CSS modules and drop global selectors
- render LevelUpModal with CSS module classes and add regression test for overlay styling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f129179788332acbc5b79f8c06c67