### PR TITLE
style: rely on gap for button spacing

### DIFF
--- a/src/components/AidInterfereModal.module.css
+++ b/src/components/AidInterfereModal.module.css
@@ -70,4 +70,5 @@
   cursor: pointer;
   font-weight: bold;
   transition: all 0.3s ease;
+  flex: 1 1 150px;
 }

--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -57,6 +57,7 @@
   justify-content: center;
   flex-wrap: wrap;
   width: 100%;
+  gap: 10px;
 }
 
 @media (max-width: 360px) {
@@ -74,7 +75,7 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
+  flex: 1 1 150px;
 }
 
 .resolveButton {

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -49,6 +49,7 @@
   justify-content: center;
   flex-wrap: wrap;
   width: 100%;
+  gap: 10px;
 }
 
 @media (max-width: 360px) {
@@ -66,7 +67,7 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
+  flex: 1 1 150px;
 }
 
 .applyButton {

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -76,6 +76,7 @@
   justify-content: center;
   flex-wrap: wrap;
   width: 100%;
+  gap: 10px;
 }
 
 @media (max-width: 360px) {
@@ -98,7 +99,7 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
+  flex: 1 1 150px;
 }
 
 .cancelButton {

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -45,6 +45,7 @@
   justify-content: center;
   flex-wrap: wrap;
   width: 100%;
+  gap: 10px;
 }
 
 @media (max-width: 360px) {
@@ -62,5 +63,5 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
+  flex: 1 1 150px;
 }

--- a/src/components/InventoryModal.module.css
+++ b/src/components/InventoryModal.module.css
@@ -73,6 +73,7 @@
   justify-content: center;
   flex-wrap: wrap;
   width: 100%;
+  gap: 6px;
 }
 
 @media (max-width: 360px) {
@@ -88,7 +89,7 @@
   color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
-  margin: 3px;
+  flex: 1 1 150px;
 }
 
 .inventoryClose {

--- a/src/components/LastBreathModal.module.css
+++ b/src/components/LastBreathModal.module.css
@@ -49,4 +49,5 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
+  flex: 1 1 150px;
 }

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -271,6 +271,7 @@
   font-weight: bold;
   transition: var(--hud-transition);
   font-size: 14px;
+  flex: 1 1 150px;
 }
 
 .buttonRolled {

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -95,5 +95,5 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
+  flex: 1 1 150px;
 }

--- a/src/components/StatusModal.module.css
+++ b/src/components/StatusModal.module.css
@@ -51,9 +51,14 @@
   color: var(--color-white);
   padding: 5px 10px;
   cursor: pointer;
-  margin-top: 10px;
+  flex: 1 1 150px;
 }
 
 .statusFooter {
   text-align: center;
+  margin-top: 10px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
 }

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -94,10 +94,10 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
   display: flex;
   align-items: center;
   gap: 5px;
+  flex: 1 1 150px;
 }
 
 .undoButton {


### PR DESCRIPTION
## Summary
- drop button margins and rely on flex gap for spacing
- make buttons flexibly wrap across modals

## Testing
- `npm run lint`
- `npm test` *(fails: addCharacter is not a function, etc.)*
- `npm run format:check` *(fails: .github/workflows/codex-preflight.yml syntax error)*
- `npm run test:e2e` *(fails: glib-2.0 not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f60a504f48332829c2765a1e68ea1