### PR TITLE
test: rename originalResult to initialResult in dice roller test

### DIFF
--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -158,8 +158,8 @@ describe('useDiceRoller aid/interfere', () => {
       await p;
     });
     expect(alertSpy).toHaveBeenCalled();
-    const { originalResult, result: finalResult } = result.current.rollModalData;
-    expect(originalResult).toBe('2d6: 3 + 3 = 6 ❌ Failure');
+    const { initialResult, result: finalResult } = result.current.rollModalData;
+    expect(initialResult).toBe('2d6: 3 + 3 = 6 ❌ Failure');
     expect(finalResult).toBe('2d6: 3 + 3 +1 = 7 (Helper Consequences) ⚠️ Partial Success');
     expect(result.current.rollHistory[0].result).toContain('Helper Consequences');
     alertSpy.mockRestore();
@@ -186,14 +186,8 @@ describe('useDiceRoller aid/interfere', () => {
       await p;
     });
     const data = result.current.rollModalData;
-    const { unmount } = render(
-      <RollModal
-        isOpen
-        data={{ ...data, initialResult: data.originalResult }}
-        onClose={() => {}}
-      />,
-    );
-    expect(screen.getByText(`Original Roll: ${data.originalResult}`)).toBeInTheDocument();
+    const { unmount } = render(<RollModal isOpen data={data} onClose={() => {}} />);
+    expect(screen.getByText(`Original Roll: ${data.initialResult}`)).toBeInTheDocument();
     unmount();
     unmountHook();
     rollSpy.mockRestore();


### PR DESCRIPTION
## Summary
- update dice roller tests to use `initialResult`
- pass roll modal data without remapping

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check`
- `npm run test:e2e` *(fails: Hook timed out and missing WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01d48f16c8332b2c4b44d71133a59