### PR TITLE
refactor: remove deprecated web resource request hook

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,6 @@
 use directories::ProjectDirs;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use tauri::http::header::HeaderValue;
 use tauri::webview::WebviewWindowBuilder;
 
 fn resolve_app_path(path: &str) -> Result<PathBuf, String> {
@@ -78,12 +77,6 @@ pub fn run() -> Result<(), tauri::Error> {
                 app,
                 app.config().app.windows.get(0).unwrap(),
             )?
-            .on_web_resource_request(|_, response| {
-                response.headers_mut().insert(
-                    "X-Frame-Options",
-                    HeaderValue::from_static("DENY"),
-                );
-            })
             .build()?;
             Ok(())
         })


### PR DESCRIPTION
## Summary
- remove deprecated web resource request hook
- rely on Tauri configuration for security headers

## Testing
- `npm run lint`
- `npm test` *(fails: multiple test failures)*
- `npm run format:check`
- `npm run test:e2e` *(fails: invalid tauri.conf.json, hook timeout)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0bded66808332a69ab03830bdac99