### PR TITLE
test: use tauri-driver for e2e

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "test": "vitest run --exclude tests",
-    "test:e2e": "playwright test tests/app.e2e.spec.ts",
+    "test:e2e": "vitest run -c vitest.e2e.config.js tests/app.e2e.spec.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/tests/app.e2e.spec.ts
+++ b/tests/app.e2e.spec.ts
@@ -1,18 +1,59 @@
-/* eslint-disable import/no-unresolved */
-import { test, expect } from '@playwright/test';
-import { launch } from 'playwright-tauri';
+import { spawn, spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { waitTauriDriverReady } from '@crabnebula/tauri-driver';
+import { remote } from 'webdriverio';
+import { beforeAll, afterAll, test, expect } from 'vitest';
 
-test.beforeAll(async () => {
-  // Ensure the Tauri app is built in debug mode
-  // e.g., `npx tauri build --debug` run separately or via scripts
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let browser; // WebdriverIO.Browser
+let tauriDriver;
+
+const parseXp = (text: string): number => {
+  const match = /XP: (\d+)/.exec(text);
+  return match ? Number(match[1]) : 0;
+};
+
+beforeAll(async () => {
+  const tauriDir = path.resolve(__dirname, '../src-tauri');
+  spawnSync('npx', ['tauri', 'build', '--debug'], {
+    cwd: tauriDir,
+    stdio: 'inherit',
+  });
+
+  tauriDriver = spawn('npx', ['tauri-driver'], {
+    stdio: 'inherit',
+    shell: true,
+  });
+  await waitTauriDriverReady();
+
+  const appPath = path.resolve(tauriDir, 'target/debug/zimbo-panel');
+  browser = await remote({
+    hostname: '127.0.0.1',
+    port: 4444,
+    capabilities: {
+      'tauri:options': {
+        application: appPath,
+      },
+    },
+    logLevel: 'error',
+  });
+}, 120000);
+
+afterAll(async () => {
+  if (browser) {
+    await browser.deleteSession();
+  }
+  if (tauriDriver) {
+    tauriDriver.kill();
+  }
 });
 
 test('increments XP on button click', async () => {
-  const app = await launch({ path: 'src-tauri/target/debug/zimbo-panel' });
-  const window = await app.firstWindow();
-
-  await window.click('button:has-text("+1 XP")');
-  await expect(window.locator('div:has-text("XP:")')).toContainText('XP: 1');
-
-  await app.close();
-});
+  const xpEl = await browser.$('div*=XP:');
+  const initialXp = parseXp(await xpEl.getText());
+  const xpButton = await browser.$('button=+1 XP');
+  await xpButton.click();
+  expect(parseXp(await xpEl.getText())).toBe(initialXp + 1);
+}, 120000);

--- a/vitest.e2e.config.js
+++ b/vitest.e2e.config.js
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['tests/**/*.e2e.test.js', 'tests/e2e/**/*.spec.ts'],
+    include: ['tests/**/*.e2e.test.js', 'tests/**/*.e2e.spec.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- replace playwright-tauri with tauri-driver in e2e spec
- run e2e tests with Vitest

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: glib-2.0 PC file missing, WebKitWebDriver binary not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f192f2f3c8332a8e3a5e9ad72a4bf