### PR TITLE
refactor: remove unused button style

### DIFF
--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -1,5 +1,3 @@
-import { baseColors } from '../styles/colorMap.js';
-
 export const panelStyle = {
   background: 'var(--panel-bg)',
   backdropFilter: 'blur(10px)',
@@ -7,16 +5,4 @@ export const panelStyle = {
   padding: '20px',
   border: '1px solid var(--panel-border)',
   boxShadow: '0 8px 32px var(--panel-shadow)',
-};
-
-export const buttonStyle = {
-  background: 'linear-gradient(45deg, var(--color-accent), var(--color-accent-dark))',
-  border: 'none',
-  borderRadius: '6px',
-  color: baseColors.white,
-  padding: 'var(--space-sm) 15px',
-  cursor: 'pointer',
-  fontWeight: 'bold',
-  transition: 'all 0.3s ease',
-  margin: '5px',
 };


### PR DESCRIPTION
## Summary
- remove obsolete `buttonStyle` helper to rely on CSS classes
- ensure buttons avoid inline styling

## Testing
- `npm run lint`
- `npm test` *(fails: TypeError addCharacter is not a function)*
- `npm run format:check` *(fails: SyntaxError in workflow YAML)*
- `npm run test:e2e` *(fails: Hook timed out / missing WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f60a8bd748332ba5f977f92706c8d