### PR TITLE
refactor: remove unused createDefaultCharacter

### DIFF
--- a/src/state/CharacterContext.jsx
+++ b/src/state/CharacterContext.jsx
@@ -6,8 +6,6 @@ const STORAGE_FILE = 'character.json';
 
 const CharacterContext = createContext();
 
-const createDefaultCharacter = () => ({ id: crypto.randomUUID(), ...INITIAL_CHARACTER_DATA });
-
 export const CharacterProvider = ({ children }) => {
   const [character, setCharacter] = useState(INITIAL_CHARACTER_DATA);
   const initializedRef = useRef(false);


### PR DESCRIPTION
## Summary
- remove unused createDefaultCharacter helper

## Testing
- `npm run lint`
- `npm test` *(fails: addCharacter is not a function; missing act wrappers)*
- `npm run format:check` *(fails: SyntaxError in `.github/workflows/codex-preflight.yml`)*
- `npm run test:e2e` *(fails: missing WebKitWebDriver and glib-2.0 library)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6d91aa0c833288145cf024106294