### PR TITLE
test: consolidate confirm mock setup in App tests

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -9,23 +9,17 @@ import { SettingsProvider } from './state/SettingsContext.jsx';
 import { ThemeProvider } from './state/ThemeContext.jsx';
 import './styles/theme.css';
 
-beforeEach(() => {
-  vi.spyOn(window, 'confirm').mockReturnValue(false);
-  vi.spyOn(window, 'prompt').mockReturnValue('0');
-});
-
-afterEach(() => {
-  window.confirm.mockRestore();
-  window.prompt.mockRestore();
-});
-
 let confirmSpy;
+let promptSpy;
+
 beforeEach(() => {
   confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+  promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('0');
 });
 
 afterEach(() => {
   confirmSpy.mockRestore();
+  promptSpy.mockRestore();
 });
 
 const createWrapper = (initialCharacter, autoXpOnMiss) =>


### PR DESCRIPTION
## Summary
- simplify `window.confirm` mocking in `App.test.jsx`

## Testing
- `npm run lint`
- `npm run format:check` *(fails: SyntaxError in .github/workflows/codex-preflight.yml)*
- `npm test src/App.test.jsx`
- `npm run test:e2e` *(fails: missing glib-2.0/gobject-2.0 and WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f50244074833285e95d0ad3ceedcb