### PR TITLE
style: replace deprecated color tokens

### DIFF
--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -13,7 +13,7 @@
 
 .modal {
   background: var(--color-modal-bg);
-  border: 2px solid var(--color-neon);
+  border: 2px solid var(--color-accent);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -23,7 +23,7 @@
 }
 
 .title {
-  color: var(--color-neon);
+  color: var(--color-accent);
 }
 
 .empty {
@@ -66,7 +66,7 @@
 }
 
 .button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);
@@ -78,7 +78,7 @@
 }
 
 .resolveButton {
-  background: linear-gradient(45deg, var(--color-emerald), var(--color-emerald-dark));
+  background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
 }
 
 .unresolveButton {
@@ -91,7 +91,7 @@
 
 .input {
   background: var(--color-modal-bg-dark);
-  border: 1px solid var(--color-neon);
+  border: 1px solid var(--color-accent);
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm);

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -13,7 +13,7 @@
 
 .modal {
   background: var(--color-modal-bg);
-  border: 2px solid var(--color-neon);
+  border: 2px solid var(--color-accent);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -21,7 +21,7 @@
 }
 
 .title {
-  color: var(--color-neon);
+  color: var(--color-accent);
 }
 
 .info {
@@ -31,7 +31,7 @@
 
 .input {
   background: var(--color-modal-bg-dark);
-  border: 1px solid var(--color-neon);
+  border: 1px solid var(--color-accent);
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm);
@@ -58,7 +58,7 @@
 }
 
 .button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -13,7 +13,7 @@
 
 .modal {
   background: var(--color-modal-bg);
-  border: 2px solid var(--color-neon);
+  border: 2px solid var(--color-accent);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -23,7 +23,7 @@
 }
 
 .title {
-  color: var(--color-neon);
+  color: var(--color-accent);
 }
 
 .section {
@@ -45,7 +45,7 @@
   margin-top: 5px;
   padding: 5px;
   border-radius: 4px;
-  border: 1px solid var(--color-neon);
+  border: 1px solid var(--color-accent);
   background: var(--color-modal-bg-dark);
   color: var(--color-white);
 }
@@ -55,7 +55,7 @@
   margin-top: 5px;
   padding: 5px;
   border-radius: 4px;
-  border: 1px solid var(--color-neon);
+  border: 1px solid var(--color-accent);
   background: var(--color-modal-bg-dark);
   color: var(--color-white);
 }
@@ -90,7 +90,7 @@
 }
 
 .button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -13,7 +13,7 @@
 
 .modal {
   background: var(--color-modal-bg);
-  border: 2px solid var(--color-neon);
+  border: 2px solid var(--color-accent);
   border-radius: 15px;
   padding: 30px;
   text-align: center;
@@ -21,13 +21,13 @@
 }
 
 .title {
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin-bottom: 10px;
 }
 
 .input {
   background: var(--color-modal-bg-dark);
-  border: 1px solid var(--color-neon);
+  border: 1px solid var(--color-accent);
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   padding: var(--space-sm);
@@ -36,7 +36,7 @@
 }
 
 .message {
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin-bottom: 10px;
 }
 
@@ -54,7 +54,7 @@
 }
 
 .button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -8,7 +8,7 @@
 }
 
 .title {
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin-bottom: 15px;
   font-size: 1.3rem;
 }
@@ -23,11 +23,11 @@
   padding: var(--space-sm) 12px;
   margin: 5px 0;
   border-radius: var(--hud-radius-sm);
-  border-left: 3px solid var(--color-neon);
+  border-left: 3px solid var(--color-accent);
 }
 
 .equipped {
-  border-left-color: var(--color-emerald);
+  border-left-color: var(--color-success);
 }
 
 .itemRow {
@@ -73,7 +73,7 @@
 }
 
 .equippedMark {
-  color: var(--color-emerald);
+  color: var(--color-success);
   font-size: 0.7rem;
 }
 
