### PR TITLE
fix: add charset to html content type

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -33,6 +33,9 @@ export default defineConfig(async () => ({
           port: 1421,
         }
       : undefined,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+    },
     watch: {
       // 3. tell Vite to ignore watching `src-tauri`
       ignored: ['**/src-tauri/**'],


### PR DESCRIPTION
## Summary
- ensure dev server serves HTML with an explicit UTF-8 charset header

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType is not defined; element text not found; undefined handler; assertion mismatch)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib/gobject/gio system libraries; WebKitWebDriver not found; hook timeout)*
- `npm run build`
- `curl -I http://localhost:1420/`


------
https://chatgpt.com/codex/tasks/task_e_68a0a8766c8c8332beac82df8306429f