### PR TITLE
chore: fix codex preflight workflow indentation

### DIFF
--- a/.github/workflows/codex-preflight.yml
+++ b/.github/workflows/codex-preflight.yml
@@ -19,14 +19,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
       - uses: actions/setup-node@v4
-- name: Install deps (lockfile-aware)
-  run: |
-    if [ -f pnpm-lock.yaml ]; then pnpm install;
-    elif [ -f yarn.lock ]; then yarn install --silent;
-    elif [ -f package-lock.json ]; then npm ci;
-    else npm i --no-audit --no-fund; fi
         with:
           node-version: '20'
+      - name: Install deps (lockfile-aware)
+        run: |
+          if [ -f pnpm-lock.yaml ]; then pnpm install;
+          elif [ -f yarn.lock ]; then yarn install --silent;
+          elif [ -f package-lock.json ]; then npm ci;
+          else npm i --no-audit --no-fund; fi
       - name: Install (best-effort)
         run: npm ci || npm i --prefer-offline
       - name: Preflight (auto-fix for codex/*)
@@ -50,4 +50,3 @@ jobs:
 
           # Enforce pass
           node .github/tools/codex-preflight.mjs --base "${{ github.base_ref || 'main' }}"
-


### PR DESCRIPTION
## Summary
- indent setup-node and specify Node 20
- fix lockfile-aware install step indentation in codex preflight workflow

## Testing
- `npm run lint`
- `npm test` (fails: addCharacter is not a function)
- `npm run format:check` (fails: code style issues found in 3 files)
- `npm run test:e2e` (fails: Hook timed out in 120000ms)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6c58cba4833293c3053d56c4dea0