@@ -83,7 +83,7 @@
 }
 
 .useButton {
-  background: linear-gradient(45deg, var(--color-emerald), var(--color-emerald-dark));
+  background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
   border: none;
   color: var(--color-white);
   padding: 4px var(--space-sm);

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -16,7 +16,7 @@
 
 .modal {
   background: linear-gradient(135deg, var(--color-modal-bg), var(--color-modal-bg-secondary));
-  border: 2px solid var(--color-neon);
+  border: 2px solid var(--color-accent);
   border-radius: 15px;
   max-width: 700px;
   width: 100%;
@@ -26,7 +26,7 @@
 }
 
 .header {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   padding: var(--hud-spacing);
   border-radius: 13px 13px 0 0;
   text-align: center;
@@ -78,7 +78,7 @@
 }
 
 .progressStep.complete {
-  color: var(--color-neon);
+  color: var(--color-accent);
 }
 
 .progressIcon {
@@ -94,7 +94,7 @@
 }
 
 .stepTitle {
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin-bottom: 10px;
   font-size: 1.2rem;
 }
@@ -125,9 +125,9 @@
 }
 
 .statButton.selected {
-  border-color: var(--color-neon);
+  border-color: var(--color-accent);
   background: rgba(0, 255, 136, 0.2);
-  color: var(--color-neon);
+  color: var(--color-accent);
 }
 
 .statButton.maxed {
@@ -163,7 +163,7 @@
   border: 1px solid rgba(0, 255, 136, 0.3);
   border-radius: var(--hud-radius-sm);
   font-size: 14px;
-  color: var(--color-neon);
+  color: var(--color-accent);
 }
 
 .selectedMove {
@@ -195,7 +195,7 @@
 }
 
 .moveButton.selected {
-  border-color: var(--color-neon);
+  border-color: var(--color-accent);
   background: rgba(0, 255, 136, 0.2);
 }
 
@@ -211,7 +211,7 @@
 
 .moveName {
   margin: 0;
-  color: var(--color-neon);
+  color: var(--color-accent);
   font-size: 14px;
   font-weight: bold;
 }
@@ -226,7 +226,7 @@
 .detailsButton {
   background: none;
   border: none;
-  color: var(--color-neon);
+  color: var(--color-accent);
   cursor: pointer;
   font-size: var(--font-size-sm);
   margin-left: var(--space-sm);
@@ -262,7 +262,7 @@
 }
 
 .button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   color: var(--color-white);
   padding: 10px 20px;
@@ -274,7 +274,7 @@
 }
 
 .buttonRolled {
-  background: linear-gradient(45deg, var(--color-neon-dark), var(--color-neon-darker));
+  background: linear-gradient(45deg, var(--color-accent-dark), var(--color-accent-darker));
 }
 
 .buttonCancel {
@@ -282,7 +282,7 @@
 }
 
 .buttonComplete {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   font-size: 16px;
   padding: 12px 24px;
 }
@@ -299,7 +299,7 @@
 }
 
 .hpResult {
-  color: var(--color-neon);
+  color: var(--color-accent);
   font-weight: bold;
   margin-top: 4px;
 }
@@ -321,7 +321,7 @@
 }
 
 .summaryTitle {
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin: 0 0 10px;
   font-size: 1.1rem;
 }

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -15,7 +15,7 @@
 
 .modal {
   background: linear-gradient(135deg, var(--color-modal-bg), var(--color-modal-bg-secondary));
-  border: 2px solid var(--color-neon);
+  border: 2px solid var(--color-accent);
   border-radius: 15px;
   max-width: 500px;
   width: 100%;
@@ -37,7 +37,7 @@
 
 .title {
   font-size: 1.5rem;
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin: 0;
 }
 
@@ -65,7 +65,7 @@
 .result {
   font-size: 1.5rem;
   font-weight: bold;
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin-bottom: 15px;
 }
 
@@ -87,7 +87,7 @@
 }
 
 .button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -8,7 +8,7 @@
 }
 
 .title {
-  color: var(--color-neon);
+  color: var(--color-accent);
   margin-bottom: 15px;
   font-size: 1.3rem;
 }
@@ -39,7 +39,7 @@
 }
 
 .button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
   border: none;
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);


### PR DESCRIPTION
## Summary
- replace neon and emerald color references with accent/success tokens
- align modal and panel styles with theme variables

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: Hook timed out)*
- `npm run build`
- `npm run format:check` *(fails: SyntaxError in .github/workflows/codex-preflight.yml)*

------
https://chatgpt.com/codex/tasks/task_e_689f5ea0c2648332b3642e02080739f2