### PR TITLE
fix: use stable identifiers for roll history entries

### DIFF
--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -95,9 +95,13 @@ const DiceRoller = ({
       {rollHistory.length > 0 && (
         <div className={styles.history}>
           <div className={styles.historyTitle}>Recent Rolls:</div>
-          {rollHistory.slice(0, 3).map((roll, index) => (
-            <div key={index} className={styles.historyItem}>
-              <span className={styles.historyTime}>{roll.timestamp}</span> - {roll.result}
+          {rollHistory.slice(0, 3).map((roll) => (
+            <div key={roll.timestamp} className={styles.historyItem}>
+              <span className={styles.historyTime}>
+                {new Date(roll.timestamp).toLocaleTimeString()}
+              </span>
+              {' - '}
+              {roll.result}
             </div>
           ))}
         </div>

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -12,7 +12,7 @@ const minimalCharacter = {
   },
 };
 
-const rollHistory = [{ timestamp: '10:00', result: '2d6: 7 = 7' }];
+const rollHistory = [{ timestamp: 1697040000000, result: '2d6: 7 = 7' }];
 
 describe('DiceRoller', () => {
   it('calls rollDice when buttons clicked', async () => {

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -102,7 +102,7 @@ const LevelUpModal = ({
           rolls: [roll],
           modifier: conMod,
           total: increase,
-          timestamp: new Date().toLocaleTimeString(),
+          timestamp: Date.now(),
         },
         ...(prev.rollHistory ? prev.rollHistory.slice(0, 9) : []),
       ],

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -287,7 +287,7 @@ export default function useDiceRoller(
       total,
       rolls,
       modifier: totalModifier,
-      timestamp: new Date().toLocaleTimeString(),
+      timestamp: Date.now(),
       ...(originalResult && { originalResult }),
     };
     if (originalResult) rollData.originalResult = originalResult;


### PR DESCRIPTION
## Summary
- render roll history entries using their timestamp as React keys
- record unique numeric timestamps for dice and HP rolls

## Testing
- `npm run lint`
- `npm test` (fails: addCharacter is not a function)
- `npm run format:check` (fails: SyntaxError in .github/workflows/codex-preflight.yml)
- `npm run test:e2e` (fails: The system library `glib-2.0` required by crate `glib-sys` was not found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6d98accc8332b8053bd3f62965e1