### PR TITLE
fix: merge duplicate headers in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -36,9 +36,6 @@ export default defineConfig(async () => ({
     port: 1420,
     strictPort: true,
     host: host || false,
-    headers: {
-      'X-Frame-Options': 'DENY',
-    },
     hmr: host
       ? {
           protocol: 'ws',
@@ -47,25 +44,20 @@ export default defineConfig(async () => ({
         }
       : undefined,
     headers: {
+      'X-Frame-Options': 'DENY',
       'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'no-store',
+      Expires: '0',
     },
     watch: {
       // 3. tell Vite to ignore watching `src-tauri`
       ignored: ['**/src-tauri/**'],
     },
-    headers: {
-      'Cache-Control': 'no-store',
-      Expires: '0',
-    },
   },
   preview: {
     headers: {
       'Cache-Control': 'no-store',
       Expires: '0',
-    },
-  },
-  preview: {
-    headers: {
       'X-Frame-Options': 'DENY',
     },
   },


### PR DESCRIPTION
## Summary
- consolidate `server.headers` into a single object in Vite config
- merge duplicate `preview` headers to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: 10 failed | 109 passed | 2 skipped)*
- `npm run format:check`
- `npm run test:e2e` *(fails: build interrupted while compiling Rust dependencies)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0abb633cc8332a45863210d1d68cf