### PR TITLE
style: add webkit backdrop filter before standard

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -108,8 +108,8 @@ select:focus {
 
 /* Modal Backdrop Blur */
 .modal-backdrop {
-  backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
 }
 
 /* Responsive Design */
@@ -149,6 +149,7 @@ select:focus {
 
 .glass-panel {
   background: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: var(--hud-radius);
   border: 1px solid var(--panel-border);

--- a/src/components/AidInterfereModal.module.css
+++ b/src/components/AidInterfereModal.module.css
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
+  -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
   z-index: 1000;
   display: flex;

--- a/src/components/CharacterAvatar.module.css
+++ b/src/components/CharacterAvatar.module.css
@@ -1,5 +1,6 @@
 .avatarContainer {
   background: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);

--- a/src/components/CharacterHUD/Portrait.module.css
+++ b/src/components/CharacterHUD/Portrait.module.css
@@ -1,5 +1,6 @@
 .avatarContainer {
   background: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: 12px;
   padding: var(--hud-spacing);

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -1,5 +1,6 @@
 .panel {
   background: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -1,5 +1,6 @@
 .panel {
   background: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -1,5 +1,6 @@
 .panel {
   background: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);

--- a/src/components/LastBreathModal.module.css
+++ b/src/components/LastBreathModal.module.css
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
+  -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
   z-index: 1000;
   display: flex;

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.9);
+  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   z-index: 1000;
   display: flex;

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
+  -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
   z-index: 1000;
   display: flex;

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -1,5 +1,6 @@
 .panel {
   background: var(--panel-bg);
+  -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);
@@ -95,6 +96,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
+  -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
   z-index: 1000;
   display: flex;


### PR DESCRIPTION
## Summary
- ensure all style blocks use -webkit-backdrop-filter before backdrop-filter for better browser compatibility

## Testing
- `npm run lint` *(fails: 1 warning)*
- `npm test` *(fails: ReferenceError and failing tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system libraries and WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02be8a0088332b46d773aad41a34d