### PR TITLE
feat(theme): add distinct fonts for classic and moebius

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A cross-platform desktop application for managing tabletop RPG characters. Built
 - **Undo/History** – Reverse recent actions with a built-in undo system.
 - **Import/Export** – Save or load characters with the `ExportModal`.
 - **Visual Effects** – Status-based overlays (poisoned, burning, shocked, etc.).
-- **Theme Switching** – Select from cosmic, classic, or moebius themes.
+- **Theme Switching** – Select from cosmic, classic, or moebius themes, each with distinct fonts, spacing, and motion.
 - **Cross-Platform Packaging** – Create native binaries via Tauri.
 
 ## Saving and Loading a Character

--- a/docs/hud-theme.md
+++ b/docs/hud-theme.md
@@ -4,15 +4,19 @@ The heads-up display (HUD) uses a small set of CSS custom properties to keep spa
 radius and animation speeds consistent across components. These tokens live in
 [`src/styles/theme.css`](../src/styles/theme.css) and can be overridden per theme.
 
-| Token                   | Description                                    | Default                 | Classic                 | Moebius                 |
-| ----------------------- | ---------------------------------------------- | ----------------------- | ----------------------- | ----------------------- |
-| `--hud-radius`          | Corner rounding for panels and containers      | `0.75rem`               | `0.5rem`                | `0.75rem`               |
-| `--hud-radius-sm`       | Corner rounding for buttons and small elements | `0.375rem`              | `0.25rem`               | `0.375rem`              |
-| `--hud-spacing`         | Standard padding for panels                    | `1.25rem`               | `1rem`                  | `1.5rem`                |
-| `--hud-spacing-sm`      | Compact padding for inner elements             | `0.625rem`              | `0.5rem`                | `0.75rem`               |
-| `--hud-transition-fast` | Quick animations                               | `all 150ms ease-in-out` | `all 100ms ease-in-out` | `all 200ms ease-in-out` |
-| `--hud-transition`      | Default animations                             | `all 300ms ease-in-out` | `all 250ms ease-in-out` | `all 350ms ease-in-out` |
-| `--hud-transition-slow` | Emphasized animations                          | `all 500ms ease-in-out` | `all 400ms ease-in-out` | `all 600ms ease-in-out` |
+| Token                   | Description                                    | Default                    | Classic                    | Moebius                      |
+| ----------------------- | ---------------------------------------------- | -------------------------- | -------------------------- | ---------------------------- |
+| `--hud-radius`          | Corner rounding for panels and containers      | `0.75rem`                  | `0.5rem`                   | `0.75rem`                    |
+| `--hud-radius-sm`       | Corner rounding for buttons and small elements | `0.375rem`                 | `0.25rem`                  | `0.375rem`                   |
+| `--hud-spacing`         | Standard padding for panels                    | `1.25rem`                  | `1rem`                     | `1.5rem`                     |
+| `--hud-spacing-sm`      | Compact padding for inner elements             | `0.625rem`                 | `0.5rem`                   | `0.75rem`                    |
+| `--hud-transition-fast` | Quick animations                               | `all 150ms ease-in-out`    | `all 100ms ease-in-out`    | `all 200ms ease-in-out`      |
+| `--hud-transition`      | Default animations                             | `all 300ms ease-in-out`    | `all 250ms ease-in-out`    | `all 350ms ease-in-out`      |
+| `--hud-transition-slow` | Emphasized animations                          | `all 500ms ease-in-out`    | `all 400ms ease-in-out`    | `all 600ms ease-in-out`      |
+| `--font-heading`        | Typeface used for headings                     | `'Montserrat', sans-serif` | `'Georgia', serif`         | `'Trebuchet MS', sans-serif` |
+| `--font-body`           | Typeface used for body text                    | `'Inter', sans-serif`      | `'Times New Roman', serif` | `'Verdana', sans-serif`      |
+| `--space-sm`            | General small spacing                          | `0.5rem`                   | `0.5rem`                   | `0.75rem`                    |
+| `--space-md`            | General medium spacing                         | `1rem`                     | `1rem`                     | `1.5rem`                     |
 
 Use these tokens within HUD components to guarantee visual consistency:
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -135,6 +135,11 @@
   --accent-shadow: var(--glow-shadow);
 }
 :root[data-theme='classic'] {
+  --font-heading: 'Georgia', serif;
+  --font-body: 'Times New Roman', serif;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+
   --color-bg-start: #f0f0f0;
   --color-bg-end: #dcdcdc;
   --color-text: #222222;
@@ -249,6 +254,11 @@
 }
 
 :root[data-theme='moebius'] {
+  --font-heading: 'Trebuchet MS', sans-serif;
+  --font-body: 'Verdana', sans-serif;
+  --space-sm: 0.75rem;
+  --space-md: 1.5rem;
+
   --color-bg-start: #f2e9e4;
   --color-bg-end: #e4d2cc;
   --color-text: #2d2a26;


### PR DESCRIPTION
## Summary
- differentiate classic and moebius themes with their own fonts and spacing tokens
- document theme font and spacing tokens
- note theme styling differences in readme

## Testing
- `npm run lint`
- `npm test` *(fails: 3 failed)*
- `npm run format:check` *(fails: SyntaxError in .github/workflows/codex-preflight.yml)*
- `npm run test:e2e` *(fails: build interrupted)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5ea6a6448332bb5e33d359752057