### PR TITLE
fix: add cache-control headers for dev server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -37,5 +37,15 @@ export default defineConfig(async () => ({
       // 3. tell Vite to ignore watching `src-tauri`
       ignored: ['**/src-tauri/**'],
     },
+    headers: {
+      'Cache-Control': 'no-store',
+      Expires: '0',
+    },
+  },
+  preview: {
+    headers: {
+      'Cache-Control': 'no-store',
+      Expires: '0',
+    },
   },
 }));


### PR DESCRIPTION
## Summary
- disable caching on dev/preview servers by adding `Cache-Control: no-store`
- override `Expires` header to prevent cached responses

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check`
- `npm run test:e2e` *(fails: failed to run custom build command for `glib-sys v0.18.1`)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a87c8a1c833298643fbc28630c11