### PR TITLE
feat: add inventory metadata

### DIFF
--- a/src/hooks/useInventory.js
+++ b/src/hooks/useInventory.js
@@ -14,6 +14,23 @@ export default function useInventory(character, setCharacter) {
     return weapon ? weapon.damage || 'd6' : 'd6';
   }, [character.inventory]);
 
+  const handleAddItem = useCallback(
+    (item) => {
+      setCharacter((prev) => ({
+        ...prev,
+        inventory: [
+          ...prev.inventory,
+          {
+            ...item,
+            addedAt: new Date().toISOString(),
+            notes: item.notes || '',
+          },
+        ],
+      }));
+    },
+    [setCharacter],
+  );
+
   const handleEquipItem = useCallback(
     (id) => {
       setCharacter((prev) => ({
@@ -61,6 +78,7 @@ export default function useInventory(character, setCharacter) {
   return {
     totalArmor,
     equippedWeaponDamage,
+    handleAddItem,
     handleEquipItem,
     handleConsumeItem,
     handleDropItem,

--- a/src/hooks/useInventory.test.jsx
+++ b/src/hooks/useInventory.test.jsx
@@ -67,10 +67,28 @@ describe('useInventory equippedWeaponDamage', () => {
 });
 
 describe('useInventory actions', () => {
+  it('adds items with handleAddItem including timestamp and notes', () => {
+    const { result } = renderHook(() => {
+      const [character, setCharacter] = useState({ inventory: [] });
+      const inventory = useInventory(character, setCharacter);
+      return { ...inventory, character };
+    });
+
+    act(() => result.current.handleAddItem({ id: 'potion', name: 'Potion', quantity: 1 }));
+
+    expect(result.current.character.inventory[0]).toMatchObject({
+      id: 'potion',
+      name: 'Potion',
+      quantity: 1,
+      notes: '',
+    });
+    expect(result.current.character.inventory[0].addedAt).toBeDefined();
+  });
+
   it('toggles item equipment state with handleEquipItem', () => {
     const { result } = renderHook(() => {
       const [character, setCharacter] = useState({
-        inventory: [{ id: 'shield', equipped: false }],
+        inventory: [{ id: 'shield', equipped: false, addedAt: '2024-01-01', notes: '' }],
       });
       const inventory = useInventory(character, setCharacter);
       return { ...inventory, character };
@@ -86,14 +104,18 @@ describe('useInventory actions', () => {
   it('reduces quantity or removes items with handleConsumeItem', () => {
     const { result } = renderHook(() => {
       const [character, setCharacter] = useState({
-        inventory: [{ id: 'potion', quantity: 2 }],
+        inventory: [{ id: 'potion', quantity: 2, addedAt: '2024-01-01', notes: 'healing' }],
       });
       const inventory = useInventory(character, setCharacter);
       return { ...inventory, character };
     });
 
     act(() => result.current.handleConsumeItem('potion'));
-    expect(result.current.character.inventory[0].quantity).toBe(1);
+    expect(result.current.character.inventory[0]).toMatchObject({
+      quantity: 1,
+      addedAt: '2024-01-01',
+      notes: 'healing',
+    });
 
     act(() => result.current.handleConsumeItem('potion'));
     expect(result.current.character.inventory.find((i) => i.id === 'potion')).toBeUndefined();
@@ -102,13 +124,18 @@ describe('useInventory actions', () => {
   it('removes items with handleDropItem', () => {
     const { result } = renderHook(() => {
       const [character, setCharacter] = useState({
-        inventory: [{ id: 'rock' }, { id: 'coin' }],
+        inventory: [
+          { id: 'rock', addedAt: '2024-01-01', notes: '' },
+          { id: 'coin', addedAt: '2024-01-02', notes: 'shiny' },
+        ],
       });
       const inventory = useInventory(character, setCharacter);
       return { ...inventory, character };
     });
 
     act(() => result.current.handleDropItem('rock'));
-    expect(result.current.character.inventory).toEqual([{ id: 'coin' }]);
+    expect(result.current.character.inventory).toEqual([
+      { id: 'coin', addedAt: '2024-01-02', notes: 'shiny' },
+    ]);
   });
 });

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -67,6 +67,8 @@ export const INITIAL_CHARACTER_DATA = {
       equipped: true,
       description: 'Phases through time occasionally',
       tags: ['melee', 'forceful', 'messy'],
+      addedAt: new Date().toISOString(),
+      notes: '',
     },
     {
       id: 2,
@@ -74,6 +76,8 @@ export const INITIAL_CHARACTER_DATA = {
       type: 'magic',
       equipped: true,
       description: 'Grants Chrono-Retcon ability',
+      addedAt: new Date().toISOString(),
+      notes: '',
     },
     {
       id: 3,
@@ -81,6 +85,8 @@ export const INITIAL_CHARACTER_DATA = {
       type: 'material',
       quantity: 1,
       description: "Crafting material for Sar's companion Kumquat",
+      addedAt: new Date().toISOString(),
+      notes: '',
     },
     {
       id: 4,
@@ -88,6 +94,8 @@ export const INITIAL_CHARACTER_DATA = {
       type: 'consumable',
       quantity: 2,
       description: 'Restore 1d8 HP',
+      addedAt: new Date().toISOString(),
+      notes: '',
     },
     {
       id: 5,
@@ -96,6 +104,8 @@ export const INITIAL_CHARACTER_DATA = {
       armor: 1,
       equipped: false,
       description: 'Light armor with energy dispersal',
+      addedAt: new Date().toISOString(),
+      notes: '',
     },
   ],
 


### PR DESCRIPTION
## Summary
- track item `addedAt` timestamp and `notes` across inventory state
- add `handleAddItem` hook to append inventory entries with metadata
- expand inventory tests for metadata and item lifecycle

## Testing
- `npm run format` *(fails: src/components/DiceRoller.jsx: SyntaxError: Adjacent JSX elements must be wrapped in an enclosing tag)*
- `npm run format:check` *(fails: src/components/DiceRoller.jsx: SyntaxError: Adjacent JSX elements must be wrapped in an enclosing tag)*
- `npm run lint`
- `npm test` *(fails: Transform failed with error in src/components/DiceRoller.jsx)*
- `npm run test:e2e` *(fails: build failed in src/components/DiceRoller.jsx; WebKitWebDriver missing; hooks timed out)*
- `npm run build` *(fails: Transform failed with error in src/components/DiceRoller.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a023d05d308332a82959bffa9cbf52