### PR TITLE
feat: add Safari backdrop filter fallback

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -108,8 +108,9 @@ select:focus {
 
 /* Modal Backdrop Blur */
 .modal-backdrop {
-  backdrop-filter: blur(5px);
+  background-color: var(--color-modal-bg-dark);
   -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
 }
 
 /* Responsive Design */
@@ -148,7 +149,8 @@ select:focus {
 }
 
 .glass-panel {
-  background: var(--panel-bg);
+  background-color: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: var(--hud-radius);
   border: 1px solid var(--panel-border);


### PR DESCRIPTION
## Summary
- add `-webkit-backdrop-filter` to modal and panel overlays for Safari compatibility
- supply background-color fallback for browsers lacking backdrop-filter

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType is not defined)*
- `npm run format:check`
- `npm run test:e2e` *(fails: Missing glib-2.0 / gobject-2.0 system libraries; CannotFindBinaryPath)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02be6b60c8332af3d253fe67dc4ce