### PR TITLE
fix: rename originalResult to initialResult in dice roller

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -204,7 +204,7 @@ export default function useDiceRoller(
 
     const originalTotal = total;
     let originalInterpretation = '';
-    let originalResult;
+    let initialResult;
 
     const resolveAidOrInterfere = async () => {
       const response = await openAidModal();
@@ -256,7 +256,7 @@ export default function useDiceRoller(
       if (!isAidMove) {
         const aid = await resolveAidOrInterfere();
         if (aid) {
-          originalResult = buildResultString(mods, originalTotal, notes) + originalInterpretation;
+          initialResult = buildResultString(mods, originalTotal, notes) + originalInterpretation;
           if (aid.modifier !== 0) {
             mods.push(aid.modifier);
             total += aid.modifier;
@@ -288,7 +288,7 @@ export default function useDiceRoller(
       rolls,
       modifier: totalModifier,
       timestamp: Date.now(),
-      ...(originalResult && { originalResult }),
+      ...(initialResult && { initialResult }),
     };
 
     setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);


### PR DESCRIPTION
## Summary
- rename `originalResult` variable to `initialResult` in dice roller hook for clarity and ensure single declaration

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: missing glib/gobject system libraries and native driver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a010460bfc83328981cb05eba8ef5f