### PR TITLE
feat: improve focus outlines

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -71,6 +71,11 @@ button:active {
   transform: translateY(0px);
 }
 
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 button:disabled {
   transform: none !important;
   box-shadow: none !important;
@@ -101,9 +106,15 @@ button:disabled {
 input:focus,
 textarea:focus,
 select:focus {
-  outline: none;
   border-color: var(--color-accent) !important;
   box-shadow: 0 0 10px var(--glow-shadow);
+}
+
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* Modal Backdrop Blur */

--- a/src/components/AddItemModal.module.css
+++ b/src/components/AddItemModal.module.css
@@ -66,6 +66,11 @@
   flex: 1 1 150px;
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .options {
   list-style: none;
   padding: 0;

--- a/src/components/AidInterfereModal.module.css
+++ b/src/components/AidInterfereModal.module.css
@@ -73,3 +73,8 @@
   transition: all 0.3s ease;
   flex: 1 1 150px;
 }
+
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/src/components/BondsModal.module.css
+++ b/src/components/BondsModal.module.css
@@ -80,6 +80,11 @@
   flex: 1 1 150px;
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .resolveButton {
   background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
 }
@@ -108,4 +113,9 @@
 
 .closeButton {
   margin-top: var(--space-md);
+}
+
+.closeButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -89,6 +89,11 @@
   margin: var(--space-sm);
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .buttonRed {
   background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -54,6 +54,11 @@
   margin: var(--space-sm);
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .small {
   padding: var(--space-sm) 6px;
   margin: 2px;

--- a/src/components/EndSessionModal.module.css
+++ b/src/components/EndSessionModal.module.css
@@ -104,6 +104,11 @@
   flex: 1 1 150px;
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .cancelButton {
   background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }

--- a/src/components/InventoryPanel.module.css
+++ b/src/components/InventoryPanel.module.css
@@ -110,6 +110,11 @@
   font-size: 10px;
 }
 
+.useButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .debilitiesSection {
   margin-top: var(--space-md);
   padding-top: var(--hud-spacing-sm);

--- a/src/components/LastBreathModal.module.css
+++ b/src/components/LastBreathModal.module.css
@@ -52,3 +52,8 @@
   transition: var(--hud-transition);
   flex: 1 1 150px;
 }
+
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -59,6 +59,11 @@
   font-size: 18px;
 }
 
+.closeButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .content {
   padding: var(--hud-spacing);
 }
@@ -293,6 +298,11 @@
   transition: var(--hud-transition);
   font-size: 14px;
   flex: 1 1 150px;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .buttonRolled {

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -52,6 +52,11 @@
   border-radius: 8px;
 }
 
+.closeButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .body {
   padding: var(--hud-spacing);
   text-align: center;
@@ -97,4 +102,9 @@
   font-weight: bold;
   transition: var(--hud-transition);
   flex: 1 1 150px;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -57,6 +57,11 @@
   gap: 5px;
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .danger {
   background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -38,7 +38,15 @@
   --color-neutral: #6b7280;
   --color-neutral-dark: #374151;
   --color-neutral-rgb: 107, 114, 128;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #6b7280;
+  --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
   --color-gray-800: #1f2937;
+  --color-gray-900: #111827;
   --color-white: #ffffff;
 
   /* semantic tokens */
@@ -163,7 +171,15 @@
   --color-neutral: #6b7280;
   --color-neutral-dark: #4b5563;
   --color-neutral-rgb: 107, 114, 128;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #6b7280;
+  --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
   --color-gray-800: #4b5563;
+  --color-gray-900: #111827;
   --color-white: #ffffff;
 
   /* semantic tokens */
@@ -262,7 +278,15 @@
   --color-bg-start: #f2e9e4;
   --color-bg-end: #e4d2cc;
   --color-text: #2d2a26;
+  --color-gray-100: #f5f5f5;
+  --color-gray-200: #e5e5e5;
+  --color-gray-300: #d4d4d4;
+  --color-gray-400: #a3a3a3;
+  --color-gray-500: #737373;
+  --color-gray-600: #525252;
+  --color-gray-700: #404040;
   --color-gray-800: #4a4a4a;
+  --color-gray-900: #262626;
   --color-white: #ffffff;
 
   /* HUD layout tokens */
@@ -274,10 +298,10 @@
   --hud-transition: all 350ms ease-in-out;
   --hud-transition-slow: all 600ms ease-in-out;
 
-  --color-accent: #27a9a1;
-  --color-accent-dark: #1e827c;
-  --color-accent-darker: #155b58;
-  --color-accent-rgb: 39, 169, 161;
+  --color-accent: #1e827c;
+  --color-accent-dark: #155b58;
+  --color-accent-darker: #0d423e;
+  --color-accent-rgb: 30, 130, 124;
 
   --color-info: #d2666f;
   --color-info-dark: #a74e55;


### PR DESCRIPTION
## Summary
- add focus-visible outlines to buttons, inputs, and modal close icons
- define missing gray tokens and darken moebius accent for AA contrast

## Testing
- `npm run lint`
- `npm test` *(fails: inventoryItemType is not defined, missing driver errors)*
- `npm run format:check`
- `npm run test:e2e` *(fails: glib-2.0 not found, hook timeouts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0a952c4988332b3ace3ae5c1fd2e1