### PR TITLE
docs: document export and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ A cross-platform desktop application for managing tabletop RPG characters. Built
 - **Inventory System** – Equip, consume, or drop items; calculates total armor and weapon damage.
 - **Session Notes** – Take persistent notes, switch between compact and full modes.
 - **Undo/History** – Reverse recent actions with a built-in undo system.
+- **Import/Export** – Save or load characters with the `ExportModal`.
 - **Visual Effects** – Status-based overlays (poisoned, burning, shocked, etc.).
 - **Theme Switching** – Select from cosmic, classic, or moebius themes.
 - **Cross-Platform Packaging** – Create native binaries via Tauri.
+
+## Saving and Loading a Character
+
+1. Click **Export/Import** in the toolbar.
+2. Choose **Export** to save the current character, for example `my-hero.json`.
+3. To load it later, reopen **Export/Import**, select **Import**, and pick the saved file.
 
 ## Settings
 


### PR DESCRIPTION
## Summary
- document export/import features using ExportModal in README
- add example for saving and loading a character

## Testing
- `npm run lint`
- `npm run format:check` *(fails: .github/workflows/codex-preflight.yml SyntaxError)*
- `npx prettier --check README.md`
- `npm test`
- `npm run test:e2e` *(fails: missing system libraries and driver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f53fe00e48332b2aa6d5ab6d12985