### PR TITLE
chore: add TypeScript project configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,9 +70,7 @@ export default [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-        ecmaFeatures: { jsx: true },
+        project: true,
       },
       globals: {
         ...globals.browser,
@@ -80,7 +78,7 @@ export default [
       },
     },
     rules: {
-      ...tseslint.configs.recommended.rules,
+      ...tseslint.configs['flat/recommended-type-checked'].rules,
     },
   },
   {

--- a/index.html
+++ b/index.html
@@ -15,6 +15,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "prettier": "^3.6.2",
         "rimraf": "^4.4.1",
         "rollup": "^4.46.2",
+        "typescript": "^5.6.3",
         "vite": "^7.0.4",
         "vitest": "^3.2.4",
         "webdriverio": "^9.19.1"
@@ -10262,7 +10263,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "prettier": "^3.6.2",
     "rimraf": "^4.4.1",
     "rollup": "^4.46.2",
+    "typescript": "^5.6.3",
     "vite": "^7.0.4",
     "vitest": "^3.2.4",
     "webdriverio": "^9.19.1"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import { CharacterProvider } from './state/CharacterContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
 import { SettingsProvider } from './state/SettingsContext.jsx';
+import { ThemeProvider } from './state/ThemeContext.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "allowJs": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "tests", "vite.config.ts", "playwright.config.ts"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig(async () => ({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/setupTests.js',
-    include: ['src/**/*.{test,spec}.{js,jsx}'],
+    include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
   },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`


### PR DESCRIPTION
## Summary
- add `tsconfig.json` with strict settings for React and bundler resolution
- enable type-aware ESLint rules and allow TS tests in Vite
- convert entrypoint to TypeScript and install TypeScript dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3ee53d5483329a1eda29f878de60