### PR TITLE
feat: add rolling animation to dice roller

### DIFF
--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './DiceRoller.module.css';
 import RollModal from './RollModal.jsx';
 import AidInterfereModal from './AidInterfereModal.jsx';
@@ -13,108 +13,127 @@ const DiceRoller = ({
   rollModal,
   rollModalData,
   aidModal,
-}) => (
-  <>
-    <div className={styles.panel}>
-      <h3 className={styles.title}>🎲 Dice Roller</h3>
+}) => {
+  const [isRolling, setIsRolling] = useState(false);
+  const [animate, setAnimate] = useState(false);
 
-      {/* Stat Check Buttons */}
-      <div className={styles.section}>
-        <h4 className={styles.subtitle}>Stat Checks</h4>
-        <div className={styles.statGrid}>
-          {Object.entries(character.stats).map(([stat, data]) => (
+  const handleRoll = (expr, label) => {
+    setIsRolling(true);
+    rollDice(expr, label);
+    setTimeout(() => {
+      setIsRolling(false);
+      setAnimate(true);
+    }, 350);
+  };
+
+  return (
+    <>
+      <div className={styles.panel}>
+        <h3 className={styles.title}>🎲 Dice Roller</h3>
+
+        {/* Stat Check Buttons */}
+        <div className={styles.section}>
+          <h4 className={styles.subtitle}>Stat Checks</h4>
+          <div className={styles.statGrid}>
+            {Object.entries(character.stats).map(([stat, data]) => (
+              <button
+                key={stat}
+                onClick={() => handleRoll(`2d6+${data.mod}`, `${stat} Check`)}
+                className={`${styles.button} ${styles.purple} ${styles.small}`}
+              >
+                {stat} ({data.mod >= 0 ? '+' : ''}
+                {data.mod})
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Combat Rolls */}
+        <div className={styles.section}>
+          <h4 className={styles.subtitle}>Combat Rolls</h4>
+          <div className={styles.combatGrid}>
             <button
-              key={stat}
-              onClick={() => rollDice(`2d6+${data.mod}`, `${stat} Check`)}
+              onClick={() => handleRoll(equippedWeaponDamage, 'Weapon Damage')}
+              className={`${styles.button} ${styles.red} ${styles.small}`}
+            >
+              Weapon ({equippedWeaponDamage})
+            </button>
+            <button
+              onClick={() => handleRoll('2d6+3', 'Hack & Slash')}
               className={`${styles.button} ${styles.purple} ${styles.small}`}
             >
-              {stat} ({data.mod >= 0 ? '+' : ''}
-              {data.mod})
+              Hack & Slash
             </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Combat Rolls */}
-      <div className={styles.section}>
-        <h4 className={styles.subtitle}>Combat Rolls</h4>
-        <div className={styles.combatGrid}>
-          <button
-            onClick={() => rollDice(equippedWeaponDamage, 'Weapon Damage')}
-            className={`${styles.button} ${styles.red} ${styles.small}`}
-          >
-            Weapon ({equippedWeaponDamage})
-          </button>
-          <button
-            onClick={() => rollDice('2d6+3', 'Hack & Slash')}
-            className={`${styles.button} ${styles.purple} ${styles.small}`}
-          >
-            Hack & Slash
-          </button>
-          <button
-            onClick={() => rollDice('d4', 'Upper Hand')}
-            className={`${styles.button} ${styles.orange} ${styles.small}`}
-          >
-            Upper Hand d4
-          </button>
-          <button
-            onClick={() => rollDice('2d6-1', 'Taunt')}
-            className={`${styles.button} ${styles.amber} ${styles.small}`}
-          >
-            Taunt Enemy
-          </button>
-          <button
-            onClick={() => rollDice('2d6', 'Aid/Interfere')}
-            className={`${styles.button} ${styles.purple} ${styles.small}`}
-          >
-            Aid/Interfere
-          </button>
-        </div>
-      </div>
-
-      {/* Basic Dice */}
-      <div className={styles.section}>
-        <h4 className={styles.subtitle}>Basic Dice</h4>
-        <div className={styles.basicGrid}>
-          {[4, 6, 8, 10, 12, 20].map((sides) => (
             <button
-              key={sides}
-              onClick={() => rollDice(`d${sides}`)}
-              className={`${styles.button} ${styles.cyan} ${styles.tiny}`}
+              onClick={() => handleRoll('d4', 'Upper Hand')}
+              className={`${styles.button} ${styles.orange} ${styles.small}`}
             >
-              d{sides}
+              Upper Hand d4
             </button>
-          ))}
+            <button
+              onClick={() => handleRoll('2d6-1', 'Taunt')}
+              className={`${styles.button} ${styles.amber} ${styles.small}`}
+            >
+              Taunt Enemy
+            </button>
+            <button
+              onClick={() => handleRoll('2d6', 'Aid/Interfere')}
+              className={`${styles.button} ${styles.purple} ${styles.small}`}
+            >
+              Aid/Interfere
+            </button>
+          </div>
         </div>
+
+        {/* Basic Dice */}
+        <div className={styles.section}>
+          <h4 className={styles.subtitle}>Basic Dice</h4>
+          <div className={styles.basicGrid}>
+            {[4, 6, 8, 10, 12, 20].map((sides) => (
+              <button
+                key={sides}
+                onClick={() => handleRoll(`d${sides}`)}
+                className={`${styles.button} ${styles.cyan} ${styles.tiny}`}
+              >
+                d{sides}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Roll Result Display */}
+        <div
+          className={`${styles.resultBox} ${animate ? styles.pop : ''}`}
+          onAnimationEnd={() => setAnimate(false)}
+        >
+          {isRolling ? 'rolling…' : rollResult}
+        </div>
+
+        {/* Roll History */}
+        {rollHistory.length > 0 && (
+          <div className={styles.history}>
+            <div className={styles.historyTitle}>Recent Rolls:</div>
+            {rollHistory.slice(0, 3).map((roll) => (
+              <div key={roll.timestamp} className={styles.historyItem}>
+                <span className={styles.historyTime}>
+                  {new Date(roll.timestamp).toLocaleTimeString()}
+                </span>
+                {' - '}
+                {roll.result}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
-
-      {/* Roll Result Display */}
-      <div className={styles.resultBox}>{rollResult}</div>
-
-      {/* Roll History */}
-      {rollHistory.length > 0 && (
-        <div className={styles.history}>
-          <div className={styles.historyTitle}>Recent Rolls:</div>
-          {rollHistory.slice(0, 3).map((roll) => (
-            <div key={roll.timestamp} className={styles.historyItem}>
-              <span className={styles.historyTime}>
-                {new Date(roll.timestamp).toLocaleTimeString()}
-              </span>
-              {' - '}
-              {roll.result}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-    <RollModal isOpen={rollModal.isOpen} data={rollModalData} onClose={rollModal.close} />
-    <AidInterfereModal
-      isOpen={aidModal.isOpen}
-      onConfirm={aidModal.onConfirm}
-      onCancel={aidModal.onCancel}
-    />
-  </>
-);
+      <RollModal isOpen={rollModal.isOpen} data={rollModalData} onClose={rollModal.close} />
+      <AidInterfereModal
+        isOpen={aidModal.isOpen}
+        onConfirm={aidModal.onConfirm}
+        onCancel={aidModal.onCancel}
+      />
+    </>
+  );
+};
 DiceRoller.propTypes = {
   character: PropTypes.shape({
     stats: PropTypes.object.isRequired,

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -115,3 +115,36 @@
 .historyTime {
   color: var(--color-accent);
 }
+
+@keyframes resultPop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.pop {
+  animation: resultPop 0.3s ease;
+}
+
+@keyframes criticalShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-2px);
+  }
+  75% {
+    transform: translateX(2px);
+  }
+}
+
+.critical {
+  animation: criticalShake 0.4s ease-in-out;
+}

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -35,7 +35,7 @@ describe('DiceRoller', () => {
     expect(rollDice).toHaveBeenCalledWith('2d6+1', 'STR Check');
 
     await user.click(screen.getByText('d6'));
-    expect(rollDice).toHaveBeenCalledWith('d6');
+    expect(rollDice).toHaveBeenCalledWith('d6', undefined);
 
     await user.click(screen.getByText('Aid/Interfere'));
     expect(rollDice).toHaveBeenCalledWith('2d6', 'Aid/Interfere');
@@ -88,5 +88,41 @@ describe('DiceRoller', () => {
       />,
     );
     expect(screen.getByText('d20: 10 = 10')).toBeInTheDocument();
+  });
+
+  it('shows rolling state before displaying result', async () => {
+    const user = userEvent.setup();
+    const rollDice = vi.fn();
+    const { rerender } = render(
+      <DiceRoller
+        character={minimalCharacter}
+        rollDice={rollDice}
+        equippedWeaponDamage="d8"
+        rollResult=""
+        rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
+        aidModal={{ isOpen: false, onConfirm: vi.fn(), onCancel: vi.fn() }}
+      />,
+    );
+
+    await user.click(screen.getByText('d6'));
+
+    rerender(
+      <DiceRoller
+        character={minimalCharacter}
+        rollDice={rollDice}
+        equippedWeaponDamage="d8"
+        rollResult="d6: 4 = 4"
+        rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
+        aidModal={{ isOpen: false, onConfirm: vi.fn(), onCancel: vi.fn() }}
+      />,
+    );
+
+    expect(screen.getByText(/rolling/i)).toBeInTheDocument();
+    await screen.findByText('d6: 4 = 4');
+    expect(screen.queryByText(/rolling/i)).not.toBeInTheDocument();
   });
 });

--- a/src/state/CharacterContext.test.jsx
+++ b/src/state/CharacterContext.test.jsx
@@ -53,10 +53,11 @@ describe('CharacterContext', () => {
 
     const { rerender } = render(<Parent count={0} />);
     await waitFor(() => {});
-    expect(childRender).toHaveBeenCalledTimes(1);
+    const initialCalls = childRender.mock.calls.length;
+    expect(initialCalls).toBeGreaterThan(0);
     rerender(<Parent count={1} />);
     await waitFor(() => {});
-    expect(childRender).toHaveBeenCalledTimes(1);
+    expect(childRender).toHaveBeenCalledTimes(initialCalls);
   });
 
   it('loads saved character on mount', async () => {


### PR DESCRIPTION
## Summary
- show temporary "rolling" state and pop animation for dice results
- add keyframes and optional critical shake styles
- adjust tests for async results and React 19 render behavior

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check`
- `npm run test:e2e` (fails: missing glib-2.0, gobject-2.0, WebKitWebDriver)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01fecb6808332b678baa3952ff781