### PR TITLE
feat: improve dice roll accessibility

### DIFF
--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -137,6 +137,7 @@ const DiceRoller = ({
         <div
           className={`${styles.resultBox} ${animate ? styles.pop : ''}`}
           onAnimationEnd={() => setAnimate(false)}
+          aria-live="polite"
         >
           {isRolling ? 'rolling…' : rollResult}
         </div>

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -93,6 +93,7 @@
   text-align: center;
   font-weight: bold;
   min-height: 40px;
+  min-width: 80px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -60,6 +60,23 @@ describe('DiceRoller', () => {
     expect(screen.getByText(/2d6: 7 = 7/)).toBeInTheDocument();
   });
 
+  it('announces results politely', () => {
+    const rollDice = vi.fn();
+    render(
+      <DiceRoller
+        character={minimalCharacter}
+        rollDice={rollDice}
+        equippedWeaponDamage="d8"
+        rollResult="d20: 9 = 9"
+        rollHistory={rollHistory}
+        rollModal={{ isOpen: false, close: vi.fn() }}
+        rollModalData={{}}
+        aidModal={{ isOpen: false, onConfirm: vi.fn(), onCancel: vi.fn() }}
+      />,
+    );
+    expect(screen.getByText('d20: 9 = 9')).toHaveAttribute('aria-live', 'polite');
+  });
+
   it('updates displayed roll result when prop changes', () => {
     const rollDice = vi.fn();
     const { rerender } = render(


### PR DESCRIPTION
## Summary
- announce dice results via `aria-live="polite"`
- prevent layout shift by reserving space for results
- cover polite announcement with test

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType not defined, AddItemModal failures, GameModals hook undefined)*
- `npm run format:check`
- `npm run test:e2e` *(fails: hook timed out, missing system libraries)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a953b2a88332a5b0b401959094b0