### PR TITLE
fix: resolve duplicate originalResult variable

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -204,7 +204,7 @@ export default function useDiceRoller(
 
     const originalTotal = total;
     let originalInterpretation = '';
-    let originalResult;
+    let originalResultString;
 
     const resolveAidOrInterfere = async () => {
       const response = await openAidModal();
@@ -256,7 +256,8 @@ export default function useDiceRoller(
       if (!isAidMove) {
         const aid = await resolveAidOrInterfere();
         if (aid) {
-          originalResult = buildResultString(mods, originalTotal, notes) + originalInterpretation;
+          originalResultString =
+            buildResultString(mods, originalTotal, notes) + originalInterpretation;
           if (aid.modifier !== 0) {
             mods.push(aid.modifier);
             total += aid.modifier;
@@ -288,7 +289,7 @@ export default function useDiceRoller(
       rolls,
       modifier: totalModifier,
       timestamp: Date.now(),
-      ...(originalResult && { originalResult }),
+      ...(originalResultString && { originalResult: originalResultString }),
     };
 
     setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);


### PR DESCRIPTION
## Summary
- avoid redeclaring `originalResult` in `useDiceRoller` by renaming internal variable

## Testing
- `npm run lint`
- `npm test` *(fails: createDefaultCharacter is not defined; several tests warn about act wrapping)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system library `glib-2.0`, WebKitWebDriver not found, hook timeout)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a00b0538a08332b6f09a603534102c