### PR TITLE
feat: add modal confirmation to session notes

### DIFF
--- a/.github/workflows/codex-preflight.yml
+++ b/.github/workflows/codex-preflight.yml
@@ -19,14 +19,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
       - uses: actions/setup-node@v4
-- name: Install deps (lockfile-aware)
-  run: |
-    if [ -f pnpm-lock.yaml ]; then pnpm install;
-    elif [ -f yarn.lock ]; then yarn install --silent;
-    elif [ -f package-lock.json ]; then npm ci;
-    else npm i --no-audit --no-fund; fi
         with:
           node-version: '20'
+      - name: Install deps (lockfile-aware)
+        run: |
+          if [ -f pnpm-lock.yaml ]; then pnpm install;
+          elif [ -f yarn.lock ]; then yarn install --silent;
+          elif [ -f package-lock.json ]; then npm ci;
+          else npm i --no-audit --no-fund; fi
       - name: Install (best-effort)
         run: npm ci || npm i --prefer-offline
       - name: Preflight (auto-fix for codex/*)
@@ -50,4 +50,3 @@ jobs:
 
           # Enforce pass
           node .github/tools/codex-preflight.mjs --base "${{ github.base_ref || 'main' }}"
-

--- a/src/components/SessionNotes.jsx
+++ b/src/components/SessionNotes.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { saveFile, loadFile } from '../utils/fileStorage.js';
+import useModal from '../hooks/useModal.js';
 import {
   FaClipboard,
   FaCalendarDays,
@@ -14,8 +15,39 @@ import styles from './SessionNotes.module.css';
 
 const NOTES_FILE = 'session_notes.txt';
 
+const ClearNotesModal = ({ isOpen, onConfirm, onCancel }) => {
+  if (!isOpen) return null;
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <p>Clear all notes?</p>
+        <div className={styles.buttons}>
+          <button className={styles.button} onClick={onConfirm}>
+            Confirm
+          </button>
+          <button className={styles.button} onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ClearNotesModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
 const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMode }) => {
   const [warning, setWarning] = useState('');
+  const clearModal = useModal();
+  const handleClear = () => clearModal.open();
+  const handleConfirmClear = () => {
+    setSessionNotes('');
+    clearModal.close();
+  };
 
   useEffect(() => {
     try {
@@ -27,70 +59,70 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
   }, []);
 
   return (
-    <div className={`${styles.panel} ${compactMode ? '' : styles.fullWidth}`}>
-      <h3 className={styles.title}>
-        <FaClipboard className={styles.icon} /> Session Notes
-      </h3>
-      <textarea
-        className={styles.textarea}
-        value={sessionNotes}
-        onChange={(e) => setSessionNotes(e.target.value)}
-        placeholder="Track important events, NPCs, plot threads, and campaign notes here..."
-      />
-      {warning && <div className={styles.warning}>{warning}</div>}
-      <div className={styles.buttons}>
-        <button
-          className={styles.button}
-          onClick={() => {
-            const timestamp = new Date().toLocaleString();
-            setSessionNotes((prev) => prev + (prev ? '\n\n' : '') + `--- ${timestamp} ---\n`);
-          }}
-        >
-          <FaCalendarDays className={styles.icon} /> Timestamp
-        </button>
-        <button
-          className={styles.button}
-          onClick={async () => {
-            try {
-              await saveFile(NOTES_FILE, sessionNotes);
-            } catch {
-              setWarning('Persistence unavailable; notes may not be saved.');
-            }
-          }}
-        >
-          <FaFloppyDisk className={styles.icon} /> Save
-        </button>
-        <button
-          className={styles.button}
-          onClick={async () => {
-            try {
-              const contents = await loadFile(NOTES_FILE);
-              setSessionNotes(contents);
-            } catch {
-              setWarning('Persistence unavailable; notes may not be loaded.');
-            }
-          }}
-        >
-          <FaFolderOpen className={styles.icon} /> Load
-        </button>
-        <button
-          className={`${styles.button} ${styles.danger}`}
-          onClick={() => {
-            if (confirm('Clear all notes?')) {
-              setSessionNotes('');
-            }
-          }}
-        >
-          <FaTrash className={styles.icon} /> Clear
-        </button>
-        <button
-          className={`${styles.button} ${styles.compact}`}
-          onClick={() => setCompactMode(!compactMode)}
-        >
-          {compactMode ? <FaLaptop /> : <FaMobileScreen />} {compactMode ? 'Expand' : 'Compact'}
-        </button>
+    <>
+      <div className={`${styles.panel} ${compactMode ? '' : styles.fullWidth}`}>
+        <h3 className={styles.title}>
+          <FaClipboard className={styles.icon} /> Session Notes
+        </h3>
+        <textarea
+          className={styles.textarea}
+          value={sessionNotes}
+          onChange={(e) => setSessionNotes(e.target.value)}
+          placeholder="Track important events, NPCs, plot threads, and campaign notes here..."
+        />
+        {warning && <div className={styles.warning}>{warning}</div>}
+        <div className={styles.buttons}>
+          <button
+            className={styles.button}
+            onClick={() => {
+              const timestamp = new Date().toLocaleString();
+              setSessionNotes((prev) => prev + (prev ? '\n\n' : '') + `--- ${timestamp} ---\n`);
+            }}
+          >
+            <FaCalendarDays className={styles.icon} /> Timestamp
+          </button>
+          <button
+            className={styles.button}
+            onClick={async () => {
+              try {
+                await saveFile(NOTES_FILE, sessionNotes);
+              } catch {
+                setWarning('Persistence unavailable; notes may not be saved.');
+              }
+            }}
+          >
+            <FaFloppyDisk className={styles.icon} /> Save
+          </button>
+          <button
+            className={styles.button}
+            onClick={async () => {
+              try {
+                const contents = await loadFile(NOTES_FILE);
+                setSessionNotes(contents);
+              } catch {
+                setWarning('Persistence unavailable; notes may not be loaded.');
+              }
+            }}
+          >
+            <FaFolderOpen className={styles.icon} /> Load
+          </button>
+          <button className={`${styles.button} ${styles.danger}`} onClick={handleClear}>
+            <FaTrash className={styles.icon} /> Clear
+          </button>
+          <button
+            className={`${styles.button} ${styles.compact}`}
+            onClick={() => setCompactMode(!compactMode)}
+          >
+            {compactMode ? <FaLaptop /> : <FaMobileScreen />} {compactMode ? 'Expand' : 'Compact'}
+          </button>
+        </div>
       </div>
-    </div>
+      <ClearNotesModal
+        isOpen={clearModal.isOpen}
+        onConfirm={handleConfirmClear}
+        onCancel={clearModal.close}
+      />
+    </>
   );
 };
 

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -67,3 +67,27 @@
 .fullWidth {
   grid-column: 1 / -1;
 }
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.modal {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--hud-radius);
+  padding: 20px;
+  color: var(--color-gray-100);
+  text-align: center;
+}

--- a/src/components/SessionNotes.test.jsx
+++ b/src/components/SessionNotes.test.jsx
@@ -47,8 +47,6 @@ describe('SessionNotes', () => {
 
   it('clears notes when confirmed', async () => {
     const user = userEvent.setup();
-    const originalConfirm = window.confirm;
-    window.confirm = vi.fn(() => true);
     const setSessionNotes = vi.fn();
     render(
       <SessionNotes
@@ -59,9 +57,24 @@ describe('SessionNotes', () => {
       />,
     );
     await user.click(screen.getByRole('button', { name: /Clear/i }));
-    expect(window.confirm).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /Confirm/i }));
     expect(setSessionNotes).toHaveBeenCalledWith('');
-    window.confirm = originalConfirm;
+  });
+
+  it('does not clear notes when cancelled', async () => {
+    const user = userEvent.setup();
+    const setSessionNotes = vi.fn();
+    render(
+      <SessionNotes
+        sessionNotes="some"
+        setSessionNotes={setSessionNotes}
+        compactMode
+        setCompactMode={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /Clear/i }));
+    await user.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(setSessionNotes).not.toHaveBeenCalled();
   });
 
   it('applies fullWidth class when not in compact mode', () => {


### PR DESCRIPTION
## Summary
- replace synchronous confirm with ClearNotesModal using useModal
- style and test modal interactions for session notes
- fix codex preflight workflow so formatting checks pass

## Testing
- `npm run lint`
- `npm test` *(fails: addCharacter is not a function, character context tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system library glib-2.0 and WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6d9b897c83328b2b26fd23809337