### PR TITLE
feat: support inventory notes and timestamps

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,8 +78,14 @@ function App() {
     clearRollHistory,
   } = useDiceRoller(character, setCharacter, saveToHistoryRef);
 
-  const { totalArmor, equippedWeaponDamage, handleEquipItem, handleConsumeItem, handleDropItem } =
-    useInventory(character, setCharacter);
+  const {
+    totalArmor,
+    equippedWeaponDamage,
+    handleEquipItem,
+    handleConsumeItem,
+    handleDropItem,
+    handleUpdateNotes,
+  } = useInventory(character, setCharacter);
 
   // Auto-detect level up opportunity
   useEffect(() => {
@@ -281,6 +287,7 @@ function App() {
         handleEquipItem={handleEquipItem}
         handleConsumeItem={handleConsumeItem}
         handleDropItem={handleDropItem}
+        handleUpdateNotes={handleUpdateNotes}
         showExportModal={showExportModal}
         setShowExportModal={setShowExportModal}
         showEndSessionModal={showEndSessionModal}

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -8,6 +8,7 @@ import InventoryModal from './InventoryModal.jsx';
 import LastBreathModal from './LastBreathModal.jsx';
 import LevelUpModal from './LevelUpModal.jsx';
 import StatusModal from './StatusModal.jsx';
+import { inventoryItemType } from './common/inventoryItemPropTypes.js';
 
 const GameModals = ({
   character,
@@ -34,6 +35,7 @@ const GameModals = ({
   handleEquipItem,
   handleConsumeItem,
   handleDropItem,
+  handleUpdateNotes,
   showExportModal,
   setShowExportModal,
   showEndSessionModal,
@@ -85,6 +87,7 @@ const GameModals = ({
         onEquip={handleEquipItem}
         onConsume={handleConsumeItem}
         onDrop={handleDropItem}
+        onUpdateNotes={handleUpdateNotes}
         onClose={() => setShowInventoryModal(false)}
       />
     )}
@@ -122,10 +125,11 @@ GameModals.propTypes = {
   setShowLastBreathModal: PropTypes.func.isRequired,
   showInventoryModal: PropTypes.bool.isRequired,
   setShowInventoryModal: PropTypes.func.isRequired,
-  inventory: PropTypes.arrayOf(PropTypes.object).isRequired,
+  inventory: PropTypes.arrayOf(inventoryItemType).isRequired,
   handleEquipItem: PropTypes.func.isRequired,
   handleConsumeItem: PropTypes.func.isRequired,
   handleDropItem: PropTypes.func.isRequired,
+  handleUpdateNotes: PropTypes.func.isRequired,
   showExportModal: PropTypes.bool.isRequired,
   setShowExportModal: PropTypes.func.isRequired,
   showEndSessionModal: PropTypes.bool.isRequired,

--- a/src/components/GameModals.test.jsx
+++ b/src/components/GameModals.test.jsx
@@ -29,6 +29,7 @@ function Wrapper(props) {
       handleEquipItem={() => {}}
       handleConsumeItem={() => {}}
       handleDropItem={() => {}}
+      handleUpdateNotes={() => {}}
       {...props}
     />
   );
@@ -51,6 +52,7 @@ const baseProps = {
   setShowEndSessionModal: () => {},
   bondsModal: { isOpen: false, close: () => {} },
   saveToHistory: () => {},
+  handleUpdateNotes: () => {},
 };
 
 const renderModals = (props) =>

--- a/src/components/InventoryModal.jsx
+++ b/src/components/InventoryModal.jsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styles from './InventoryModal.module.css';
+import { inventoryItemType } from './common/inventoryItemPropTypes.js';
 
-const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
+const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onUpdateNotes, onClose }) => {
   return (
     <div className={styles.inventoryOverlay}>
       <div className={styles.inventoryModal}>
@@ -20,6 +21,19 @@ const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
                   {item.description && (
                     <div className={styles.inventoryItemDescription}>{item.description}</div>
                   )}
+                </div>
+                <div className={styles.inventoryItemMeta}>
+                  {item.addedAt && (
+                    <div className={styles.inventoryAddedAt}>
+                      Added {new Date(item.addedAt).toLocaleDateString()}
+                    </div>
+                  )}
+                  <textarea
+                    className={styles.inventoryNotesInput}
+                    placeholder="Notes"
+                    value={item.notes || ''}
+                    onChange={(e) => onUpdateNotes(item.id, e.target.value)}
+                  />
                 </div>
                 <div className={styles.inventoryItemActions}>
                   {'equipped' in item && (
@@ -51,10 +65,11 @@ const InventoryModal = ({ inventory, onEquip, onConsume, onDrop, onClose }) => {
 };
 
 InventoryModal.propTypes = {
-  inventory: PropTypes.arrayOf(PropTypes.object).isRequired,
+  inventory: PropTypes.arrayOf(inventoryItemType).isRequired,
   onEquip: PropTypes.func.isRequired,
   onConsume: PropTypes.func.isRequired,
   onDrop: PropTypes.func.isRequired,
+  onUpdateNotes: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 

--- a/src/components/InventoryModal.module.css
+++ b/src/components/InventoryModal.module.css
@@ -78,6 +78,27 @@
   gap: 6px;
 }
 
+.inventoryItemMeta {
+  margin-top: var(--space-sm);
+  color: var(--color-gray-400);
+  font-size: 0.8rem;
+}
+
+.inventoryAddedAt {
+  margin-bottom: var(--space-sm);
+}
+
+.inventoryNotesInput {
+  width: 100%;
+  margin-top: var(--space-sm);
+  background: var(--color-gray-800);
+  border: 1px solid var(--color-gray-700);
+  border-radius: 4px;
+  color: var(--color-white);
+  padding: 4px;
+  resize: vertical;
+}
+
 @media (max-width: 360px) {
   .inventoryItemActions {
     flex-direction: column;

--- a/src/components/InventoryModal.test.jsx
+++ b/src/components/InventoryModal.test.jsx
@@ -16,6 +16,7 @@ describe('InventoryModal', () => {
       onEquip: () => {},
       onConsume: () => {},
       onDrop: () => {},
+      onUpdateNotes: () => {},
       onClose: () => {},
     };
     const { rerender } = render(<InventoryWrapper isOpen={false} {...props} />);
@@ -31,6 +32,7 @@ describe('InventoryModal', () => {
         onEquip={() => {}}
         onConsume={() => {}}
         onDrop={() => {}}
+        onUpdateNotes={() => {}}
         onClose={() => {}}
       />,
     );
@@ -51,6 +53,7 @@ describe('InventoryModal', () => {
         onEquip={() => {}}
         onConsume={() => {}}
         onDrop={() => {}}
+        onUpdateNotes={() => {}}
         onClose={() => {}}
       />,
     );
@@ -75,6 +78,7 @@ describe('InventoryModal', () => {
         onEquip={onEquip}
         onConsume={onConsume}
         onDrop={onDrop}
+        onUpdateNotes={() => {}}
         onClose={onClose}
       />,
     );
@@ -101,6 +105,7 @@ describe('InventoryModal', () => {
         onEquip={() => {}}
         onConsume={() => {}}
         onDrop={() => {}}
+        onUpdateNotes={() => {}}
         onClose={() => {}}
       />,
     );
@@ -128,11 +133,34 @@ describe('InventoryModal', () => {
         onEquip={() => {}}
         onConsume={() => {}}
         onDrop={() => {}}
+        onUpdateNotes={() => {}}
         onClose={() => {}}
       />,
     );
     const group = screen.getByText('Drop').parentElement;
     group.style.overflowX = 'auto';
     expect(group.scrollWidth).toBeLessThanOrEqual(group.clientWidth);
+  });
+
+  it('renders added date and edits notes', async () => {
+    const user = userEvent.setup();
+    const onUpdateNotes = vi.fn();
+    const addedAt = new Date('2024-01-01').toISOString();
+    const inventory = [{ id: 1, name: 'Sword', type: 'weapon', addedAt, notes: 'old' }];
+    render(
+      <InventoryModal
+        inventory={inventory}
+        onEquip={() => {}}
+        onConsume={() => {}}
+        onDrop={() => {}}
+        onUpdateNotes={onUpdateNotes}
+        onClose={() => {}}
+      />,
+    );
+    const dateString = new Date(addedAt).toLocaleDateString();
+    expect(screen.getByText(new RegExp(dateString))).toBeInTheDocument();
+    const textarea = screen.getByPlaceholderText('Notes');
+    await user.type(textarea, '!');
+    expect(onUpdateNotes).toHaveBeenLastCalledWith(1, 'old!');
   });
 });

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -11,6 +11,7 @@ import {
 import useInventory from '../hooks/useInventory';
 import { debilityTypes } from '../state/character';
 import styles from './InventoryPanel.module.css';
+import { inventoryItemType } from './common/inventoryItemPropTypes.js';
 
 const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveToHistory }) => {
   const { handleConsumeItem } = useInventory(character, setCharacter);
@@ -44,6 +45,12 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveT
                   {item.damage && `${item.damage} damage`}
                   {item.armor && `+${item.armor} armor`}
                   {item.quantity > 1 && ` x${item.quantity}`}
+                  {item.addedAt && (
+                    <div className={styles.itemAddedAt}>
+                      Added {new Date(item.addedAt).toLocaleDateString()}
+                    </div>
+                  )}
+                  {item.notes && <div className={styles.itemNotes}>{item.notes}</div>}
                 </div>
               </div>
               {item.type === 'consumable' && item.quantity > 0 && (
@@ -91,7 +98,10 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveT
 };
 
 InventoryPanel.propTypes = {
-  character: PropTypes.object.isRequired,
+  character: PropTypes.shape({
+    inventory: PropTypes.arrayOf(inventoryItemType).isRequired,
+    debilities: PropTypes.arrayOf(PropTypes.string).isRequired,
+  }).isRequired,
   setCharacter: PropTypes.func.isRequired,
   rollDie: PropTypes.func.isRequired,
   setRollResult: PropTypes.func.isRequired,

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -89,6 +89,16 @@
   color: var(--color-gray-400);
 }
 
+.itemNotes {
+  margin-top: var(--space-sm);
+  color: var(--color-gray-300);
+}
+
+.itemAddedAt {
+  margin-top: var(--space-sm);
+  color: var(--color-gray-500);
+}
+
 .useButton {
   background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
   border: none;

--- a/src/components/InventoryPanel.test.jsx
+++ b/src/components/InventoryPanel.test.jsx
@@ -69,6 +69,26 @@ describe('InventoryPanel', () => {
     expect(screen.getByText('A sharp blade')).toBeInTheDocument();
   });
 
+  it('displays notes and added date', () => {
+    const addedAt = new Date('2024-01-01').toISOString();
+    const character = {
+      inventory: [{ id: 1, name: 'Sword', notes: 'gift', addedAt }],
+      debilities: [],
+    };
+    render(
+      <InventoryPanel
+        character={character}
+        setCharacter={() => {}}
+        rollDie={() => 1}
+        setRollResult={() => {}}
+        saveToHistory={() => {}}
+      />,
+    );
+    expect(screen.getByText('gift')).toBeInTheDocument();
+    const dateString = new Date(addedAt).toLocaleDateString();
+    expect(screen.getByText(new RegExp(dateString))).toBeInTheDocument();
+  });
+
   it('undo restores consumed item', async () => {
     const user = userEvent.setup();
     function Wrapper() {

--- a/src/components/common/inventoryItemPropTypes.js
+++ b/src/components/common/inventoryItemPropTypes.js
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+
+export const inventoryItemType = PropTypes.shape({
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  quantity: PropTypes.number,
+  description: PropTypes.string,
+  equipped: PropTypes.bool,
+  damage: PropTypes.string,
+  armor: PropTypes.number,
+  addedAt: PropTypes.string,
+  notes: PropTypes.string,
+});
+
+export default inventoryItemType;

--- a/src/hooks/useInventory.js
+++ b/src/hooks/useInventory.js
@@ -58,11 +58,22 @@ export default function useInventory(character, setCharacter) {
     [setCharacter],
   );
 
+  const handleUpdateNotes = useCallback(
+    (id, notes) => {
+      setCharacter((prev) => ({
+        ...prev,
+        inventory: prev.inventory.map((item) => (item.id === id ? { ...item, notes } : item)),
+      }));
+    },
+    [setCharacter],
+  );
+
   return {
     totalArmor,
     equippedWeaponDamage,
     handleEquipItem,
     handleConsumeItem,
     handleDropItem,
+    handleUpdateNotes,
   };
 }

--- a/src/hooks/useInventory.test.jsx
+++ b/src/hooks/useInventory.test.jsx
@@ -111,4 +111,17 @@ describe('useInventory actions', () => {
     act(() => result.current.handleDropItem('rock'));
     expect(result.current.character.inventory).toEqual([{ id: 'coin' }]);
   });
+
+  it('updates item notes with handleUpdateNotes', () => {
+    const { result } = renderHook(() => {
+      const [character, setCharacter] = useState({
+        inventory: [{ id: 'rock', notes: '' }],
+      });
+      const inventory = useInventory(character, setCharacter);
+      return { ...inventory, character };
+    });
+
+    act(() => result.current.handleUpdateNotes('rock', 'A simple stone'));
+    expect(result.current.character.inventory[0].notes).toBe('A simple stone');
+  });
 });


### PR DESCRIPTION
## Summary
- show item added date and notes in inventory modal
- surface notes and added date in quick-view panel
- document inventory item shape with addedAt and notes

## Testing
- `npm run lint`
- `npm test` *(fails: Transform failed with 1 error: DiceRoller.jsx Expected ")" but found "onClick")*
- `npx vitest run src/components/InventoryModal.test.jsx src/components/InventoryPanel.test.jsx src/hooks/useInventory.test.jsx`
- `npm run format:check` *(fails: DiceRoller.jsx syntax error)*
- `npm run test:e2e` *(fails: DiceRoller.jsx syntax error, CannotFindBinaryPath)*
- `npm run build` *(fails: DiceRoller.jsx syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68a023d15b3c8332b6bd79ce4d98b643