### PR TITLE
feat(ui): add reusable button components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,8 @@ import Settings from './components/Settings.jsx';
 import CharacterSwitcher from './components/CharacterSwitcher.jsx';
 import AppVersion from './components/AppVersion.tsx';
 import DiagnosticOverlay from './components/DiagnosticOverlay.jsx';
+import Button from './components/common/Button.jsx';
+import ButtonGroup from './components/common/ButtonGroup.jsx';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
 import useModal from './hooks/useModal.js';
@@ -154,55 +156,43 @@ function App() {
                 )}
               </div>
             </div>
-            <div className={styles.buttonRow}>
-              <button
+            <ButtonGroup>
+              <Button
                 onClick={undoLastAction}
                 disabled={character.actionHistory.length === 0}
-                className={`${styles.button} ${styles.undoButton}`}
+                className={styles.undoButton}
                 title="Undo last action"
               >
                 <FaArrowRotateLeft className={styles.icon} /> Undo
-              </button>
-              <button
-                onClick={() => setShowDamageModal(true)}
-                className={`${styles.button} ${styles.damageButton}`}
-              >
+              </Button>
+              <Button onClick={() => setShowDamageModal(true)} className={styles.damageButton}>
                 <FaMeteor className={styles.icon} /> Take Damage
-              </button>
-              <button
-                onClick={() => setShowStatusModal(true)}
-                className={`${styles.button} ${styles.statusButton}`}
-              >
+              </Button>
+              <Button onClick={() => setShowStatusModal(true)} className={styles.statusButton}>
                 <FaRadiation className={styles.icon} /> Effects (
                 {statusEffects.length + debilities.length})
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={() => setShowInventoryModal(true)}
-                className={`${styles.button} ${styles.inventoryButton}`}
+                className={styles.inventoryButton}
               >
                 <FaBoxOpen className={styles.icon} /> Inventory
-              </button>
-              <button
-                onClick={bondsModal.open}
-                className={`${styles.button} ${styles.bondsButton}`}
-              >
+              </Button>
+              <Button onClick={bondsModal.open} className={styles.bondsButton}>
                 <FaUserAstronaut className={styles.icon} /> Bonds (
                 {character.bonds.filter((b) => !b.resolved).length})
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={() => setShowEndSessionModal(true)}
-                className={`${styles.button} ${styles.endSessionButton}`}
+                className={styles.endSessionButton}
               >
                 <FaFlagCheckered className={styles.icon} /> End Session
-              </button>
-              <button
-                onClick={() => setShowExportModal(true)}
-                className={`${styles.button} ${styles.exportButton}`}
-              >
+              </Button>
+              <Button onClick={() => setShowExportModal(true)} className={styles.exportButton}>
                 <FaSatellite className={styles.icon} /> Export/Save
-              </button>
+              </Button>
               <Settings />
