### PR TITLE
style: standardize panel spacing

### DIFF
--- a/src/components/AidInterfereModal.module.css
+++ b/src/components/AidInterfereModal.module.css
@@ -10,7 +10,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: var(--hud-spacing);
 }
 
 .modal {
@@ -21,18 +21,18 @@
   width: 100%;
   box-shadow: 0 0 30px rgba(var(--color-accent-rgb), 0.5);
   text-align: center;
-  padding: 20px;
+  padding: var(--hud-spacing);
   color: var(--color-text);
 }
 
 .title {
   font-size: 1.5rem;
   color: var(--color-accent);
-  margin: 0 0 20px 0;
+  margin: 0 0 var(--space-md) 0;
 }
 
 .formRow {
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
   display: flex;
   justify-content: center;
   gap: 20px;

--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -9,13 +9,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--hud-spacing);
 }
 
 .modal {
   background: var(--color-modal-bg);
   border: 2px solid var(--color-accent);
   border-radius: 15px;
-  padding: 30px;
+  padding: var(--hud-spacing);
   text-align: center;
   width: 400px;
   max-height: 80%;
@@ -24,21 +25,22 @@
 
 .title {
   color: var(--color-accent);
+  margin-bottom: var(--space-md);
 }
 
 .empty {
   color: var(--color-gray-400);
-  margin: 20px 0;
+  margin: var(--space-md) 0;
 }
 
 .bondList {
   list-style: none;
   padding: 0;
-  margin: 20px 0;
+  margin: var(--space-md) 0;
 }
 
 .bondItem {
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
   text-align: left;
 }
 
@@ -52,7 +54,7 @@
 }
 
 .bondActions {
-  margin-top: 5px;
+  margin-top: var(--space-md);
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
@@ -97,7 +99,7 @@
   color: var(--color-white);
   padding: var(--space-sm);
   width: 100%;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .form {
@@ -105,5 +107,5 @@
 }
 
 .closeButton {
-  margin-top: 20px;
+  margin-top: var(--space-md);
 }

--- a/src/components/CharacterHUD/Portrait.module.css
+++ b/src/components/CharacterHUD/Portrait.module.css
@@ -2,7 +2,7 @@
   background: var(--panel-bg);
   backdrop-filter: blur(10px);
   border-radius: 12px;
-  padding: 20px;
+  padding: var(--hud-spacing);
   border: 1px solid var(--panel-border);
   box-shadow: 0 8px 32px var(--panel-shadow);
   display: flex;

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -46,7 +46,7 @@
   border-radius: var(--hud-radius);
   overflow: hidden;
   border: 2px solid var(--color-gray-700);
-  margin: 10px 0;
+  margin: var(--space-md) 0;
 }
 
 .hpBarContainer:focus {
@@ -67,7 +67,7 @@
 
 .controls {
   text-align: center;
-  margin-top: 10px;
+  margin-top: var(--space-md);
 }
 
 .button {
@@ -79,7 +79,7 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
+  margin: var(--space-sm);
 }
 
 .buttonRed {
@@ -92,7 +92,7 @@
   background: var(--color-gray-800);
   border-radius: 10px;
   overflow: hidden;
-  margin: var(--space-md) 0 10px 0;
+  margin: var(--space-md) 0 var(--space-md) 0;
 }
 
 .xpBarContainer:focus {
@@ -109,18 +109,18 @@
 .autoXpLabel {
   display: block;
   text-align: center;
-  margin-top: 10px;
+  margin-top: var(--space-md);
 }
 
 .resourceRow {
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .resourceHeader {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 5px;
+  margin-bottom: var(--space-md);
 }
 
 .resourceLabel {
@@ -192,7 +192,7 @@
   border-radius: var(--hud-radius-sm);
   padding: var(--hud-spacing-sm);
   text-align: center;
-  margin-top: 10px;
+  margin-top: var(--space-md);
 }
 
 .warningText {
@@ -217,7 +217,7 @@
 .devButton {
   background: linear-gradient(45deg, var(--color-purple-dark), var(--color-purple));
   width: 100%;
-  margin-top: 10px;
+  margin-top: var(--space-md);
 }
 
 .levelUpButton {

--- a/src/components/DamageModal.module.css
+++ b/src/components/DamageModal.module.css
@@ -9,23 +9,25 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--hud-spacing);
 }
 
 .modal {
   background: var(--color-modal-bg);
   border: 2px solid var(--color-accent);
   border-radius: 15px;
-  padding: 30px;
+  padding: var(--hud-spacing);
   text-align: center;
   width: 300px;
 }
 
 .title {
   color: var(--color-accent);
+  margin-bottom: var(--space-md);
 }
 
 .info {
-  margin: 15px 0;
+  margin: var(--space-md) 0;
   color: var(--color-white);
 }
 
@@ -36,12 +38,12 @@
   color: var(--color-white);
   padding: var(--space-sm);
   width: 100%;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .summary {
   color: var(--color-gray-400);
-  margin-bottom: 20px;
+  margin-bottom: var(--space-md);
 }
 
 .applyButton {

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -9,17 +9,17 @@
 
 .title {
   color: var(--color-accent);
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
   font-size: 1.3rem;
 }
 
 .section {
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
 }
 
 .subtitle {
   color: var(--color-accent);
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
   font-size: 1rem;
 }
 
@@ -50,7 +50,7 @@
   cursor: pointer;
   font-weight: bold;
   transition: var(--hud-transition);
-  margin: 5px;
+  margin: var(--space-sm);
 }
 
 .small {
@@ -98,13 +98,13 @@
 }
 
 .history {
-  margin-top: 10px;
+  margin-top: var(--space-md);
   font-size: 0.8rem;
 }
 
 .historyTitle {
   color: var(--color-accent);
-  margin-bottom: 5px;
+  margin-bottom: var(--space-md);
 }
 
 .historyItem {

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -9,13 +9,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--hud-spacing);
 }
 
 .modal {
   background: var(--color-modal-bg);
   border: 2px solid var(--color-accent);
   border-radius: 15px;
-  padding: 30px;
+  padding: var(--hud-spacing);
   text-align: center;
   width: 400px;
   max-height: 80%;
@@ -24,11 +25,12 @@
 
 .title {
   color: var(--color-accent);
+  margin-bottom: var(--space-md);
 }
 
 .section {
   text-align: left;
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
 }
 
 .bondList {
@@ -37,12 +39,12 @@
 }
 
 .bondItem {
-  margin-bottom: 5px;
+  margin-bottom: var(--space-sm);
 }
 
 .bondInput {
   width: 100%;
-  margin-top: 5px;
+  margin-top: var(--space-sm);
   padding: 5px;
   border-radius: 4px;
   border: 1px solid var(--color-accent);
@@ -52,7 +54,7 @@
 
 .recapInput {
   width: 100%;
-  margin-top: 5px;
+  margin-top: var(--space-sm);
   padding: 5px;
   border-radius: 4px;
   border: 1px solid var(--color-accent);
@@ -61,17 +63,17 @@
 }
 
 .total {
-  margin-top: 10px;
+  margin-top: var(--space-md);
   color: var(--color-white);
 }
 
 .error {
   color: var(--color-danger);
-  margin-top: 10px;
+  margin-top: var(--space-md);
 }
 
 .actions {
-  margin-top: 20px;
+  margin-top: var(--space-md);
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
@@ -87,7 +89,7 @@
 
 .error {
   color: var(--color-danger);
-  margin-top: 10px;
+  margin-top: var(--space-md);
 }
 
 .button {

--- a/src/components/ExportModal.module.css
+++ b/src/components/ExportModal.module.css
@@ -9,20 +9,21 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--hud-spacing);
 }
 
 .modal {
   background: var(--color-modal-bg);
   border: 2px solid var(--color-accent);
   border-radius: 15px;
-  padding: 30px;
+  padding: var(--hud-spacing);
   text-align: center;
   width: 300px;
 }
 
 .title {
   color: var(--color-accent);
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .input {
@@ -32,10 +33,10 @@
   color: var(--color-white);
   padding: var(--space-sm);
   width: 100%;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .message {
   color: var(--color-accent);
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }

--- a/src/components/InventoryModal.module.css
+++ b/src/components/InventoryModal.module.css
@@ -9,6 +9,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--hud-spacing);
 }
 
 .inventoryModal {
@@ -25,6 +26,7 @@
 .inventoryTitle {
   color: var(--color-accent);
   text-align: center;
+  margin-bottom: var(--space-md);
 }
 
 .inventoryEmpty {
@@ -37,9 +39,9 @@
 }
 
 .inventoryItem {
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
   border-bottom: 1px solid var(--color-gray-800);
-  padding-bottom: 10px;
+  padding-bottom: var(--space-md);
 }
 
 .inventoryItemName {
@@ -68,7 +70,7 @@
 }
 
 .inventoryItemActions {
-  margin-top: 5px;
+  margin-top: var(--space-md);
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
@@ -94,5 +96,5 @@
 
 .inventoryClose {
   text-align: center;
-  margin-top: 15px;
+  margin-top: var(--space-md);
 }

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -9,7 +9,7 @@
 
 .title {
   color: var(--color-accent);
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
   font-size: 1.3rem;
 }
 
@@ -21,7 +21,7 @@
 .item {
   background: var(--overlay-darker);
   padding: var(--space-sm) 12px;
-  margin: 5px 0;
+  margin: var(--space-sm) 0;
   border-radius: var(--hud-radius-sm);
   border-left: 3px solid var(--color-accent);
 }
@@ -93,7 +93,7 @@
 }
 
 .debilitiesSection {
-  margin-top: 15px;
+  margin-top: var(--space-md);
   padding-top: var(--hud-spacing-sm);
   border-top: 1px solid var(--panel-border);
 }
@@ -101,7 +101,7 @@
 .debilitiesTitle {
   font-size: 0.8rem;
   color: var(--color-danger);
-  margin-bottom: 5px;
+  margin-bottom: var(--space-md);
 }
 
 .debilitiesList {

--- a/src/components/LastBreathModal.module.css
+++ b/src/components/LastBreathModal.module.css
@@ -21,23 +21,23 @@
   width: 100%;
   box-shadow: 0 0 30px rgba(var(--color-accent-rgb), 0.5);
   text-align: center;
-  padding: 30px;
+  padding: var(--hud-spacing);
   color: var(--color-text);
 }
 
 .title {
   font-size: 1.5rem;
   color: var(--color-accent);
-  margin: 0 0 20px 0;
+  margin: 0 0 var(--space-md) 0;
 }
 
 .result {
   font-size: 1.3rem;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .outcome {
-  margin-bottom: 20px;
+  margin-bottom: var(--space-md);
 }
 
 .button {

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -40,7 +40,7 @@
 }
 
 .headerText {
-  margin: 5px 0 0;
+  margin: var(--space-sm) 0 0;
   color: var(--color-info-light);
 }
 
@@ -65,7 +65,7 @@
 .progress {
   display: flex;
   justify-content: space-between;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-md);
   padding: var(--hud-spacing-sm);
   background: rgba(var(--color-accent-rgb), 0.1);
   border-radius: 8px;
@@ -90,12 +90,12 @@
 }
 
 .step {
-  margin-bottom: 20px;
+  margin-bottom: var(--space-md);
 }
 
 .stepTitle {
   color: var(--color-accent);
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
   font-size: 1.2rem;
 }
 
@@ -109,7 +109,7 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 10px;
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .statButton {
@@ -237,7 +237,7 @@
   background: rgba(var(--color-accent-rgb), 0.05);
   border: 1px solid rgba(var(--color-accent-rgb), 0.2);
   border-radius: var(--hud-radius-sm);
-  margin-left: 10px;
+  margin-left: var(--space-md);
   font-size: var(--font-size-sm);
 }
 
@@ -254,8 +254,8 @@
 .hpContainer {
   display: flex;
   align-items: center;
-  gap: 15px;
-  padding: 15px;
+  gap: var(--space-md);
+  padding: var(--hud-spacing);
   background: rgba(255, 255, 255, 0.05);
   border-radius: 8px;
   border: 1px solid var(--color-gray-700);
@@ -306,7 +306,7 @@
 }
 
 .summary {
-  padding: 15px;
+  padding: var(--hud-spacing);
   border-radius: 8px;
   text-align: center;
 }
@@ -323,7 +323,7 @@
 
 .summaryTitle {
   color: var(--color-accent);
-  margin: 0 0 10px;
+  margin: 0 0 var(--space-md);
   font-size: 1.1rem;
 }
 

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -38,7 +38,7 @@
 .title {
   font-size: 1.5rem;
   color: var(--color-accent);
-  margin: 0;
+  margin: 0 0 var(--space-md);
 }
 
 .closeButton {
@@ -52,38 +52,38 @@
 }
 
 .body {
-  padding: 30px;
+  padding: var(--hud-spacing);
   text-align: center;
 }
 
 .initialResult {
   font-size: 0.9rem;
   color: var(--color-gray-300);
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .result {
   font-size: 1.5rem;
   font-weight: bold;
   color: var(--color-accent);
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
 }
 
 .description {
   color: var(--color-gray-100);
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
 }
 
 .context {
   color: var(--color-gray-400);
   font-size: 0.9rem;
-  margin-bottom: 20px;
+  margin-bottom: var(--space-md);
 }
 
 .original {
   font-size: 1rem;
   color: var(--color-gray-400);
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
 }
 
 .button {

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -9,7 +9,7 @@
 
 .title {
   color: var(--color-accent);
-  margin-bottom: 15px;
+  margin-bottom: var(--space-md);
   font-size: 1.3rem;
 }
 
@@ -28,12 +28,12 @@
 
 .warning {
   color: var(--color-danger);
-  margin-top: 10px;
+  margin-top: var(--space-md);
   font-size: 0.9rem;
 }
 
 .buttons {
-  margin-top: 10px;
+  margin-top: var(--space-md);
   display: flex;
   gap: 10px;
 }
@@ -80,14 +80,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
+  padding: var(--hud-spacing);
 }
 
 .modal {
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);
   border-radius: var(--hud-radius);
-  padding: 20px;
+  padding: var(--hud-spacing);
   color: var(--color-gray-100);
   text-align: center;
 }

--- a/src/components/StatusModal.module.css
+++ b/src/components/StatusModal.module.css
@@ -9,6 +9,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--hud-spacing);
 }
 
 .statusModal {
@@ -25,10 +26,12 @@
 .statusTitle {
   color: var(--color-accent);
   text-align: center;
+  margin-bottom: var(--space-md);
 }
 
 .statusSubtitle {
   color: var(--color-accent);
+  margin-bottom: var(--space-md);
 }
 
 .statusList {
@@ -56,7 +59,7 @@
 
 .statusFooter {
   text-align: center;
-  margin-top: 10px;
+  margin-top: var(--space-md);
   display: flex;
   justify-content: center;
   flex-wrap: wrap;

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -15,7 +15,7 @@
 
 .header {
   text-align: center;
-  margin-bottom: 30px;
+  margin-bottom: var(--space-md);
   padding: var(--hud-spacing);
   border-radius: 15px;
   border: 2px solid var(--color-accent);
@@ -34,7 +34,7 @@
   font-family: var(--font-heading);
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-heading);
-  margin-bottom: 10px;
+  margin-bottom: var(--space-md);
   text-shadow: 0 0 10px var(--color-accent);
 }
 
@@ -76,7 +76,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: var(--space-md);
-  margin-bottom: 20px;
+  margin-bottom: var(--space-md);
 }
 
 .undoButton {


### PR DESCRIPTION
## Summary
- replace hardcoded spacing with CSS variables across panels and modals
- unify heading spacing to `var(--space-md)`
- clean up stray margins for consistent layout

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test` *(fails: CharacterContext doesn't re-render children when setCharacter is stable)*
- `npm run test:e2e` *(fails: system library `glib-2.0` not found; WebKit driver missing)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a01fe4fe0c833295b9204122aca99d