### PR TITLE
perf: use transform for move expansion

### DIFF
--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -240,6 +240,7 @@
   margin-left: var(--space-md);
   font-size: var(--font-size-sm);
   overflow: hidden;
+  transform-origin: top;
   animation: expandSection 0.3s ease forwards;
 }
 
@@ -255,11 +256,11 @@
 
 @keyframes expandSection {
   from {
-    max-height: 0;
+    transform: scaleY(0);
     opacity: 0;
   }
   to {
-    max-height: 1000px;
+    transform: scaleY(1);
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary
- animate move expansion with transform-based keyframes to avoid max-height layout thrashing

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType is not defined, etc.)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing WebKitWebDriver / glib libs)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a02bea33dc8332aaf6d69a459a71aa