### PR TITLE
feat: make stats grid responsive

### DIFF
--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -15,9 +15,15 @@
 
 .statsGrid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
   gap: 10px;
   margin-bottom: var(--space-md);
+}
+
+@media (min-width: 1200px) {
+  .statsGrid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
 }
 
 .statItem {


### PR DESCRIPTION
## Summary
- use responsive grid auto-fit for character stats
- bump min width at desktop for wider columns

## Testing
- `npm run lint`
- `npm test` *(fails: expected "spy" to be called 1 times, but got 2 times)*
- `npm run format:check`
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01fdfe254833284ec533bbfd50473