### PR TITLE
fix: configure X-Frame-Options via Tauri config

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,6 @@
 use directories::ProjectDirs;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use tauri::http::header::HeaderValue;
 
 fn resolve_app_path(path: &str) -> Result<PathBuf, String> {
     let relative = Path::new(path);
@@ -72,11 +71,6 @@ pub fn run() -> Result<(), tauri::Error> {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![write_file, read_file, get_os])
-        .on_web_resource_request(|_, response| {
-            response
-                .headers_mut()
-                .insert("X-Frame-Options", HeaderValue::from_static("DENY"));
-        })
         .run(tauri::generate_context!())?;
     Ok(())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,10 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; frame-ancestors 'self'"
+      "csp": "default-src 'self'; script-src 'self'; frame-ancestors 'self'",
+      "headers": {
+        "X-Frame-Options": "DENY"
+      }
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- remove deprecated on_web_resource_request hook
- add X-Frame-Options header in tauri config

## Testing
- `npm run lint`
- `npm test` (fails: 8 failed | 37 passed)
- `npm run format:check`
- `npm run test:e2e` (fails: schema invalid / missing driver)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bb83aae0833296fb7d989a75cc1e