### PR TITLE
style: update grid layout breakpoints

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -113,17 +113,7 @@ select:focus {
 }
 
 /* Responsive Design */
-@media (max-width: 1024px) {
-  .grid {
-    grid-template-columns: 1fr 1fr !important;
-  }
-}
-
-@media (max-width: 768px) {
-  .grid {
-    grid-template-columns: 1fr !important;
-  }
-
+@media (max-width: 767px) {
   .header h1 {
     font-size: 1.8rem !important;
   }

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -74,8 +74,21 @@
 
 .grid {
   display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: var(--space-md);
   margin-bottom: var(--space-md);
+}
+
+@media (max-width: 1199px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .undoButton {


### PR DESCRIPTION
## Summary
- Set default grid to three columns and add responsive two- and one-column layouts
- Remove obsolete grid breakpoints from global styles

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType is not defined)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system library glib-2.0, hook timed out)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a9596e688332bfa3157b0ec2e1d6