### PR TITLE
feat: support multiple characters

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,7 @@ import InventoryPanel from './components/InventoryPanel.jsx';
 import SessionNotes from './components/SessionNotes.jsx';
 import CharacterHUD from './components/CharacterHUD/CharacterHUD.jsx';
 import Settings from './components/Settings.jsx';
+import CharacterSwitcher from './components/CharacterSwitcher.jsx';
 import AppVersion from './components/AppVersion.tsx';
 import DiagnosticOverlay from './components/DiagnosticOverlay.jsx';
 import useDiceRoller from './hooks/useDiceRoller';
@@ -122,6 +123,7 @@ function App() {
         {/* Header */}
         <div className={styles.header} style={{ background: getHeaderColor() }}>
           <div className={styles.headerTop}>
+            <CharacterSwitcher />
             <div>
               {/* eslint-disable-next-line jsx-a11y/tabindex-no-positive */}
               <h1 className={styles.title} tabIndex={1}>

--- a/src/components/CharacterSwitcher.jsx
+++ b/src/components/CharacterSwitcher.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useCharacter } from '../state/CharacterContext.jsx';
+
+export default function CharacterSwitcher() {
+  const ctx = useCharacter();
+  if (!ctx?.characters || !ctx?.setSelectedId || ctx.selectedId === undefined) return null;
+  const { characters, selectedId, setSelectedId } = ctx;
+  return (
+    <select
+      value={selectedId}
+      onChange={(e) => setSelectedId(e.target.value)}
+      aria-label="Select character"
+    >
+      {characters.map((c, idx) => (
+        <option key={c.id} value={c.id}>
+          {c.name || `Character ${idx + 1}`}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/CharacterSwitcher.test.jsx
+++ b/src/components/CharacterSwitcher.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { INITIAL_CHARACTER_DATA } from '../state/character.js';
+import { CharacterProvider, useCharacter } from '../state/CharacterContext.jsx';
+import CharacterSwitcher from './CharacterSwitcher.jsx';
+
+describe('CharacterSwitcher', () => {
+  it('switches characters via select', async () => {
+    const user = userEvent.setup();
+    function AddCharacter() {
+      const { addCharacter } = useCharacter();
+      React.useEffect(() => {
+        addCharacter({ ...INITIAL_CHARACTER_DATA, hp: 5 });
+      }, [addCharacter]);
+      return null;
+    }
+    function ShowHp() {
+      const { character } = useCharacter();
+      return <div data-testid="hp">{character.hp}</div>;
+    }
+    render(
+      <CharacterProvider>
+        <AddCharacter />
+        <CharacterSwitcher />
+        <ShowHp />
+      </CharacterProvider>,
+    );
+    const select = screen.getByLabelText('Select character');
+    expect(select.options).toHaveLength(2);
+    await user.selectOptions(select, select.options[1]);
+    expect(screen.getByTestId('hp')).toHaveTextContent('5');
+  });
+});

--- a/src/components/ExportModal.jsx
+++ b/src/components/ExportModal.jsx
@@ -1,14 +1,18 @@
 import { saveFile, loadFile } from '../utils/fileStorage.js';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { FaSatellite } from 'react-icons/fa6';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './ExportModal.module.css';
 
 export default function ExportModal({ isOpen, onClose }) {
-  const { character, setCharacter } = useCharacter();
-  const [fileName, setFileName] = useState('character.json');
+  const { character, addCharacter, selectedId } = useCharacter();
+  const [fileName, setFileName] = useState(`character-${selectedId}.json`);
   const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    setFileName(`character-${selectedId}.json`);
+  }, [selectedId]);
 
   if (!isOpen) return null;
 
@@ -25,7 +29,11 @@ export default function ExportModal({ isOpen, onClose }) {
     try {
       const contents = await loadFile(fileName);
       const data = JSON.parse(contents);
-      setCharacter(data);
+      if (data.id) {
+        addCharacter(data);
+      } else {
+        addCharacter({ ...data });
+      }
       setMessage('Character loaded!');
     } catch (err) {
       setMessage('Failed to load.');

--- a/src/components/ExportModal.test.jsx
+++ b/src/components/ExportModal.test.jsx
@@ -13,11 +13,34 @@ vi.mock('../utils/fileStorage.js', () => ({
 
 function renderWithCharacter(ui, { character }) {
   const Wrapper = ({ children }) => {
-    const [charState, setCharState] = React.useState(character);
+    const [characters, setCharacters] = React.useState([{ id: '1', ...character }]);
+    const [selectedId, setSelectedId] = React.useState('1');
+    const setCharacter = (update) => {
+      setCharacters((prev) =>
+        prev.map((c) => {
+          if (c.id !== selectedId) return c;
+          const next = typeof update === 'function' ? update(c) : update;
+          return { ...next, id: selectedId };
+        }),
+      );
+    };
+    const addCharacter = (char) => {
+      const id = char.id || String(characters.length + 1);
+      setCharacters((prev) => [...prev, { ...char, id }]);
+      setSelectedId(id);
+    };
+    const value = {
+      characters,
+      selectedId,
+      setSelectedId,
+      character: characters.find((c) => c.id === selectedId),
+      setCharacter,
+      addCharacter,
+    };
     return (
-      <CharacterContext.Provider value={{ character: charState, setCharacter: setCharState }}>
+      <CharacterContext.Provider value={value}>
         {children}
-        <div data-testid="name">{charState.name}</div>
+        <div data-testid="name">{value.character.name}</div>
       </CharacterContext.Provider>
     );
   };

--- a/src/state/CharacterContext.jsx
+++ b/src/state/CharacterContext.jsx
@@ -1,11 +1,50 @@
-import React, { createContext, useContext, useState, useMemo } from 'react';
+import React, { createContext, useContext, useState, useMemo, useCallback } from 'react';
 import { INITIAL_CHARACTER_DATA } from './character';
 
 const CharacterContext = createContext();
 
+const createDefaultCharacter = () => ({ id: crypto.randomUUID(), ...INITIAL_CHARACTER_DATA });
+
 export const CharacterProvider = ({ children }) => {
-  const [character, setCharacter] = useState(INITIAL_CHARACTER_DATA);
-  const value = useMemo(() => ({ character, setCharacter }), [character]);
+  const [characters, setCharacters] = useState([createDefaultCharacter()]);
+  const [selectedId, setSelectedId] = useState(characters[0].id);
+
+  const character = useMemo(
+    () => characters.find((c) => c.id === selectedId),
+    [characters, selectedId],
+  );
+
+  const setCharacter = useCallback(
+    (update) => {
+      setCharacters((prev) =>
+        prev.map((c) => {
+          if (c.id !== selectedId) return c;
+          const updated = typeof update === 'function' ? update(c) : update;
+          return { ...updated, id: selectedId };
+        }),
+      );
+    },
+    [selectedId],
+  );
+
+  const addCharacter = useCallback((char) => {
+    const id = char.id || crypto.randomUUID();
+    setCharacters((prev) => [...prev, { ...char, id }]);
+    setSelectedId(id);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      characters,
+      selectedId,
+      setSelectedId,
+      character,
+      setCharacter,
+      addCharacter,
+    }),
+    [characters, selectedId, character, setCharacter, addCharacter],
+  );
+
   return <CharacterContext.Provider value={value}>{children}</CharacterContext.Provider>;
 };
 

--- a/src/state/CharacterContext.test.jsx
+++ b/src/state/CharacterContext.test.jsx
@@ -10,7 +10,8 @@ describe('CharacterContext', () => {
 
   it('provides initial character data', () => {
     const { result } = renderHook(() => useCharacter(), { wrapper });
-    expect(result.current.character).toEqual(INITIAL_CHARACTER_DATA);
+    expect(result.current.character).toMatchObject(INITIAL_CHARACTER_DATA);
+    expect(result.current.character.id).toBeDefined();
   });
 
   it('updates character state', () => {
@@ -19,6 +20,21 @@ describe('CharacterContext', () => {
       result.current.setCharacter((prev) => ({ ...prev, hp: 20 }));
     });
     expect(result.current.character.hp).toBe(20);
+  });
+
+  it('adds and switches characters', () => {
+    const { result } = renderHook(() => useCharacter(), { wrapper });
+    act(() => {
+      result.current.addCharacter({ ...INITIAL_CHARACTER_DATA, hp: 5 });
+    });
+    expect(result.current.characters).toHaveLength(2);
+    const newId = result.current.selectedId;
+    expect(result.current.character.hp).toBe(5);
+    act(() => {
+      result.current.setSelectedId(result.current.characters[0].id);
+    });
+    expect(result.current.selectedId).not.toBe(newId);
+    expect(result.current.character.hp).toBe(INITIAL_CHARACTER_DATA.hp);
   });
 
   it("doesn't re-render children when setCharacter is stable", () => {


### PR DESCRIPTION
## Summary
- refactor character context to manage multiple characters with selection
- add UI component to switch active characters
- handle per-character export/import and add tests for switching

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check` *(fails: SyntaxError in .github/workflows/codex-preflight.yml)*
- `npm run test:e2e` *(fails: system library `glib-2.0` missing and WebKitWebDriver not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f54128f788332b488c140cb4d4202