### PR TITLE
feat: adjust typography for small screens

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -312,3 +312,19 @@
   --glow-shadow: rgba(39, 169, 161, 0.35);
   --glow-shadow-strong: rgba(39, 169, 161, 0.6);
 }
+
+@media (max-width: 767px) {
+  :root {
+    --font-size-heading: 2.25rem;
+    --font-size-body: 0.9rem;
+    --hud-spacing: 1.125rem;
+  }
+
+  :root[data-theme='classic'] {
+    --hud-spacing: 0.9rem;
+  }
+
+  :root[data-theme='moebius'] {
+    --hud-spacing: 1.35rem;
+  }
+}


### PR DESCRIPTION
## Summary
- scale heading and body font sizes on small screens
- tighten HUD spacing on mobile while preserving theme overrides

## Testing
- `npm run lint`
- `npm test` *(fails: CharacterContext > doesn't re-render children when setCharacter is stable)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib-2.0, gobject-2.0, WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01fd66ffc8332b6484f4e80d56414