### PR TITLE
build: set relative base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,6 +6,7 @@ const host = process.env.TAURI_DEV_HOST;
 // https://vite.dev/config/
 export default defineConfig(async () => ({
   plugins: [react()],
+  base: './',
   define: {
     'import.meta.env.VITE_BUILD_TIMESTAMP': JSON.stringify(new Date().toISOString()),
   },


### PR DESCRIPTION
## Summary
- set Vite base to "./" so built assets use relative paths

## Testing
- `npm run lint`
- `npm test` (fails: ReferenceError: inventoryItemType is not defined, TestingLibraryElementError ...)
- `npm run format:check`
- `npm run test:e2e` (fails: The system library `glib-2.0` required by crate `glib-sys` was not found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0290cd52483329b53eecabbf87765