### PR TITLE
fix: deep copy default character data

### DIFF
--- a/src/state/CharacterContext.jsx
+++ b/src/state/CharacterContext.jsx
@@ -1,13 +1,16 @@
 import React, { createContext, useContext, useState, useMemo, useEffect, useRef } from 'react';
 import { INITIAL_CHARACTER_DATA } from './character';
 import { saveFile, loadFile } from '../utils/fileStorage.js';
+import cloneDeep from '../utils/cloneDeep.js';
 
 const STORAGE_FILE = 'character.json';
+
+const createDefaultCharacter = () => cloneDeep(INITIAL_CHARACTER_DATA);
 
 const CharacterContext = createContext();
 
 export const CharacterProvider = ({ children }) => {
-  const [character, setCharacter] = useState(INITIAL_CHARACTER_DATA);
+  const [character, setCharacter] = useState(createDefaultCharacter);
   const initializedRef = useRef(false);
 
   useEffect(() => {

--- a/src/state/CharacterContext.test.jsx
+++ b/src/state/CharacterContext.test.jsx
@@ -93,4 +93,12 @@ describe('CharacterContext', () => {
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
   });
+  it('creates a default character when loading fails', async () => {
+    const { loadFile } = await import('../utils/fileStorage.js');
+    loadFile.mockRejectedValueOnce(new Error('missing'));
+
+    const { result } = renderHook(() => useCharacter(), { wrapper });
+    await waitFor(() => expect(result.current.character).toMatchObject(INITIAL_CHARACTER_DATA));
+    expect(loadFile).toHaveBeenCalledWith('character.json');
+  });
 });


### PR DESCRIPTION
## Summary
- use cloneDeep helper to create default character data
- ensure default character is generated on load failures
- test default creation when file loading fails

## Testing
- `npm run lint`
- `npm test` (fails: useDiceRoller aid/interfere applies modifiers and enforces helper consequences on 7-9)
- `npm run format:check`
- `npm run test:e2e` *(fails: build process interrupted)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a010f0460c83328e32d777988a364e