### PR TITLE
style: use flex layout for button group

### DIFF
--- a/src/components/common/ButtonGroup.module.css
+++ b/src/components/common/ButtonGroup.module.css
@@ -1,12 +1,10 @@
 .group {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 10px;
-  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  justify-content: center;
 }
 
-@media (max-width: 360px) {
-  .group {
-    grid-template-columns: 1fr;
-  }
+.group > * {
+  width: auto;
 }


### PR DESCRIPTION
## Summary
- refactor common ButtonGroup to use a flexible wrapping layout
- let group buttons size to their content for better label spacing

## Testing
- `npm run lint`
- `npm test` *(fails: useDiceRoller aid/interfere tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system deps for glib and WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a018001a2c8332b5a7873e232bb7d9