### PR TITLE
ci: fix codex preflight workflow indentation

### DIFF
--- a/.github/workflows/codex-preflight.yml
+++ b/.github/workflows/codex-preflight.yml
@@ -19,14 +19,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
       - uses: actions/setup-node@v4
-- name: Install deps (lockfile-aware)
-  run: |
-    if [ -f pnpm-lock.yaml ]; then pnpm install;
-    elif [ -f yarn.lock ]; then yarn install --silent;
-    elif [ -f package-lock.json ]; then npm ci;
-    else npm i --no-audit --no-fund; fi
         with:
           node-version: '20'
+      - name: Install deps (lockfile-aware)
+        run: |
+          if [ -f pnpm-lock.yaml ]; then pnpm install;
+          elif [ -f yarn.lock ]; then yarn install --silent;
+          elif [ -f package-lock.json ]; then npm ci;
+          else npm i --no-audit --no-fund; fi
       - name: Install (best-effort)
         run: npm ci || npm i --prefer-offline
       - name: Preflight (auto-fix for codex/*)
@@ -50,4 +50,3 @@ jobs:
 
           # Enforce pass
           node .github/tools/codex-preflight.mjs --base "${{ github.base_ref || 'main' }}"
-


### PR DESCRIPTION
## Summary
- indent setup-node step and specify Node 20
- align lockfile-aware dependency installation step

## Testing
- `npm run lint`
- `npm test` *(fails: addCharacter is not a function, update wrapped in act warnings)*
- `npm run format:check` *(fails: code style issues in 4 files)*
- `npm run test:e2e` *(fails: glib-2.0 system library missing; WebKitWebDriver not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6ddaf78083328f8956da617453fc