### PR TITLE
fix: remove duplicate originalResult declaration

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -204,7 +204,7 @@ export default function useDiceRoller(
 
     const originalTotal = total;
     let originalInterpretation = '';
-    let originalResultString;
+    let originalResult;
 
     const resolveAidOrInterfere = async () => {
       const response = await openAidModal();
@@ -256,8 +256,7 @@ export default function useDiceRoller(
       if (!isAidMove) {
         const aid = await resolveAidOrInterfere();
         if (aid) {
-          originalResultString =
-            buildResultString(mods, originalTotal, notes) + originalInterpretation;
+          originalResult = buildResultString(mods, originalTotal, notes) + originalInterpretation;
           if (aid.modifier !== 0) {
             mods.push(aid.modifier);
             total += aid.modifier;
@@ -289,7 +288,7 @@ export default function useDiceRoller(
       rolls,
       modifier: totalModifier,
       timestamp: Date.now(),
-      ...(originalResultString && { originalResult: originalResultString }),
+      ...(originalResult && { originalResult }),
     };
 
     setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);


### PR DESCRIPTION
## Summary
- remove later duplicate `originalResult` declaration and consolidate to a single variable

## Testing
- `npm run lint`
- `npm test` *(fails: `AssertionError: expected undefined to be '2d6: 3 + 3 = 6 ❌ Failure'`)*
- `npm run format:check`
- `npm run test:e2e` *(fails: `error: failed to run custom build command for glib-sys v0.18.1`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a00dd7ce208332b3e6e7840fe5a8de