### PR TITLE
feat: add AI-driven item creation modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -51,6 +51,7 @@ function App() {
   const [showDamageModal, setShowDamageModal] = useState(false);
   const [showLastBreathModal, setShowLastBreathModal] = useState(false);
   const [showInventoryModal, setShowInventoryModal] = useState(false);
+  const [showAddItemModal, setShowAddItemModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showEndSessionModal, setShowEndSessionModal] = useState(false);
   const [compactMode, setCompactMode] = useState(() => window.innerWidth < 768);
@@ -80,6 +81,17 @@ function App() {
 
   const { totalArmor, equippedWeaponDamage, handleEquipItem, handleConsumeItem, handleDropItem } =
     useInventory(character, setCharacter);
+
+  const handleAddItem = React.useCallback(
+    (item) => {
+      setCharacter((prev) => ({
+        ...prev,
+        inventory: [...prev.inventory, { id: Date.now().toString(), ...item }],
+      }));
+      saveToHistory('Inventory Change');
+    },
+    [setCharacter, saveToHistory],
+  );
 
   // Auto-detect level up opportunity
   useEffect(() => {
@@ -239,6 +251,7 @@ function App() {
               rollDie={rollDie}
               setRollResult={setRollResult}
               saveToHistory={saveToHistory}
+              setShowAddItemModal={setShowAddItemModal}
             />
           </div>
 
@@ -281,12 +294,15 @@ function App() {
         handleEquipItem={handleEquipItem}
         handleConsumeItem={handleConsumeItem}
         handleDropItem={handleDropItem}
+        handleAddItem={handleAddItem}
         showExportModal={showExportModal}
         setShowExportModal={setShowExportModal}
         showEndSessionModal={showEndSessionModal}
         setShowEndSessionModal={setShowEndSessionModal}
         bondsModal={bondsModal}
         saveToHistory={saveToHistory}
+        showAddItemModal={showAddItemModal}
+        setShowAddItemModal={setShowAddItemModal}
       />
       {PerformanceHud && (
         <Suspense fallback={null}>

--- a/src/components/AddItemModal.jsx
+++ b/src/components/AddItemModal.jsx
@@ -1,0 +1,119 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import styles from './AddItemModal.module.css';
+
+const itemTypes = ['gear', 'weapon', 'armor', 'consumable', 'magic', 'material'];
+
+const AddItemModal = ({ onAdd, onClose, generateOptions }) => {
+  const [name, setName] = useState('');
+  const [type, setType] = useState('gear');
+  const [flavor, setFlavor] = useState('');
+  const [effect, setEffect] = useState('');
+  const [options, setOptions] = useState([]);
+
+  const handleGenerate = async () => {
+    const generated = await generateOptions(name, type);
+    setOptions(generated);
+  };
+
+  const handleSelect = (opt) => {
+    setName(opt.name || '');
+    setType(opt.type || 'gear');
+    setFlavor(opt.flavor || '');
+    setEffect(opt.effect || '');
+  };
+
+  const handleSave = () => {
+    onAdd({ name, type, description: flavor, effect });
+    onClose();
+  };
+
+  const handleCopyPrompt = () => {
+    const prompt = `Create a ${type} item named ${name} with flavor text and effect.`;
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(prompt);
+    }
+  };
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.modal}>
+        <h2 className={styles.title}>Add Item</h2>
+        <label className={styles.label}>
+          Name
+          <input className={styles.input} value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <label className={styles.label}>
+          Type
+          <select className={styles.select} value={type} onChange={(e) => setType(e.target.value)}>
+            {itemTypes.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className={styles.actions}>
+          <button className={styles.button} onClick={handleGenerate}>
+            Generate with AI
+          </button>
+          <button className={styles.button} onClick={handleCopyPrompt}>
+            Copy Prompt
+          </button>
+        </div>
+        {options.length > 0 && (
+          <ul className={styles.options}>
+            {options.map((opt, idx) => (
+              <li key={idx}>
+                <button
+                  type="button"
+                  className={styles.optionButton}
+                  onClick={() => handleSelect(opt)}
+                >
+                  <div className={styles.optionFlavor}>{opt.flavor}</div>
+                  <div className={styles.optionEffect}>{opt.effect}</div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <label className={styles.label}>
+          Flavor Text
+          <textarea
+            className={styles.textarea}
+            value={flavor}
+            onChange={(e) => setFlavor(e.target.value)}
+          />
+        </label>
+        <label className={styles.label}>
+          Effect
+          <textarea
+            className={styles.textarea}
+            value={effect}
+            onChange={(e) => setEffect(e.target.value)}
+          />
+        </label>
+        <div className={styles.footer}>
+          <button className={styles.button} onClick={handleSave}>
+            Save
+          </button>
+          <button className={styles.button} onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+AddItemModal.propTypes = {
+  onAdd: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  generateOptions: PropTypes.func,
+};
+
+AddItemModal.defaultProps = {
+  generateOptions: async () => [],
+};
+
+export default AddItemModal;

--- a/src/components/AddItemModal.module.css
+++ b/src/components/AddItemModal.module.css
@@ -1,0 +1,102 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--hud-spacing);
+}
+
+.modal {
+  background: var(--color-bg-primary);
+  border: 2px solid var(--color-accent);
+  border-radius: 15px;
+  padding: var(--hud-spacing);
+  max-width: 500px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.title {
+  color: var(--color-accent);
+  text-align: center;
+  margin-bottom: var(--space-md);
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  color: var(--color-white);
+  margin-bottom: var(--space-sm);
+  gap: var(--space-xs);
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  padding: var(--space-xs);
+  border-radius: var(--hud-radius-sm);
+  border: 1px solid var(--panel-border);
+  background: var(--overlay-darker);
+  color: var(--color-white);
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: var(--space-md) 0;
+  flex-wrap: wrap;
+}
+
+.button {
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
+  border: none;
+  border-radius: var(--hud-radius-sm);
+  color: var(--color-white);
+  padding: 5px 10px;
+  cursor: pointer;
+  flex: 1 1 150px;
+}
+
+.options {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 var(--space-md) 0;
+}
+
+.optionButton {
+  width: 100%;
+  text-align: left;
+  background: var(--overlay-darker);
+  border: 1px solid var(--panel-border);
+  color: var(--color-white);
+  padding: var(--space-sm);
+  border-radius: var(--hud-radius-sm);
+  cursor: pointer;
+  margin-bottom: var(--space-sm);
+}
+
+.optionFlavor {
+  font-weight: bold;
+}
+
+.optionEffect {
+  font-size: 0.8rem;
+  color: var(--color-gray-400);
+}
+
+.footer {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: var(--space-md);
+}

--- a/src/components/AddItemModal.test.jsx
+++ b/src/components/AddItemModal.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import AddItemModal from './AddItemModal.jsx';
+
+describe('AddItemModal', () => {
+  it('generates options and saves selected item', async () => {
+    const user = userEvent.setup();
+    const generateOptions = vi
+      .fn()
+      .mockResolvedValue([
+        { name: 'Sword', type: 'weapon', flavor: 'A sharp blade', effect: '+1 dmg' },
+      ]);
+    const onAdd = vi.fn();
+    render(<AddItemModal onAdd={onAdd} onClose={() => {}} generateOptions={generateOptions} />);
+
+    await user.click(screen.getByText(/generate with ai/i));
+    expect(generateOptions).toHaveBeenCalled();
+
+    const option = await screen.findByText('A sharp blade');
+    await user.click(option);
+
+    expect(screen.getByLabelText(/name/i)).toHaveValue('Sword');
+
+    await user.click(screen.getByText(/save/i));
+    expect(onAdd).toHaveBeenCalledWith({
+      name: 'Sword',
+      type: 'weapon',
+      description: 'A sharp blade',
+      effect: '+1 dmg',
+    });
+  });
+
+  it('copies prompt', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn();
+    Object.defineProperty(global.navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    render(<AddItemModal onAdd={() => {}} onClose={() => {}} />);
+
+    await user.type(screen.getByLabelText(/name/i), 'Dagger');
+    await user.click(screen.getByText(/copy prompt/i));
+    expect(writeText).toHaveBeenCalled();
+  });
+});

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -5,6 +5,7 @@ import DamageModal from './DamageModal.jsx';
 import ExportModal from './ExportModal.jsx';
 import EndSessionModal from './EndSessionModal.jsx';
 import InventoryModal from './InventoryModal.jsx';
+import AddItemModal from './AddItemModal.jsx';
 import LastBreathModal from './LastBreathModal.jsx';
 import LevelUpModal from './LevelUpModal.jsx';
 import StatusModal from './StatusModal.jsx';
@@ -30,10 +31,13 @@ const GameModals = ({
   setShowLastBreathModal,
   showInventoryModal,
   setShowInventoryModal,
+  showAddItemModal,
+  setShowAddItemModal,
   inventory,
   handleEquipItem,
   handleConsumeItem,
   handleDropItem,
+  handleAddItem,
   showExportModal,
   setShowExportModal,
   showEndSessionModal,
@@ -89,6 +93,10 @@ const GameModals = ({
       />
     )}
 
+    {showAddItemModal && (
+      <AddItemModal onAdd={handleAddItem} onClose={() => setShowAddItemModal(false)} />
+    )}
+
     <BondsModal isOpen={bondsModal.isOpen} onClose={bondsModal.close} />
 
     <EndSessionModal
@@ -122,10 +130,13 @@ GameModals.propTypes = {
   setShowLastBreathModal: PropTypes.func.isRequired,
   showInventoryModal: PropTypes.bool.isRequired,
   setShowInventoryModal: PropTypes.func.isRequired,
+  showAddItemModal: PropTypes.bool.isRequired,
+  setShowAddItemModal: PropTypes.func.isRequired,
   inventory: PropTypes.arrayOf(PropTypes.object).isRequired,
   handleEquipItem: PropTypes.func.isRequired,
   handleConsumeItem: PropTypes.func.isRequired,
   handleDropItem: PropTypes.func.isRequired,
+  handleAddItem: PropTypes.func.isRequired,
   showExportModal: PropTypes.bool.isRequired,
   setShowExportModal: PropTypes.func.isRequired,
   showEndSessionModal: PropTypes.bool.isRequired,

--- a/src/components/GameModals.test.jsx
+++ b/src/components/GameModals.test.jsx
@@ -45,12 +45,15 @@ const baseProps = {
   setShowLastBreathModal: () => {},
   showInventoryModal: false,
   setShowInventoryModal: () => {},
+  showAddItemModal: false,
+  setShowAddItemModal: () => {},
   showExportModal: false,
   setShowExportModal: () => {},
   showEndSessionModal: false,
   setShowEndSessionModal: () => {},
   bondsModal: { isOpen: false, close: () => {} },
   saveToHistory: () => {},
+  handleAddItem: () => {},
 };
 
 const renderModals = (props) =>
@@ -144,6 +147,23 @@ describe('GameModals', () => {
       </CharacterProvider>,
     );
     expect(screen.queryByRole('heading', { name: /inventory/i })).not.toBeInTheDocument();
+  });
+
+  it('toggles AddItemModal with showAddItemModal', () => {
+    const { rerender } = renderModals();
+    expect(screen.queryByText(/add item/i)).not.toBeInTheDocument();
+    rerender(
+      <CharacterProvider>
+        <Wrapper {...baseProps} showAddItemModal />
+      </CharacterProvider>,
+    );
+    expect(screen.getByText(/add item/i)).toBeInTheDocument();
+    rerender(
+      <CharacterProvider>
+        <Wrapper {...baseProps} />
+      </CharacterProvider>,
+    );
+    expect(screen.queryByText(/add item/i)).not.toBeInTheDocument();
   });
 
   it('toggles BondsModal with bondsModal.isOpen', () => {

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -12,7 +12,14 @@ import useInventory from '../hooks/useInventory';
 import { debilityTypes } from '../state/character';
 import styles from './InventoryPanel.module.css';
 
-const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveToHistory }) => {
+const InventoryPanel = ({
+  character,
+  setCharacter,
+  rollDie,
+  setRollResult,
+  saveToHistory,
+  setShowAddItemModal,
+}) => {
   const { handleConsumeItem } = useInventory(character, setCharacter);
 
   return (
@@ -86,6 +93,11 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveT
           </div>
         </div>
       )}
+      <div className={styles.addItemSection}>
+        <button className={styles.addButton} onClick={() => setShowAddItemModal(true)}>
+          Add Item
+        </button>
+      </div>
     </div>
   );
 };
@@ -96,6 +108,7 @@ InventoryPanel.propTypes = {
   rollDie: PropTypes.func.isRequired,
   setRollResult: PropTypes.func.isRequired,
   saveToHistory: PropTypes.func.isRequired,
+  setShowAddItemModal: PropTypes.func.isRequired,
 };
 
 export default InventoryPanel;

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -125,3 +125,18 @@
   border-radius: 4px;
   font-size: 0.7rem;
 }
+
+.addItemSection {
+  margin-top: var(--space-md);
+  text-align: center;
+}
+
+.addButton {
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
+  border: none;
+  color: var(--color-white);
+  padding: 4px var(--space-sm);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}

--- a/src/components/InventoryPanel.test.jsx
+++ b/src/components/InventoryPanel.test.jsx
@@ -22,6 +22,7 @@ describe('InventoryPanel', () => {
         rollDie={rollDie}
         setRollResult={setRollResult}
         saveToHistory={() => {}}
+        setShowAddItemModal={() => {}}
       />,
     );
     const useBtn = screen.getByText('Use');
@@ -40,6 +41,7 @@ describe('InventoryPanel', () => {
         rollDie={() => 1}
         setRollResult={() => {}}
         saveToHistory={() => {}}
+        setShowAddItemModal={() => {}}
       />,
     );
     expect(screen.getByText(/Active Debilities:/i)).toBeInTheDocument();
@@ -64,6 +66,7 @@ describe('InventoryPanel', () => {
         rollDie={() => 1}
         setRollResult={() => {}}
         saveToHistory={() => {}}
+        setShowAddItemModal={() => {}}
       />,
     );
     expect(screen.getByText('A sharp blade')).toBeInTheDocument();
@@ -86,6 +89,7 @@ describe('InventoryPanel', () => {
             rollDie={() => 1}
             setRollResult={() => {}}
             saveToHistory={saveToHistory}
+            setShowAddItemModal={() => {}}
           />
           <button onClick={undoLastAction}>Undo</button>
         </>
@@ -96,5 +100,23 @@ describe('InventoryPanel', () => {
     expect(screen.queryByText('Potion')).not.toBeInTheDocument();
     await user.click(screen.getByText('Undo'));
     expect(screen.getByText('Potion')).toBeInTheDocument();
+  });
+
+  it('calls setShowAddItemModal when Add Item clicked', async () => {
+    const user = userEvent.setup();
+    const setShowAddItemModal = vi.fn();
+    const character = { inventory: [], debilities: [] };
+    render(
+      <InventoryPanel
+        character={character}
+        setCharacter={() => {}}
+        rollDie={() => 1}
+        setRollResult={() => {}}
+        saveToHistory={() => {}}
+        setShowAddItemModal={setShowAddItemModal}
+      />,
+    );
+    await user.click(screen.getByText(/add item/i));
+    expect(setShowAddItemModal).toHaveBeenCalledWith(true);
   });
 });


### PR DESCRIPTION
## Summary
- add AddItemModal for AI-generated inventory items with copyable prompts
- wire Add Item button and modal registration
- cover new modal with unit tests

## Testing
- `npm run lint`
- `npm test` *(fails: Transform failed in DiceRoller.jsx: Expected ")" but found "onClick")*
- `npm run format:check` *(fails: Adjacent JSX elements in DiceRoller.jsx)*
- `npm run test:e2e` *(fails: build error in DiceRoller.jsx; Cannot find WebKitWebDriver)*
- `npm run build` *(fails: Transform failed in DiceRoller.jsx: Expected ")" but found "onClick")*

------
https://chatgpt.com/codex/tasks/task_e_68a0249cb52883329ccfc5253fbf92f9