### PR TITLE
feat: show full inventory with responsive grid

### DIFF
--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -13,6 +13,7 @@ import useInventory from '../hooks/useInventory';
 import { debilityTypes } from '../state/character';
 import styles from './InventoryPanel.module.css';
 import AddItemModal from './AddItemModal.jsx';
+import { inventoryItemType } from './common/inventoryItemPropTypes.js';
 
 const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveToHistory }) => {
   const { handleConsumeItem, handleAddItem } = useInventory(character, setCharacter);
@@ -26,62 +27,64 @@ const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveT
       <button className={styles.useButton} onClick={() => setShowAddModal(true)}>
         Add Item
       </button>
-      <div className={styles.items}>
-        {character.inventory.slice(0, 5).map((item) => (
-          <div key={item.id} className={`${styles.item} ${item.equipped ? styles.equipped : ''}`}>
-            <div className={styles.itemRow}>
-              <div className={styles.itemInfo}>
-                <div className={styles.itemName}>
-                  {item.type === 'weapon' && <FaMeteor className={styles.itemIcon} />}
-                  {item.type === 'magic' && <FaStar className={styles.itemIcon} />}
-                  {item.type === 'consumable' && <FaFlask className={styles.itemIcon} />}
-                  {item.type === 'armor' && <FaShield className={styles.itemIcon} />}
-                  {item.type === 'material' && <FaCube className={styles.itemIcon} />}
-                  {(!item.type || item.type === 'gear') && (
-                    <FaSatellite className={styles.itemIcon} />
-                  )}
-                  {item.name}
-                  {item.equipped && <span className={styles.equippedMark}>✓</span>}
-                  {item.description && (
-                    <div className={styles.itemDescription}>{item.description}</div>
-                  )}
+      <div className={styles.itemsContainer}>
+        <div className={styles.items}>
+          {character.inventory.map((item) => (
+            <div key={item.id} className={`${styles.item} ${item.equipped ? styles.equipped : ''}`}>
+              <div className={styles.itemRow}>
+                <div className={styles.itemInfo}>
+                  <div className={styles.itemName}>
+                    {item.type === 'weapon' && <FaMeteor className={styles.itemIcon} />}
+                    {item.type === 'magic' && <FaStar className={styles.itemIcon} />}
+                    {item.type === 'consumable' && <FaFlask className={styles.itemIcon} />}
+                    {item.type === 'armor' && <FaShield className={styles.itemIcon} />}
+                    {item.type === 'material' && <FaCube className={styles.itemIcon} />}
+                    {(!item.type || item.type === 'gear') && (
+                      <FaSatellite className={styles.itemIcon} />
+                    )}
+                    {item.name}
+                    {item.equipped && <span className={styles.equippedMark}>✓</span>}
+                    {item.description && (
+                      <div className={styles.itemDescription}>{item.description}</div>
+                    )}
+                  </div>
+                  <div className={styles.itemDetails}>
+                    {item.damage && `${item.damage} damage`}
+                    {item.armor && `+${item.armor} armor`}
+                    {item.quantity > 1 && ` x${item.quantity}`}
+                    {item.addedAt && (
+                      <div className={styles.itemAddedAt}>
+                        Added {new Date(item.addedAt).toLocaleDateString()}
+                      </div>
+                    )}
+                    {item.notes && <div className={styles.itemNotes}>{item.notes}</div>}
+                  </div>
                 </div>
-                <div className={styles.itemDetails}>
-                  {item.damage && `${item.damage} damage`}
-                  {item.armor && `+${item.armor} armor`}
-                  {item.quantity > 1 && ` x${item.quantity}`}
-                  {item.addedAt && (
-                    <div className={styles.itemAddedAt}>
-                      Added {new Date(item.addedAt).toLocaleDateString()}
-                    </div>
-                  )}
-                  {item.notes && <div className={styles.itemNotes}>{item.notes}</div>}
-                </div>
+                {item.type === 'consumable' && item.quantity > 0 && (
+                  <button
+                    className={styles.useButton}
+                    onClick={() => {
+                      saveToHistory('Inventory Change');
+                      if (item.name === 'Healing Potion') {
+                        const healing = rollDie(8);
+                        setRollResult(`Used ${item.name}: healed ${healing} HP!`);
+                        handleConsumeItem(item.id, (char) => ({
+                          ...char,
+                          hp: Math.min(char.maxHp, char.hp + healing),
+                        }));
+                      } else {
+                        handleConsumeItem(item.id);
+                      }
+                    }}
+                    aria-label={`Use ${item.name}`}
+                  >
+                    Use
+                  </button>
+                )}
               </div>
-              {item.type === 'consumable' && item.quantity > 0 && (
-                <button
-                  className={styles.useButton}
-                  onClick={() => {
-                    saveToHistory('Inventory Change');
-                    if (item.name === 'Healing Potion') {
-                      const healing = rollDie(8);
-                      setRollResult(`Used ${item.name}: healed ${healing} HP!`);
-                      handleConsumeItem(item.id, (char) => ({
-                        ...char,
-                        hp: Math.min(char.maxHp, char.hp + healing),
-                      }));
-                    } else {
-                      handleConsumeItem(item.id);
-                    }
-                  }}
-                  aria-label={`Use ${item.name}`}
-                >
-                  Use
-                </button>
-              )}
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
       {character.debilities.length > 0 && (
         <div className={styles.debilitiesSection}>

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -14,15 +14,32 @@
   font-size: 1.3rem;
 }
 
-.items {
-  max-height: 300px;
-  overflow-y: auto;
+.itemsContainer {
+  max-height: 40vh;
+  overflow: auto;
+}
+
+@media (max-width: 1199px) {
+  .itemsContainer {
+    max-height: 50vh;
+  }
 }
 
 @media (max-width: 767px) {
+  .itemsContainer {
+    max-height: 45vh;
+  }
+}
+
+.items {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-sm);
+}
+
+@media (min-width: 1200px) {
   .items {
-    max-height: 50vh;
-    overflow: auto;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 


### PR DESCRIPTION
## Summary
- render all inventory items and scroll within a responsive container
- display items in a single-column grid on small screens and two columns on large screens

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: Hook timed out, missing WebKitWebDriver)*
- `npm run build`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a0a95755248332b98063011e21a954