### PR TITLE
fix: remove duplicate originalResult assignment in dice roller

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -290,7 +290,6 @@ export default function useDiceRoller(
       timestamp: Date.now(),
       ...(originalResult && { originalResult }),
     };
-    if (originalResult) rollData.originalResult = originalResult;
 
     setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);
     setRollModalData(rollData);


### PR DESCRIPTION
## Summary
- keep a single `originalResult` variable in `useDiceRoller`

## Testing
- `npm run lint`
- `npm test` *(fails: createDefaultCharacter is not defined)*
- `npm run format:check` *(fails: code style issues in many files)*
- `npm run test:e2e` *(fails: glib-2.0, gobject-2.0 missing; WebKitWebDriver not found)*
- `npm run build`
- `npm run tauri dev` *(fails: glib-2.0, gobject-2.0, gio-2.0, gdk-3.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a005a1bfec83329aed25f04269d2d6