### PR TITLE
fix: improve session notes panel height

### DIFF
--- a/docs/hud-theme.md
+++ b/docs/hud-theme.md
@@ -17,6 +17,7 @@ radius and animation speeds consistent across components. These tokens live in
 | `--font-body`           | Typeface used for body text                    | `'Inter', sans-serif`      | `'Times New Roman', serif` | `'Verdana', sans-serif`      |
 | `--space-sm`            | General small spacing                          | `0.5rem`                   | `0.5rem`                   | `0.75rem`                    |
 | `--space-md`            | General medium spacing                         | `1rem`                     | `1rem`                     | `1.5rem`                     |
+| `--space-lg`            | General large spacing                          | `1.5rem`                   | `1.5rem`                   | `2.25rem`                    |
 
 Use these tokens within HUD components to guarantee visual consistency:
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,6 +67,7 @@ function App() {
   const [levelUpState, setLevelUpState] = useState(getDefaultLevelUpState);
 
   const saveToHistoryRef = useRef(() => {});
+  const headerRef = useRef(null);
   const {
     rollResult,
     setRollResult,
@@ -123,6 +124,20 @@ function App() {
     }
   }, [sessionNotes]);
 
+  useEffect(() => {
+    const updateHeaderHeight = () => {
+      if (headerRef.current) {
+        document.documentElement.style.setProperty(
+          '--header-height',
+          `${headerRef.current.offsetHeight}px`,
+        );
+      }
+    };
+    updateHeaderHeight();
+    window.addEventListener('resize', updateHeaderHeight);
+    return () => window.removeEventListener('resize', updateHeaderHeight);
+  }, []);
+
   const { saveToHistory, undoLastAction } = useUndo(character, setCharacter, setRollResult);
   saveToHistoryRef.current = saveToHistory;
 
@@ -141,7 +156,7 @@ function App() {
     <div className={`${styles.container} ${getActiveVisualEffects()}`}>
       <div className={styles.innerContainer}>
         {/* Header */}
-        <div className={styles.header} style={{ background: getHeaderColor() }}>
+        <div ref={headerRef} className={styles.header} style={{ background: getHeaderColor() }}>
           <div className={styles.headerTop}>
             <CharacterSwitcher />
             <div>

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -79,7 +79,8 @@
 }
 
 .panelExpanded {
-  max-height: 1000px;
+  max-height: calc(100vh - var(--header-height) - 2 * var(--space-lg));
+  overflow: auto;
   opacity: 1;
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -14,6 +14,9 @@
 
   --space-sm: 0.5rem;
   --space-md: 1rem;
+  --space-lg: 1.5rem;
+
+  --header-height: 0px;
 
   /* HUD layout tokens */
   --hud-radius: 0.75rem;
@@ -139,6 +142,7 @@
   --font-body: 'Times New Roman', serif;
   --space-sm: 0.5rem;
   --space-md: 1rem;
+  --space-lg: 1.5rem;
 
   --color-bg-start: #f0f0f0;
   --color-bg-end: #dcdcdc;
@@ -258,6 +262,7 @@
   --font-body: 'Verdana', sans-serif;
   --space-sm: 0.75rem;
   --space-md: 1.5rem;
+  --space-lg: 2.25rem;
 
   --color-bg-start: #f2e9e4;
   --color-bg-end: #e4d2cc;


### PR DESCRIPTION
## Summary
- expand session notes panel to viewport height minus header spacing
- expose new spacing tokens and dynamic header height
- document large spacing token

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError inventoryItemType is not defined)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib/gobject system libraries and WebKitWebDriver)*
- `npm run build`
- `npm test src/components/SessionNotes.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a0a955bdf88332b13494201d5eade4