### PR TITLE
refactor: rename original roll property

### DIFF
--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -202,9 +202,9 @@ export default function useDiceRoller(
     const mods = [baseModifier, statusMods.modifier];
     let notes = [...statusMods.notes];
 
-    const originalTotal = total;
-    let originalInterpretation = '';
-    let originalResult;
+    const initialTotal = total;
+    let initialInterpretation = '';
+    let initialResult;
 
     const resolveAidOrInterfere = async () => {
       const response = await openAidModal();
@@ -242,9 +242,9 @@ export default function useDiceRoller(
         context = getFailureContext(desc);
       }
 
-      originalInterpretation = interpretation;
+      initialInterpretation = interpretation;
 
-      if (originalTotal < 7 && xpOnMiss) {
+      if (initialTotal < 7 && xpOnMiss) {
         saveToHistoryRef.current('XP Change');
         setCharacter((prev) => ({
           ...prev,
@@ -256,7 +256,7 @@ export default function useDiceRoller(
       if (!isAidMove) {
         const aid = await resolveAidOrInterfere();
         if (aid) {
-          originalResult = buildResultString(mods, originalTotal, notes) + originalInterpretation;
+          initialResult = buildResultString(mods, initialTotal, notes) + initialInterpretation;
           if (aid.modifier !== 0) {
             mods.push(aid.modifier);
             total += aid.modifier;
@@ -288,7 +288,7 @@ export default function useDiceRoller(
       rolls,
       modifier: totalModifier,
       timestamp: Date.now(),
-      ...(originalResult && { originalResult }),
+      ...(initialResult && { initialResult }),
     };
 
     setRollHistory((prev) => [rollData, ...prev.slice(0, 9)]);


### PR DESCRIPTION
## Summary
- rename `originalResult` to `initialResult` in dice roller
- maintain naming consistency for initial roll data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01046cff483329eb74f50f629f614