### PR TITLE
feat: add mobile scroll limits for inventory and roll history

### DIFF
--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -102,6 +102,13 @@
   font-size: 0.8rem;
 }
 
+@media (max-width: 767px) {
+  .history {
+    max-height: 50vh;
+    overflow: auto;
+  }
+}
+
 .historyTitle {
   color: var(--color-accent);
   margin-bottom: 5px;

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -18,6 +18,13 @@
   overflow-y: auto;
 }
 
+@media (max-width: 767px) {
+  .items {
+    max-height: 50vh;
+    overflow: auto;
+  }
+}
+
 .item {
   background: var(--overlay-darker);
   padding: var(--space-sm) 12px;


### PR DESCRIPTION
## Summary
- apply mobile max-height and scrolling to inventory item list
- apply mobile max-height and scrolling to dice roll history

## Testing
- `npm run lint`
- `npm test` *(fails: CharacterContext test expectation mismatch)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib/gobject system libraries and WebKit driver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01fde911483329958694823dfca7c