### PR TITLE
docs: document rollData object

### DIFF
--- a/docs/rolls.md
+++ b/docs/rolls.md
@@ -1,0 +1,35 @@
+# Dice Rolls
+
+This guide documents the structure of the `rollData` object emitted by the dice roller.
+Each roll stores the final narrative string along with metadata such as raw dice values and the total modifier.
+
+## `rollData` properties
+
+- **result** (`string` | `string[]`): Final roll result shown to the user. If multiple results are produced, this may be an array of lines.
+- **initialResult** (`string`, optional): Original roll before aid or interfere adjustments. Present only when another character modifies the roll.
+- **description** (`string`): User supplied description of the roll (e.g. move name).
+- **context** (`string`): Narrative context based on the roll outcome.
+- **total** (`number`): Final total including all modifiers.
+- **rolls** (`number[]`): Individual die results in the order rolled.
+- **modifier** (`number`): Sum of all modifiers applied to the roll.
+- **timestamp** (`number`): Unix epoch time in milliseconds when the roll occurred.
+
+## Successful aid example
+
+When a helper rolls 10+, they grant +1 without consequences. The `rollData` object records the
+original and final results:
+
+```json
+{
+  "result": "2d6: 4 + 5 +1 = 10 ✅ Success!",
+  "initialResult": "2d6: 4 + 5 = 9 ⚠️ Partial Success",
+  "description": "Hack and Slash",
+  "context": "Clean hit, enemy can't counter!",
+  "total": 10,
+  "rolls": [4, 5, 1],
+  "modifier": 1,
+  "timestamp": 1700000000000
+}
+```
+
+This object is also stored in roll history and displayed in the roll result modal.


### PR DESCRIPTION
## Summary
- add documentation for rollData object properties and aid roll example

## Testing
- `npm run lint` *(fails: 1 warning)*
- `npm test` *(fails: createDefaultCharacter is not defined)*
- `npm run format:check`
- `npm run test:e2e` *(fails: cannot find driver binary WebKitWebDriver / missing glib-2.0)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01048da988332b6f92157bbf2f4d1