### PR TITLE
feat: add hover and focus styles to Button

### DIFF
--- a/src/components/common/Button.module.css
+++ b/src/components/common/Button.module.css
@@ -16,6 +16,15 @@
   gap: 5px;
 }
 
+.button:hover {
+  filter: brightness(1.1);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .button:disabled {
   opacity: 0.5;
   cursor: not-allowed;


### PR DESCRIPTION
## Summary
- increase button brightness on hover
- show accent outline on keyboard focus

## Testing
- `npm run lint`
- `npm test` (fails: CharacterContext > doesn't re-render children when setCharacter is stable)
- `npm run format:check`
- `npm run test:e2e` (fails: missing system libraries `glib-2.0`/WebKitWebDriver)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a01ff93e388332be35944f1ca20386