### PR TITLE
fix: add React import to LevelUpModal

### DIFF
--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styles from './LevelUpModal.module.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import { scoreToMod } from '../utils/score.js';


### PR DESCRIPTION
## Summary
- add explicit React import in `LevelUpModal`

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check`
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found; can not find WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a00a983fc88332b709cc0ac5b4b889