### PR TITLE
chore: reference non-commercial license in package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zimbo-panel",
   "private": true,
   "version": "0.1.1",
-  "license": "MIT",
+  "license": "SEE LICENSE",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- reference custom Non-Commercial license in package metadata

## Testing
- `npm run format:check` *(fails: .github/workflows/codex-preflight.yml parse error)*
- `npm run lint`
- `npm test`
- `npx playwright install`
- `npx tauri build --debug` *(fails: glib-2.0 not found)*
- `npm run test:e2e` *(fails: missing gobject-2.0 / WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f50126fe48332bcb8db3039164c52