### PR TITLE
feat: improve file error handling

### DIFF
--- a/src/state/CharacterContext.jsx
+++ b/src/state/CharacterContext.jsx
@@ -16,10 +16,19 @@ export const CharacterProvider = ({ children }) => {
     loadFile(STORAGE_FILE)
       .then((data) => {
         if (data) {
-          setCharacter(JSON.parse(data));
+          try {
+            setCharacter(JSON.parse(data));
+            return;
+          } catch (error) {
+            console.error('Failed to parse character file:', error);
+          }
         }
+        setCharacter(createDefaultCharacter());
       })
-      .catch(() => {})
+      .catch((error) => {
+        console.error('Failed to load character file:', error);
+        setCharacter(createDefaultCharacter());
+      })
       .finally(() => {
         initializedRef.current = true;
       });
@@ -27,7 +36,9 @@ export const CharacterProvider = ({ children }) => {
 
   useEffect(() => {
     if (!initializedRef.current) return;
-    saveFile(STORAGE_FILE, JSON.stringify(character)).catch(() => {});
+    saveFile(STORAGE_FILE, JSON.stringify(character)).catch((error) => {
+      console.error('Failed to save character file:', error);
+    });
   }, [character]);
 
   const value = useMemo(() => ({ character, setCharacter }), [character]);

--- a/src/state/CharacterContext.test.jsx
+++ b/src/state/CharacterContext.test.jsx
@@ -99,4 +99,14 @@ describe('CharacterContext', () => {
       );
     });
   });
+  it('falls back to a default character on invalid JSON', async () => {
+    const { loadFile } = await import('../utils/fileStorage.js');
+    loadFile.mockResolvedValueOnce('not json');
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useCharacter(), { wrapper });
+    await waitFor(() => expect(result.current.character).toMatchObject(INITIAL_CHARACTER_DATA));
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- log load/save file errors in CharacterContext
- default to a new character if stored data is invalid
- add test covering parse error fallback

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check` *(fails: SyntaxError in .github/workflows/codex-preflight.yml)*
- `npm run test:e2e` *(fails: process interrupted during build)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6d8f68ec8332a3f6b7666133df70