-            </div>
+            </ButtonGroup>
           </div>
         </div>
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -279,15 +279,14 @@ describe('App header', () => {
       </ThemeProvider>,
     );
     const group = screen.getByText('Take Damage').parentElement;
-    group.style.display = 'flex';
-    group.style.flexWrap = 'wrap';
+    group.style.display = 'grid';
     Object.defineProperty(group, 'clientHeight', {
       configurable: true,
       get() {
         return group.style.width === '120px' ? 60 : 30;
       },
     });
-    expect(getComputedStyle(group).flexWrap).toBe('wrap');
+    expect(getComputedStyle(group).display).toBe('grid');
     const initialHeight = group.clientHeight;
     group.style.width = '120px';
     expect(group.clientHeight).toBeGreaterThan(initialHeight);

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -49,7 +49,7 @@ describe('Header responsiveness', () => {
     );
 
     const headerTop = container.querySelector(`.${styles.headerTop}`);
-    const buttonRow = container.querySelector(`.${styles.buttonRow}`);
+    const buttonRow = headerTop.querySelector('button').parentElement;
     const buttons = buttonRow.querySelectorAll('button');
     const lastButton = buttons[buttons.length - 1];
 

--- a/src/components/DamageModal.jsx
+++ b/src/components/DamageModal.jsx
@@ -4,6 +4,8 @@ import { FaMeteor } from 'react-icons/fa6';
 import useInventory from '../hooks/useInventory';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './DamageModal.module.css';
+import Button from './common/Button.jsx';
+import ButtonGroup from './common/ButtonGroup.jsx';
 
 export default function DamageModal({ isOpen, onClose, onLastBreath }) {
   const { character, setCharacter } = useCharacter();
@@ -52,14 +54,12 @@ export default function DamageModal({ isOpen, onClose, onLastBreath }) {
           className={styles.input}
         />
         <div className={styles.summary}>After armor: {effectiveDamage()}</div>
-        <div className={styles.buttonGroup}>
-          <button onClick={applyDamage} className={`${styles.button} ${styles.applyButton}`}>
+        <ButtonGroup>
+          <Button onClick={applyDamage} className={styles.applyButton}>
             Apply
-          </button>
-          <button onClick={onClose} className={styles.button}>
-            Cancel
-          </button>
-        </div>
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </ButtonGroup>
       </div>
     </div>
   );

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -44,31 +44,6 @@
   margin-bottom: 20px;
 }
 
-.buttonGroup {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
-@media (max-width: 360px) {
-  .buttonGroup {
-    flex-direction: column;
-  }
-}
-
-.button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: var(--color-white);
-  padding: var(--space-sm) 15px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: var(--hud-transition);
-  margin: 5px;
-}
-
 .applyButton {
   background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }

--- a/src/components/DamageModal.test.jsx
+++ b/src/components/DamageModal.test.jsx
@@ -121,15 +121,14 @@ describe('DamageModal', () => {
       character: initial,
     });
     const group = screen.getByText('Apply').parentElement;
-    group.style.display = 'flex';
-    group.style.flexWrap = 'wrap';
+    group.style.display = 'grid';
     Object.defineProperty(group, 'clientHeight', {
       configurable: true,
       get() {
         return group.style.width === '120px' ? 60 : 30;
       },
     });
-    expect(getComputedStyle(group).flexWrap).toBe('wrap');
+    expect(getComputedStyle(group).display).toBe('grid');
     const initialHeight = group.clientHeight;
     group.style.width = '120px';
     expect(group.clientHeight).toBeGreaterThan(initialHeight);

--- a/src/components/ExportModal.jsx
+++ b/src/components/ExportModal.jsx
@@ -4,6 +4,8 @@ import React, { useState, useEffect } from 'react';
 import { FaSatellite } from 'react-icons/fa6';
 import { useCharacter } from '../state/CharacterContext.jsx';
 import styles from './ExportModal.module.css';
+import Button from './common/Button.jsx';
+import ButtonGroup from './common/ButtonGroup.jsx';
 
 export default function ExportModal({ isOpen, onClose }) {
   const { character, addCharacter, selectedId } = useCharacter();
@@ -54,17 +56,11 @@ export default function ExportModal({ isOpen, onClose }) {
           className={styles.input}
         />
         {message && <div className={styles.message}>{message}</div>}
-        <div className={styles.buttonGroup}>
-          <button onClick={handleSave} className={styles.button}>
-            Save
-          </button>
-          <button onClick={handleLoad} className={styles.button}>
-            Load
-          </button>
-          <button onClick={onClose} className={styles.button}>
-            Close
-          </button>
-        </div>
+        <ButtonGroup>
+          <Button onClick={handleSave}>Save</Button>
+          <Button onClick={handleLoad}>Load</Button>
+          <Button onClick={onClose}>Close</Button>
+        </ButtonGroup>
       </div>
     </div>
   );

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -39,28 +39,3 @@
   color: var(--color-neon);
   margin-bottom: 10px;
 }
-
-.buttonGroup {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  width: 100%;
-}
-
-@media (max-width: 360px) {
-  .buttonGroup {
-    flex-direction: column;
-  }
-}
-
-.button {
-  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: var(--color-white);
-  padding: var(--space-sm) 15px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: var(--hud-transition);
-  margin: 5px;
-}

--- a/src/components/ExportModal.test.jsx
+++ b/src/components/ExportModal.test.jsx
@@ -74,15 +74,14 @@ describe('ExportModal', () => {
     const initial = { name: 'Hero' };
     renderWithCharacter(<ExportModal isOpen onClose={onClose} />, { character: initial });
     const group = screen.getByText('Save').parentElement;
-    group.style.display = 'flex';
-    group.style.flexWrap = 'wrap';
+    group.style.display = 'grid';
     Object.defineProperty(group, 'clientHeight', {
       configurable: true,
       get() {
         return group.style.width === '120px' ? 60 : 30;
       },
     });
-    expect(getComputedStyle(group).flexWrap).toBe('wrap');
+    expect(getComputedStyle(group).display).toBe('grid');
     const initialHeight = group.clientHeight;
     group.style.width = '120px';
     expect(group.clientHeight).toBeGreaterThan(initialHeight);

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styles from './Button.module.css';
+
+export default function Button({ className = '', type = 'button', children, ...props }) {
+  return (
+    <button type={type} className={`${styles.button} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+}
+
+Button.propTypes = {
+  className: PropTypes.string,
+  type: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/common/Button.module.css
+++ b/src/components/common/Button.module.css
@@ -1,0 +1,19 @@
+.button {
+  background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
+  border: none;
+  border-radius: var(--hud-radius-sm);
+  color: var(--color-white);
+  padding: var(--space-sm) 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: var(--hud-transition);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/common/ButtonGroup.jsx
+++ b/src/components/common/ButtonGroup.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styles from './ButtonGroup.module.css';
+
+export default function ButtonGroup({ className = '', children, ...props }) {
+  return (
+    <div className={`${styles.group} ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}
+
+ButtonGroup.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};

--- a/src/components/common/ButtonGroup.module.css
+++ b/src/components/common/ButtonGroup.module.css
@@ -1,0 +1,12 @@
+.group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+  width: 100%;
+}
+
+@media (max-width: 360px) {
+  .group {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -72,32 +72,11 @@
   vertical-align: middle;
 }
 
-.buttonRow {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 20px;
   margin-bottom: 20px;
-}
-
-.button {
-  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: white;
-  padding: var(--space-sm) 15px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: var(--hud-transition);
-  margin: 5px;
-  display: flex;
-  align-items: center;
-  gap: 5px;
 }
 
 .undoButton {
@@ -137,11 +116,6 @@
 @media (max-width: 768px) {
   .headerTop {
     flex-direction: column;
-  }
-
-  .buttonRow {
-    width: 100%;
-    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- add shared Button and ButtonGroup components
- refactor App and modals to use shared buttons
- update tests for new grid-based button layout

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check` *(fails: SyntaxError: A collection cannot be both a mapping and a sequence (1:1))*
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*
- `npm run build` *(fails: can not find driver binary WebKitWebDriver in the PATH)*

------
https://chatgpt.com/codex/tasks/task_e_689f60a732e08332b81b450aaafc64bc