### PR TITLE
feat: add X-Frame-Options header

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use directories::ProjectDirs;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
+use tauri::http::header::HeaderValue;
 
 fn resolve_app_path(path: &str) -> Result<PathBuf, String> {
     let relative = Path::new(path);
@@ -71,6 +72,11 @@ pub fn run() -> Result<(), tauri::Error> {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![write_file, read_file, get_os])
+        .on_web_resource_request(|_, response| {
+            response
+                .headers_mut()
+                .insert("X-Frame-Options", HeaderValue::from_static("DENY"));
+        })
         .run(tauri::generate_context!())?;
     Ok(())
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,6 +26,9 @@ export default defineConfig(async () => ({
     port: 1420,
     strictPort: true,
     host: host || false,
+    headers: {
+      'X-Frame-Options': 'DENY',
+    },
     hmr: host
       ? {
           protocol: 'ws',
@@ -36,6 +39,11 @@ export default defineConfig(async () => ({
     watch: {
       // 3. tell Vite to ignore watching `src-tauri`
       ignored: ['**/src-tauri/**'],
+    },
+  },
+  preview: {
+    headers: {
+      'X-Frame-Options': 'DENY',
     },
   },
 }));


### PR DESCRIPTION
## Summary
- inject `X-Frame-Options: DENY` on all Tauri web resource responses
- serve `X-Frame-Options: DENY` from Vite dev and preview servers

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError: inventoryItemType is not defined)*
- `npm run format:check`
- `npm run test:e2e` *(fails: system library `glib-2.0` not found)*
- `npm run build`
- `curl -I http://localhost:1420`

------
https://chatgpt.com/codex/tasks/task_e_68a0a87b07bc8332bfd4cb8fd97eeb4f