### PR TITLE
feat: add named grid layout for panels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -199,48 +199,58 @@ function App() {
         {/* Main Grid Layout */}
         <div className={styles.grid}>
           {/* Avatar Panel */}
-          <CharacterHUD onMountChange={setHudMounted} />
+          <div className={styles.hud}>
+            <CharacterHUD onMountChange={setHudMounted} />
+          </div>
 
           {/* Stats Panel */}
-          <CharacterStats
-            character={character}
-            setCharacter={setCharacter}
-            saveToHistory={saveToHistory}
-            totalArmor={totalArmor}
-            setShowLevelUpModal={setShowLevelUpModal}
-            setRollResult={setRollResult}
-            setSessionNotes={setSessionNotes}
-            clearRollHistory={clearRollHistory}
-          />
+          <div className={styles.stats}>
+            <CharacterStats
+              character={character}
+              setCharacter={setCharacter}
+              saveToHistory={saveToHistory}
+              totalArmor={totalArmor}
+              setShowLevelUpModal={setShowLevelUpModal}
+              setRollResult={setRollResult}
+              setSessionNotes={setSessionNotes}
+              clearRollHistory={clearRollHistory}
+            />
+          </div>
 
           {/* Dice Roller Panel (component-based, main branch design) */}
-          <DiceRoller
-            character={character}
-            rollDice={rollDice}
-            rollResult={rollResult}
-            rollHistory={rollHistory}
-            equippedWeaponDamage={equippedWeaponDamage}
-            rollModal={rollModal}
-            rollModalData={rollModalData}
-            aidModal={aidModal}
-          />
+          <div className={styles.dice}>
+            <DiceRoller
+              character={character}
+              rollDice={rollDice}
+              rollResult={rollResult}
+              rollHistory={rollHistory}
+              equippedWeaponDamage={equippedWeaponDamage}
+              rollModal={rollModal}
+              rollModalData={rollModalData}
+              aidModal={aidModal}
+            />
+          </div>
 
           {/* Quick Inventory Panel */}
-          <InventoryPanel
-            character={character}
-            setCharacter={setCharacter}
-            rollDie={rollDie}
-            setRollResult={setRollResult}
-            saveToHistory={saveToHistory}
-          />
+          <div className={styles.inventory}>
+            <InventoryPanel
+              character={character}
+              setCharacter={setCharacter}
+              rollDie={rollDie}
+              setRollResult={setRollResult}
+              saveToHistory={saveToHistory}
+            />
+          </div>
 
           {/* Session Notes Panel */}
-          <SessionNotes
-            sessionNotes={sessionNotes}
-            setSessionNotes={setSessionNotes}
-            compactMode={compactMode}
-            setCompactMode={setCompactMode}
-          />
+          <div className={styles.notes}>
+            <SessionNotes
+              sessionNotes={sessionNotes}
+              setSessionNotes={setSessionNotes}
+              compactMode={compactMode}
+              setCompactMode={setCompactMode}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -74,9 +74,55 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: var(--space-md);
   margin-bottom: 20px;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    'hud'
+    'stats'
+    'dice'
+    'inventory'
+    'notes';
+}
+
+.hud {
+  grid-area: hud;
+}
+
+.stats {
+  grid-area: stats;
+}
+
+.dice {
+  grid-area: dice;
+}
+
+.inventory {
+  grid-area: inventory;
+}
+
+.notes {
+  grid-area: notes;
+}
+
+@media (min-width: 768px) {
+  .grid {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'hud   stats'
+      'dice  inventory'
+      'notes notes';
+  }
+}
+
+@media (min-width: 1200px) {
+  .grid {
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-areas:
+      'hud   stats stats'
+      'hud   dice  inventory'
+      'notes notes notes';
+  }
 }
 
 .undoButton {


### PR DESCRIPTION
## Summary
- wrap each main panel with divs defining HUD, stats, dice, inventory, and notes grid areas
- implement responsive named-area CSS grid for desktop, tablet, and phone layouts

## Testing
- `npm run lint`
- `npm test` (fails: expected "spy" to be called 1 times, but got 2 times)
- `npm run format:check`
- `npm run test:e2e` (fails: The system library `glib-2.0` required by crate `glib-sys` was not found; can not find driver binary WebKitWebDriver in the PATH)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01fd3d12c8332a3867597eacba3b0