### PR TITLE
feat(styles): add grid layout areas for sections

### DIFF
--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -76,6 +76,32 @@
   display: grid;
   gap: var(--space-md);
   margin-bottom: var(--space-md);
+  grid-template-areas:
+    'hud'
+    'stats'
+    'dice'
+    'inventory'
+    'notes';
+}
+
+.hud {
+  grid-area: hud;
+}
+
+.stats {
+  grid-area: stats;
+}
+
+.dice {
+  grid-area: dice;
+}
+
+.inventory {
+  grid-area: inventory;
+}
+
+.notes {
+  grid-area: notes;
 }
 
 .undoButton {


### PR DESCRIPTION
## Summary
- define CSS grid template areas for HUD, stats, dice, inventory and notes
- assign matching grid-area styles to section classes

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType is not defined, missing elements, etc.)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib-2.0 and WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a9520bac833293b72728afbe06e9