### PR TITLE
feat: allow adding inventory items

### DIFF
--- a/src/components/AddItemModal.jsx
+++ b/src/components/AddItemModal.jsx
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+
+const AddItemModal = ({ handleAddItem, onClose }) => {
+  const [newItem, setNewItem] = useState({ name: '', type: 'gear', quantity: 1 });
+
+  const saveItem = () => {
+    handleAddItem(newItem);
+    onClose();
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={newItem.name}
+        onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+        placeholder="Item name"
+      />
+      <button onClick={saveItem}>Save</button>
+      <button onClick={onClose}>Cancel</button>
+    </div>
+  );
+};
+
+AddItemModal.propTypes = {
+  handleAddItem: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default AddItemModal;

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import React, { useState } from 'react';
 import {
   FaBoxOpen,
   FaMeteor,
@@ -11,15 +12,20 @@ import {
 import useInventory from '../hooks/useInventory';
 import { debilityTypes } from '../state/character';
 import styles from './InventoryPanel.module.css';
+import AddItemModal from './AddItemModal.jsx';
 
 const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveToHistory }) => {
-  const { handleConsumeItem } = useInventory(character, setCharacter);
+  const { handleConsumeItem, handleAddItem } = useInventory(character, setCharacter);
+  const [showAddModal, setShowAddModal] = useState(false);
 
   return (
     <div className={styles.panel}>
       <h3 className={styles.title}>
         <FaBoxOpen className={styles.itemIcon} /> Equipment
       </h3>
+      <button className={styles.useButton} onClick={() => setShowAddModal(true)}>
+        Add Item
+      </button>
       <div className={styles.items}>
         {character.inventory.slice(0, 5).map((item) => (
           <div key={item.id} className={`${styles.item} ${item.equipped ? styles.equipped : ''}`}>
@@ -85,6 +91,15 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveT
             })}
           </div>
         </div>
+      )}
+      {showAddModal && (
+        <AddItemModal
+          handleAddItem={(item) => {
+            saveToHistory('Inventory Change');
+            handleAddItem(item);
+          }}
+          onClose={() => setShowAddModal(false)}
+        />
       )}
     </div>
   );

--- a/src/hooks/useInventory.js
+++ b/src/hooks/useInventory.js
@@ -14,6 +14,19 @@ export default function useInventory(character, setCharacter) {
     return weapon ? weapon.damage || 'd6' : 'd6';
   }, [character.inventory]);
 
+  const handleAddItem = useCallback(
+    (newItem) => {
+      const id = globalThis.crypto?.randomUUID
+        ? globalThis.crypto.randomUUID()
+        : Date.now().toString();
+      setCharacter((prev) => ({
+        ...prev,
+        inventory: [...prev.inventory, { ...newItem, id }],
+      }));
+    },
+    [setCharacter],
+  );
+
   const handleEquipItem = useCallback(
     (id) => {
       setCharacter((prev) => ({
@@ -61,6 +74,7 @@ export default function useInventory(character, setCharacter) {
   return {
     totalArmor,
     equippedWeaponDamage,
+    handleAddItem,
     handleEquipItem,
     handleConsumeItem,
     handleDropItem,

--- a/src/hooks/useInventory.test.jsx
+++ b/src/hooks/useInventory.test.jsx
@@ -111,4 +111,21 @@ describe('useInventory actions', () => {
     act(() => result.current.handleDropItem('rock'));
     expect(result.current.character.inventory).toEqual([{ id: 'coin' }]);
   });
+
+  it('adds items with handleAddItem and assigns unique id', () => {
+    const { result } = renderHook(() => {
+      const [character, setCharacter] = useState({ inventory: [] });
+      const inventory = useInventory(character, setCharacter);
+      return { ...inventory, character };
+    });
+
+    act(() => result.current.handleAddItem({ name: 'Potion' }));
+    expect(result.current.character.inventory).toHaveLength(1);
+    const firstId = result.current.character.inventory[0].id;
+    expect(firstId).toBeDefined();
+
+    act(() => result.current.handleAddItem({ name: 'Sword' }));
+    const ids = result.current.character.inventory.map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
 });


### PR DESCRIPTION
## Summary
- add `handleAddItem` to inventory hook for appending items
- use new helper from `InventoryPanel` and `AddItemModal`
- test inventory item addition

## Testing
- `npm run lint`
- `npm test` *(fails: Expected ")" but found "onClick" in DiceRoller.jsx)*
- `npm run format:check` *(fails: SyntaxError in DiceRoller.jsx)*
- `npm run test:e2e` *(fails: build error for DiceRoller.jsx and missing WebKitWebDriver)*
- `npm run build` *(fails: Expected ")" but found "onClick" in DiceRoller.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a0249d607083328f5a4e776d0c180a