### PR TITLE
chore: configure security headers

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,9 +19,12 @@
     ],
     "security": {
       "csp": "default-src 'self'; script-src 'self'; frame-ancestors 'self'",
-      "headers": {
-        "X-Frame-Options": "DENY"
-      }
+      "headers": [
+        {
+          "source": "**/*",
+          "headers": [{ "name": "X-Frame-Options", "value": "DENY" }]
+        }
+      ]
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- replace security headers config with array of rules

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test` *(fails: ReferenceError: Cannot access 'saveToHistory' before initialization and 24 more failing tests)*
- `npm run test:e2e` *(fails: Additional properties are not allowed ('headers' was unexpected); CannotFindBinaryPath)*
- `npm run build`
- `npm run tauri dev` *(fails: Additional properties are not allowed ('headers' was unexpected))*

------
https://chatgpt.com/codex/tasks/task_e_68a0c0d5fd74833294371b5e4b6f9061