### PR TITLE
test: expand theme switcher coverage

### DIFF
--- a/tests/e2e/theme-switcher.spec.ts
+++ b/tests/e2e/theme-switcher.spec.ts
@@ -28,14 +28,61 @@ test.afterAll(async () => {
 
 test('changes theme via dropdown', async () => {
   const themeSelect = await page.$('#theme-select');
-  const initialBg = await page.evaluate(() =>
-    getComputedStyle(document.documentElement).getPropertyValue('--color-bg-start'),
-  );
+  const panel = await page.$('.panel');
+
+  const initialStyles = await page.evaluate((panelEl) => {
+    const root = getComputedStyle(document.documentElement);
+    const panelStyles = panelEl ? getComputedStyle(panelEl) : null;
+    return {
+      bg: root.getPropertyValue('--color-bg-start').trim(),
+      border: panelStyles ? panelStyles.borderColor : '',
+      text: getComputedStyle(document.body).color,
+    };
+  }, panel);
+
   await themeSelect.selectOption('classic');
   const theme = await page.evaluate(() => document.documentElement.dataset.theme);
   expect(theme).toBe('classic');
-  const updatedBg = await page.evaluate(() =>
-    getComputedStyle(document.documentElement).getPropertyValue('--color-bg-start'),
-  );
-  expect(updatedBg.trim()).not.toBe(initialBg.trim());
+
+  const updatedStyles = await page.evaluate((panelEl) => {
+    const root = getComputedStyle(document.documentElement);
+    const panelStyles = panelEl ? getComputedStyle(panelEl) : null;
+    return {
+      bg: root.getPropertyValue('--color-bg-start').trim(),
+      border: panelStyles ? panelStyles.borderColor : '',
+      text: getComputedStyle(document.body).color,
+    };
+  }, panel);
+
+  expect(updatedStyles.bg).not.toBe(initialStyles.bg);
+  expect(updatedStyles.border).not.toBe(initialStyles.border);
+  expect(updatedStyles.text).not.toBe(initialStyles.text);
+});
+
+test('applies unique tokens for each theme', async () => {
+  const themeSelect = await page.$('#theme-select');
+  const themes = ['cosmic', 'classic', 'moebius'];
+  const tokens: string[] = [];
+
+  for (const theme of themes) {
+    await themeSelect.selectOption(theme);
+    const tokenValues = await page.evaluate(() => {
+      const styles = getComputedStyle(document.documentElement);
+      return {
+        colorText: styles.getPropertyValue('--color-text').trim(),
+        panelBorder: styles.getPropertyValue('--panel-border').trim(),
+      };
+    });
+    tokens.push(`${tokenValues.colorText}|${tokenValues.panelBorder}`);
+  }
+
+  expect(new Set(tokens).size).toBe(themes.length);
+});
+
+test('captures visual regressions across themes', async () => {
+  const themeSelect = await page.$('#theme-select');
+  for (const theme of ['cosmic', 'classic', 'moebius']) {
+    await themeSelect.selectOption(theme);
+    await expect(page).toHaveScreenshot(`theme-${theme}.png`);
+  }
 });


### PR DESCRIPTION
## Summary
- add assertions for panel border and text color when switching themes
- verify each theme applies unique token values
- add screenshot-based regression checks for all themes

## Testing
- `npm run lint`
- `npx vitest run --exclude tests`
- `npm run format:check` *(fails: SyntaxError in .github/workflows/codex-preflight.yml)*
- `npx playwright test tests/e2e/theme-switcher.spec.ts --update-snapshots` *(fails: failed to build app: glib-2.0 not found)*
- `npm run test:e2e` *(fails: failed to build app: glib-2.0 not found / WebKitWebDriver missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5ea97aa083328992cda2bb008eb1