### PR TITLE
refactor: rename originalResult variable to initialResult

### DIFF
--- a/src/components/RollModal.jsx
+++ b/src/components/RollModal.jsx
@@ -19,8 +19,8 @@ export default function RollModal({ isOpen, data, onClose }) {
           </div>
         </div>
         <div className={styles.body}>
-          {data.originalResult && (
-            <div className={styles.originalResult}>Original Roll: {data.originalResult}</div>
+          {data.initialResult && (
+            <div className={styles.initialResult}>Original Roll: {data.initialResult}</div>
           )}
           {Array.isArray(data.result) ? (
             <div className={styles.result}>
@@ -30,7 +30,7 @@ export default function RollModal({ isOpen, data, onClose }) {
             </div>
           ) : (
             <div className={styles.result}>
-              {data.originalResult ? `With Help: ${data.result}` : data.result}
+              {data.initialResult ? `With Help: ${data.result}` : data.result}
             </div>
           )}
           {data.description && <div className={styles.description}>{data.description}</div>}

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -56,7 +56,7 @@
   text-align: center;
 }
 
-.originalResult {
+.initialResult {
   font-size: 0.9rem;
   color: var(--color-gray-300);
   margin-bottom: 10px;

--- a/src/components/RollModal.test.jsx
+++ b/src/components/RollModal.test.jsx
@@ -34,7 +34,7 @@ describe('RollModal', () => {
   it('renders original and help results when provided', () => {
     const data = {
       result: '2d6: 3 + 5 = 8',
-      originalResult: '2d6: 1 + 2 = 3 ❌ Failure',
+      initialResult: '2d6: 1 + 2 = 3 ❌ Failure',
     };
     render(<RollModal isOpen data={data} onClose={() => {}} />);
     expect(screen.getByText('Original Roll: 2d6: 1 + 2 = 3 ❌ Failure')).toBeInTheDocument();

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -204,7 +204,7 @@ export default function useDiceRoller(
 
     const originalTotal = total;
     let originalInterpretation = '';
-    let originalResult;
+    let initialResult;
 
     const resolveAidOrInterfere = async () => {
       const response = await openAidModal();
@@ -256,7 +256,7 @@ export default function useDiceRoller(
       if (!isAidMove) {
         const aid = await resolveAidOrInterfere();
         if (aid) {
-          originalResult = buildResultString(mods, originalTotal, notes) + originalInterpretation;
+          initialResult = buildResultString(mods, originalTotal, notes) + originalInterpretation;
           if (aid.modifier !== 0) {
             mods.push(aid.modifier);
             total += aid.modifier;
@@ -288,7 +288,7 @@ export default function useDiceRoller(
       rolls,
       modifier: totalModifier,
       timestamp: Date.now(),
-      ...(originalResult && { originalResult }),
+      ...(initialResult && { initialResult }),
     };
 
     setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -156,8 +156,8 @@ describe('useDiceRoller aid/interfere', () => {
       await p;
     });
     expect(alertSpy).toHaveBeenCalled();
-    const { originalResult, result: finalResult } = result.current.rollModalData;
-    expect(originalResult).toBe('2d6: 3 + 3 = 6 ❌ Failure');
+    const { initialResult, result: finalResult } = result.current.rollModalData;
+    expect(initialResult).toBe('2d6: 3 + 3 = 6 ❌ Failure');
     expect(finalResult).toBe('2d6: 3 + 3 +1 = 7 (Helper Consequences) ⚠️ Partial Success');
     alertSpy.mockRestore();
     rollSpy.mockRestore();


### PR DESCRIPTION
## Summary
- rename duplicate `originalResult` variable to `initialResult`
- update RollModal and related tests for new property

## Testing
- `npm run lint`
- `npm test` *(fails: createDefaultCharacter is not defined, unhandled errors)*
- `npm run format:check`
- `npm run test:e2e` *(fails: WebKitWebDriver not found, gobject libs missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a00a3003388332aa814c57ee676457