### PR TITLE
fix: clean up aid modal on unmount

### DIFF
--- a/src/hooks/useDiceRoller.cleanup.test.jsx
+++ b/src/hooks/useDiceRoller.cleanup.test.jsx
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { SettingsProvider } from '../state/SettingsContext.jsx';
+import useDiceRoller from './useDiceRoller.js';
+
+const aidModal = {
+  isOpen: false,
+  open: vi.fn(() => {
+    aidModal.isOpen = true;
+  }),
+  close: vi.fn(() => {
+    aidModal.isOpen = false;
+  }),
+};
+const rollModal = {
+  isOpen: false,
+  open: vi.fn(),
+  close: vi.fn(),
+};
+let modalCallCount = 0;
+vi.mock('./useModal', () => {
+  return {
+    default: () => {
+      modalCallCount += 1;
+      return modalCallCount === 1 ? rollModal : aidModal;
+    },
+  };
+});
+
+const wrapper = ({ children }) => (
+  <SettingsProvider initialAutoXpOnMiss={false}>{children}</SettingsProvider>
+);
+
+describe('useDiceRoller cleanup', () => {
+  const baseCharacter = { statusEffects: [], debilities: [], xp: 0 };
+
+  it('closes aid modal and resolves pending promise on unmount', async () => {
+    const setCharacter = () => {};
+    const { result, unmount } = renderHook(() => useDiceRoller(baseCharacter, setCharacter), {
+      wrapper,
+    });
+
+    let rollPromise;
+    act(() => {
+      rollPromise = result.current.rollDice('2d6', 'test');
+    });
+
+    expect(aidModal.isOpen).toBe(true);
+
+    act(() => {
+      unmount();
+    });
+
+    await rollPromise;
+
+    expect(aidModal.close).toHaveBeenCalledTimes(1);
+    expect(aidModal.isOpen).toBe(false);
+  });
+});

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -25,6 +25,7 @@ export default function useDiceRoller(
   });
   const rollModal = useModal();
   const aidModalState = useModal();
+  const closeAidModal = aidModalState.close;
   const aidResolverRef = useRef(null);
 
   const openAidModal = () =>
@@ -52,6 +53,16 @@ export default function useDiceRoller(
       safeLocalStorage.removeItem('rollHistory');
     }
   }, [rollHistory]);
+
+  useEffect(() => {
+    return () => {
+      if (aidResolverRef.current) {
+        aidResolverRef.current(null);
+        aidResolverRef.current = null;
+      }
+      closeAidModal();
+    };
+  }, [closeAidModal]);
 
   const getStatusModifiers = (rollType = 'general') => {
     let modifier = 0;


### PR DESCRIPTION
## Summary
- add cleanup effect to resolve pending aid rolls and close modal on unmount
- test aid modal cleanup when hook is unmounted

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f3ee7e4508332969e847174c85ebc