### PR TITLE
fix: add frame ancestors to CSP

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'"
+      "csp": "default-src 'self'; script-src 'self'; frame-ancestors 'self'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- include `frame-ancestors 'self'` directive in Tauri CSP

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType not defined, missing elements, etc.)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib-2.0/gobject-2.0/gio-2.0 system libraries and WebKitWebDriver)*
- `npm run build`
- served `dist/index.html` with `curl -I http://localhost:8081` to confirm `Content-Security-Policy` header

------
https://chatgpt.com/codex/tasks/task_e_68a0a87a08648332b6eb869840884b15