### PR TITLE
feat: add motion-aware transitions to collapsible sections

### DIFF
--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -239,6 +239,8 @@
   border-radius: var(--hud-radius-sm);
   margin-left: 10px;
   font-size: var(--font-size-sm);
+  overflow: hidden;
+  animation: expandSection 0.3s ease forwards;
 }
 
 .moveExpanded {
@@ -249,6 +251,23 @@
 
 .moveExamples {
   color: var(--color-gray-400);
+}
+
+@keyframes expandSection {
+  from {
+    max-height: 0;
+    opacity: 0;
+  }
+  to {
+    max-height: 1000px;
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .moveDetails {
+    animation: none;
+  }
 }
 
 .hpContainer {

--- a/src/components/SessionNotes.jsx
+++ b/src/components/SessionNotes.jsx
@@ -60,7 +60,11 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
 
   return (
     <>
-      <div className={`${styles.panel} ${compactMode ? '' : styles.fullWidth}`}>
+      <div
+        className={`${styles.panel} ${
+          compactMode ? styles.panelCompact : styles.panelExpanded
+        } ${compactMode ? '' : styles.fullWidth}`}
+      >
         <h3 className={styles.title}>
           <FaClipboard className={styles.icon} /> Session Notes
         </h3>

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -5,6 +5,10 @@
   padding: var(--hud-spacing);
   border: 1px solid var(--panel-border);
   box-shadow: 0 8px 32px var(--panel-shadow);
+  overflow: hidden;
+  transition:
+    max-height 0.3s ease,
+    opacity 0.3s ease;
 }
 
 .title {
@@ -66,6 +70,22 @@
 
 .fullWidth {
   grid-column: 1 / -1;
+}
+
+.panelCompact {
+  max-height: 0;
+  opacity: 0;
+}
+
+.panelExpanded {
+  max-height: 1000px;
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel {
+    transition: none;
+  }
 }
 
 .overlay {


### PR DESCRIPTION
## Summary
- animate Session Notes panel height and opacity with reduced-motion support
- add expand animation for Level Up move details

## Testing
- `npm run lint`
- `npm test` *(fails: spy called 2 times)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib-2.0 and gobject-2.0 system libraries)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01ff129088332b8c6331bbfad9733