### PR TITLE
refactor: omit extensions in module imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,11 @@ export default [
       react: {
         version: 'detect',
       },
+      'import/resolver': {
+        node: {
+          extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        },
+      },
     },
     rules: {
       ...reactHooksPlugin.configs['recommended-latest'].rules,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,32 +9,32 @@ import {
   FaArrowRotateLeft,
   FaFlagCheckered,
 } from 'react-icons/fa6';
-import CharacterStats from './components/CharacterStats.jsx';
-import DiceRoller from './components/DiceRoller.jsx';
-import GameModals from './components/GameModals.jsx';
-import InventoryPanel from './components/InventoryPanel.jsx';
-import SessionNotes from './components/SessionNotes.jsx';
-import CharacterHUD from './components/CharacterHUD/CharacterHUD.jsx';
-import Settings from './components/Settings.jsx';
-import CharacterSwitcher from './components/CharacterSwitcher.jsx';
-import AppVersion from './components/AppVersion.tsx';
-import DiagnosticOverlay from './components/DiagnosticOverlay.jsx';
-import Button from './components/common/Button.jsx';
-import ButtonGroup from './components/common/ButtonGroup.jsx';
+import CharacterStats from './components/CharacterStats';
+import DiceRoller from './components/DiceRoller';
+import GameModals from './components/GameModals';
+import InventoryPanel from './components/InventoryPanel';
+import SessionNotes from './components/SessionNotes';
+import CharacterHUD from './components/CharacterHUD/CharacterHUD';
+import Settings from './components/Settings';
+import CharacterSwitcher from './components/CharacterSwitcher';
+import AppVersion from './components/AppVersion';
+import DiagnosticOverlay from './components/DiagnosticOverlay';
+import Button from './components/common/Button';
+import ButtonGroup from './components/common/ButtonGroup';
 import useDiceRoller from './hooks/useDiceRoller';
 import useInventory from './hooks/useInventory';
 import useModal from './hooks/useModal.js';
 import useStatusEffects from './hooks/useStatusEffects.js';
 import useUndo from './hooks/useUndo.js';
 import { statusEffectTypes, debilityTypes, RULEBOOK } from './state/character';
-import { useCharacter } from './state/CharacterContext.jsx';
-import { useSettings } from './state/SettingsContext.jsx';
+import { useCharacter } from './state/CharacterContext';
+import { useSettings } from './state/SettingsContext';
 import styles from './styles/AppStyles.module.css';
 import safeLocalStorage from './utils/safeLocalStorage.js';
 
 const PerformanceHud =
   import.meta.env.DEV && import.meta.env.VITE_SHOW_PERFORMANCE_HUD === 'true'
-    ? lazy(() => import('./components/PerformanceHud.jsx'))
+    ? lazy(() => import('./components/PerformanceHud'))
     : null;
 
 function App() {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,12 +1,12 @@
 import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import App from './App.jsx';
-import Settings from './components/Settings.jsx';
+import App from './App';
+import Settings from './components/Settings';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
-import CharacterContext from './state/CharacterContext.jsx';
-import { SettingsProvider } from './state/SettingsContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
+import CharacterContext from './state/CharacterContext';
+import { SettingsProvider } from './state/SettingsContext';
+import { ThemeProvider } from './state/ThemeContext';
 import './styles/theme.css';
 
 vi.mock('@tauri-apps/api/app', () => ({

--- a/src/Header.test.jsx
+++ b/src/Header.test.jsx
@@ -1,11 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import App from './App.jsx';
+import App from './App';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
-import CharacterContext from './state/CharacterContext.jsx';
-import { SettingsProvider } from './state/SettingsContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
+import CharacterContext from './state/CharacterContext';
+import { SettingsProvider } from './state/SettingsContext';
+import { ThemeProvider } from './state/ThemeContext';
 import styles from './styles/AppStyles.module.css';
 
 vi.mock('@tauri-apps/api/app', () => ({

--- a/src/HudAccessibility.test.jsx
+++ b/src/HudAccessibility.test.jsx
@@ -2,11 +2,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import App from './App.jsx';
+import App from './App';
 import { INITIAL_CHARACTER_DATA } from './state/character.js';
-import CharacterContext from './state/CharacterContext.jsx';
-import { SettingsProvider } from './state/SettingsContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
+import CharacterContext from './state/CharacterContext';
+import { SettingsProvider } from './state/SettingsContext';
+import { ThemeProvider } from './state/ThemeContext';
 
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn().mockResolvedValue('1.0.0'),

--- a/src/components/AddItemModal.test.jsx
+++ b/src/components/AddItemModal.test.jsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import AddItemModal from './AddItemModal.jsx';
+import AddItemModal from './AddItemModal';
 
 describe('AddItemModal', () => {
   it('generates options and saves selected item', async () => {

--- a/src/components/AidInterfereModal.test.jsx
+++ b/src/components/AidInterfereModal.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import AidInterfereModal from './AidInterfereModal.jsx';
+import AidInterfereModal from './AidInterfereModal';
 
 describe('AidInterfereModal', () => {
   it('toggles visibility with isOpen', () => {

--- a/src/components/AppVersion.test.jsx
+++ b/src/components/AppVersion.test.jsx
@@ -2,7 +2,7 @@ import { getVersion } from '@tauri-apps/api/app';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import AppVersion from './AppVersion.tsx';
+import AppVersion from './AppVersion';
 
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn(),

--- a/src/components/BondsModal.jsx
+++ b/src/components/BondsModal.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { FaUserAstronaut } from 'react-icons/fa6';
-import { useCharacter } from '../state/CharacterContext.jsx';
+import { useCharacter } from '../state/CharacterContext';
 import styles from './BondsModal.module.css';
 import useModalTransition from './common/useModalTransition.js';
 

--- a/src/components/BondsModal.test.jsx
+++ b/src/components/BondsModal.test.jsx
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import CharacterContext from '../state/CharacterContext.jsx';
-import BondsModal from './BondsModal.jsx';
+import CharacterContext from '../state/CharacterContext';
+import BondsModal from './BondsModal';
 
 function renderWithCharacter(ui) {
   const Wrapper = ({ children }) => {

--- a/src/components/CharacterHUD/CastIndicator.jsx
+++ b/src/components/CharacterHUD/CastIndicator.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCharacter } from '../../state/CharacterContext.jsx';
+import { useCharacter } from '../../state/CharacterContext';
 import styles from './CastIndicator.module.css';
 
 export default function CastIndicator() {

--- a/src/components/CharacterHUD/CharacterHUD.jsx
+++ b/src/components/CharacterHUD/CharacterHUD.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
-import Nameplate from './Nameplate.jsx';
-import Portrait from './Portrait.jsx';
-import ResourceBars from './ResourceBars.jsx';
-import StatusTray from './StatusTray.jsx';
-import CastIndicator from './CastIndicator.jsx';
+import Nameplate from './Nameplate';
+import Portrait from './Portrait';
+import ResourceBars from './ResourceBars';
+import StatusTray from './StatusTray';
+import CastIndicator from './CastIndicator';
 import styles from './CharacterHUD.module.css';
-import { useCharacter } from '../../state/CharacterContext.jsx';
+import { useCharacter } from '../../state/CharacterContext';
 
 export default function CharacterHUD({ onMountChange = () => {} }) {
   const { character } = useCharacter();

--- a/src/components/CharacterHUD/CharacterHUD.test.jsx
+++ b/src/components/CharacterHUD/CharacterHUD.test.jsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
 import { statusEffectTypes } from '../../state/character.js';
-import CharacterContext from '../../state/CharacterContext.jsx';
-import CharacterHUD from './CharacterHUD.jsx';
+import CharacterContext from '../../state/CharacterContext';
+import CharacterHUD from './CharacterHUD';
 
 describe('CharacterHUD', () => {
   it('displays character data from context', () => {

--- a/src/components/CharacterHUD/Nameplate.jsx
+++ b/src/components/CharacterHUD/Nameplate.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCharacter } from '../../state/CharacterContext.jsx';
+import { useCharacter } from '../../state/CharacterContext';
 import styles from './Nameplate.module.css';
 
 export default function Nameplate() {

--- a/src/components/CharacterHUD/Portrait.jsx
+++ b/src/components/CharacterHUD/Portrait.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCharacter } from '../../state/CharacterContext.jsx';
+import { useCharacter } from '../../state/CharacterContext';
 import useStatusEffects from '../../hooks/useStatusEffects.js';
 import styles from './Portrait.module.css';
 

--- a/src/components/CharacterHUD/ResourceBars.test.jsx
+++ b/src/components/CharacterHUD/ResourceBars.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect } from 'vitest';
-import ResourceBars from './ResourceBars.jsx';
+import ResourceBars from './ResourceBars';
 
 describe('ResourceBars', () => {
   const defaultProps = {

--- a/src/components/CharacterHUD/StatusTray.jsx
+++ b/src/components/CharacterHUD/StatusTray.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCharacter } from '../../state/CharacterContext.jsx';
+import { useCharacter } from '../../state/CharacterContext';
 import { statusEffectTypes } from '../../state/character.js';
 import styles from './StatusTray.module.css';
 

--- a/src/components/CharacterHUD/index.test.jsx
+++ b/src/components/CharacterHUD/index.test.jsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect } from 'vitest';
-import CharacterHUD, { LOW_HP_THRESHOLD } from './index.jsx';
 import styles from './index.module.css';
+import CharacterHUD, { LOW_HP_THRESHOLD } from './index';
 
 describe('CharacterHUD', () => {
   it('applies casting and progress classes', () => {

--- a/src/components/CharacterStats.test.jsx
+++ b/src/components/CharacterStats.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import CharacterStats from './CharacterStats.jsx';
+import CharacterStats from './CharacterStats';
 
 function makeCharacter(overrides = {}) {
   return {

--- a/src/components/CharacterSwitcher.jsx
+++ b/src/components/CharacterSwitcher.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useCharacter } from '../state/CharacterContext.jsx';
+import { useCharacter } from '../state/CharacterContext';
 
 export default function CharacterSwitcher() {
   const ctx = useCharacter();

--- a/src/components/CharacterSwitcher.test.jsx
+++ b/src/components/CharacterSwitcher.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { CharacterProvider } from '../state/CharacterContext.jsx';
-import CharacterSwitcher from './CharacterSwitcher.jsx';
+import { CharacterProvider } from '../state/CharacterContext';
+import CharacterSwitcher from './CharacterSwitcher';
 
 describe('CharacterSwitcher', () => {
   it('renders nothing when character list is absent', () => {

--- a/src/components/DamageModal.jsx
+++ b/src/components/DamageModal.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { FaMeteor } from 'react-icons/fa6';
 import useInventory from '../hooks/useInventory';
-import { useCharacter } from '../state/CharacterContext.jsx';
+import { useCharacter } from '../state/CharacterContext';
 import styles from './DamageModal.module.css';
-import Button from './common/Button.jsx';
-import ButtonGroup from './common/ButtonGroup.jsx';
+import Button from './common/Button';
+import ButtonGroup from './common/ButtonGroup';
 import useModalTransition from './common/useModalTransition.js';
 
 export default function DamageModal({ isOpen, onClose, onLastBreath }) {

--- a/src/components/DamageModal.test.jsx
+++ b/src/components/DamageModal.test.jsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 import useUndo from '../hooks/useUndo.js';
-import CharacterContext from '../state/CharacterContext.jsx';
-import DamageModal from './DamageModal.jsx';
+import CharacterContext from '../state/CharacterContext';
+import DamageModal from './DamageModal';
 
 // Helper to simulate different viewport sizes
 window.resizeTo = (width, height) => {

--- a/src/components/DiagnosticOverlay.test.jsx
+++ b/src/components/DiagnosticOverlay.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import DiagnosticOverlay from './DiagnosticOverlay.jsx';
+import DiagnosticOverlay from './DiagnosticOverlay';
 
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn().mockResolvedValue('1.2.3'),

--- a/src/components/DiceRoller.jsx
+++ b/src/components/DiceRoller.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import styles from './DiceRoller.module.css';
-import RollModal from './RollModal.jsx';
-import AidInterfereModal from './AidInterfereModal.jsx';
+import RollModal from './RollModal';
+import AidInterfereModal from './AidInterfereModal';
 
 const DiceRoller = ({
   character,

--- a/src/components/DiceRoller.test.jsx
+++ b/src/components/DiceRoller.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import DiceRoller from './DiceRoller.jsx';
+import DiceRoller from './DiceRoller';
 
 const minimalCharacter = {
   stats: {

--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
 import { FaFlagCheckered } from 'react-icons/fa6';
-import { useCharacter } from '../state/CharacterContext.jsx';
+import { useCharacter } from '../state/CharacterContext';
 import styles from './EndSessionModal.module.css';
 import useModalTransition from './common/useModalTransition.js';
 

--- a/src/components/EndSessionModal.test.jsx
+++ b/src/components/EndSessionModal.test.jsx
@@ -3,8 +3,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import CharacterContext from '../state/CharacterContext.jsx';
-import EndSessionModal from './EndSessionModal.jsx';
+import CharacterContext from '../state/CharacterContext';
+import EndSessionModal from './EndSessionModal';
 
 function renderWithCharacter(ui, initialCharacter) {
   let currentCharacter;

--- a/src/components/ExportModal.jsx
+++ b/src/components/ExportModal.jsx
@@ -2,10 +2,10 @@ import { saveFile, loadFile } from '../utils/fileStorage.js';
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import { FaSatellite } from 'react-icons/fa6';
-import { useCharacter } from '../state/CharacterContext.jsx';
+import { useCharacter } from '../state/CharacterContext';
 import styles from './ExportModal.module.css';
-import Button from './common/Button.jsx';
-import ButtonGroup from './common/ButtonGroup.jsx';
+import Button from './common/Button';
+import ButtonGroup from './common/ButtonGroup';
 import useModalTransition from './common/useModalTransition.js';
 
 export default function ExportModal({ isOpen, onClose }) {

--- a/src/components/ExportModal.test.jsx
+++ b/src/components/ExportModal.test.jsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import CharacterContext from '../state/CharacterContext.jsx';
+import CharacterContext from '../state/CharacterContext';
 import { loadFile } from '../utils/fileStorage.js';
-import ExportModal from './ExportModal.jsx';
+import ExportModal from './ExportModal';
 
 vi.mock('../utils/fileStorage.js', () => ({
   saveFile: vi.fn(),

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import BondsModal from './BondsModal.jsx';
-import DamageModal from './DamageModal.jsx';
-import ExportModal from './ExportModal.jsx';
-import EndSessionModal from './EndSessionModal.jsx';
-import InventoryModal from './InventoryModal.jsx';
-import AddItemModal from './AddItemModal.jsx';
-import LastBreathModal from './LastBreathModal.jsx';
-import LevelUpModal from './LevelUpModal.jsx';
-import StatusModal from './StatusModal.jsx';
+import BondsModal from './BondsModal';
+import DamageModal from './DamageModal';
+import ExportModal from './ExportModal';
+import EndSessionModal from './EndSessionModal';
+import InventoryModal from './InventoryModal';
+import AddItemModal from './AddItemModal';
+import LastBreathModal from './LastBreathModal';
+import LevelUpModal from './LevelUpModal';
+import StatusModal from './StatusModal';
 import { inventoryItemType } from './common/inventoryItemPropTypes.js';
 
 const GameModals = ({

--- a/src/components/GameModals.test.jsx
+++ b/src/components/GameModals.test.jsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { statusEffectTypes, debilityTypes } from '../state/character.js';
-import { CharacterProvider, useCharacter } from '../state/CharacterContext.jsx';
-import GameModals from './GameModals.jsx';
+import { CharacterProvider, useCharacter } from '../state/CharacterContext';
+import GameModals from './GameModals';
 
 function Wrapper(props) {
   const { character, setCharacter } = useCharacter();

--- a/src/components/InventoryModal.test.jsx
+++ b/src/components/InventoryModal.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import InventoryModal from './InventoryModal.jsx';
+import InventoryModal from './InventoryModal';
 
 function InventoryWrapper({ isOpen, ...props }) {
   return isOpen ? <InventoryModal {...props} /> : null;

--- a/src/components/InventoryPanel.jsx
+++ b/src/components/InventoryPanel.jsx
@@ -12,7 +12,7 @@ import {
 import useInventory from '../hooks/useInventory';
 import { debilityTypes } from '../state/character';
 import styles from './InventoryPanel.module.css';
-import AddItemModal from './AddItemModal.jsx';
+import AddItemModal from './AddItemModal';
 import { inventoryItemType } from './common/inventoryItemPropTypes.js';
 
 const InventoryPanel = ({ character, setCharacter, rollDie, setRollResult, saveToHistory }) => {

--- a/src/components/InventoryPanel.test.jsx
+++ b/src/components/InventoryPanel.test.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 import useUndo from '../hooks/useUndo.js';
-import InventoryPanel from './InventoryPanel.jsx';
+import InventoryPanel from './InventoryPanel';
 
 describe('InventoryPanel', () => {
   it('uses consumable items and calls handlers', async () => {

--- a/src/components/LastBreathModal.test.jsx
+++ b/src/components/LastBreathModal.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import LastBreathModal from './LastBreathModal.jsx';
+import LastBreathModal from './LastBreathModal';
 
 describe('LastBreathModal', () => {
   it('rolls 2d6 and shows outcome', () => {

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import styles from './LevelUpModal.module.css';
 import { advancedMoves } from '../data/advancedMoves.js';
 import { scoreToMod } from '../utils/score.js';
-import Message from './Message.jsx';
+import Message from './Message';
 import useModalTransition from './common/useModalTransition.js';
 
 const LevelUpModal = ({

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -4,8 +4,8 @@ import React, { useState } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect, vi } from 'vitest';
 import { advancedMoves } from '../data/advancedMoves.js';
-import CharacterStats from './CharacterStats.jsx';
-import LevelUpModal from './LevelUpModal.jsx';
+import CharacterStats from './CharacterStats';
+import LevelUpModal from './LevelUpModal';
 import styles from './LevelUpModal.module.css';
 
 function LevelUpWrapper({ isOpen, ...props }) {

--- a/src/components/Message.test.jsx
+++ b/src/components/Message.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import Message from './Message.jsx';
+import Message from './Message';
 import styles from './Message.module.css';
 
 describe('Message', () => {

--- a/src/components/PerformanceHud.test.jsx
+++ b/src/components/PerformanceHud.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { vi } from 'vitest';
-import PerformanceHud from './PerformanceHud.jsx';
+import PerformanceHud from './PerformanceHud';
 
 vi.mock('../hooks/usePerformanceMetrics.js', () => ({
   default: () => ({

--- a/src/components/RollModal.test.jsx
+++ b/src/components/RollModal.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
-import RollModal from './RollModal.jsx';
+import RollModal from './RollModal';
 
 describe('RollModal', () => {
   it('toggles visibility with isOpen prop', () => {

--- a/src/components/SessionNotes.test.jsx
+++ b/src/components/SessionNotes.test.jsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { vi } from 'vitest';
 import { saveFile, loadFile } from '../utils/fileStorage.js';
-import SessionNotes from './SessionNotes.jsx';
+import SessionNotes from './SessionNotes';
 import styles from './SessionNotes.module.css';
 
 vi.mock('../utils/fileStorage.js', () => ({

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useTheme } from '../state/ThemeContext.jsx';
-import { useSettings } from '../state/SettingsContext.jsx';
+import { useTheme } from '../state/ThemeContext';
+import { useSettings } from '../state/SettingsContext';
 
 const Settings = () => {
   const { theme, setTheme, themes } = useTheme();

--- a/src/components/Settings.test.jsx
+++ b/src/components/Settings.test.jsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import SettingsContext from '../state/SettingsContext.jsx';
-import ThemeContext from '../state/ThemeContext.jsx';
-import Settings from './Settings.jsx';
+import SettingsContext from '../state/SettingsContext';
+import ThemeContext from '../state/ThemeContext';
+import Settings from './Settings';
 
 describe('Settings', () => {
   it('updates theme and auto XP on miss setting', async () => {

--- a/src/components/StatusModal.test.jsx
+++ b/src/components/StatusModal.test.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { vi } from 'vitest';
 import useStatusEffects from '../hooks/useStatusEffects.js';
 import useUndo from '../hooks/useUndo.js';
-import StatusModal from './StatusModal.jsx';
+import StatusModal from './StatusModal';
 
 function StatusWrapper({ isOpen, ...props }) {
   return isOpen ? <StatusModal {...props} /> : null;

--- a/src/components/StatusTray.test.jsx
+++ b/src/components/StatusTray.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { render, screen, act, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
-import StatusTray from './StatusTray.jsx';
+import StatusTray from './StatusTray';
 
 vi.useFakeTimers();
 

--- a/src/hooks/useDiceRoller.help.test.jsx
+++ b/src/hooks/useDiceRoller.help.test.jsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, describe, it, expect } from 'vitest';
-import { SettingsProvider } from '../state/SettingsContext.jsx';
+import { SettingsProvider } from '../state/SettingsContext';
 import useDiceRoller from './useDiceRoller.js';
 
 const aidModal = {

--- a/src/hooks/useDiceRoller.js
+++ b/src/hooks/useDiceRoller.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { debilityTypes } from '../state/character';
-import { useSettings } from '../state/SettingsContext.jsx';
+import { useSettings } from '../state/SettingsContext';
 import * as diceUtils from '../utils/dice.js';
 import safeLocalStorage from '../utils/safeLocalStorage.js';
 import useModal from './useModal';

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -1,7 +1,7 @@
 import { renderHook, act, render, screen, cleanup } from '@testing-library/react';
 import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
-import RollModal from '../components/RollModal.jsx';
-import { SettingsProvider } from '../state/SettingsContext.jsx';
+import RollModal from '../components/RollModal';
+import { SettingsProvider } from '../state/SettingsContext';
 import * as diceUtils from '../utils/dice.js';
 import useDiceRoller from './useDiceRoller.js';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
-import { CharacterProvider } from './state/CharacterContext.jsx';
-import { SettingsProvider } from './state/SettingsContext.jsx';
-import { ThemeProvider } from './state/ThemeContext.jsx';
+import App from './App';
+import { CharacterProvider } from './state/CharacterContext';
+import { SettingsProvider } from './state/SettingsContext';
+import { ThemeProvider } from './state/ThemeContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/state/CharacterContext.test.jsx
+++ b/src/state/CharacterContext.test.jsx
@@ -3,7 +3,7 @@ import { renderHook, act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { vi, afterEach } from 'vitest';
 import { INITIAL_CHARACTER_DATA } from './character.js';
-import { CharacterProvider, useCharacter } from './CharacterContext.jsx';
+import { CharacterProvider, useCharacter } from './CharacterContext';
 
 vi.mock('../utils/fileStorage.js', () => ({
   saveFile: vi.fn(() => Promise.resolve()),

--- a/src/state/SettingsContext.test.jsx
+++ b/src/state/SettingsContext.test.jsx
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
-import { SettingsProvider, useSettings } from './SettingsContext.jsx';
+import { SettingsProvider, useSettings } from './SettingsContext';
 
 describe('SettingsContext', () => {
   afterEach(() => {

--- a/src/state/ThemeContext.test.jsx
+++ b/src/state/ThemeContext.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { vi } from 'vitest';
 import safeLocalStorage from '../utils/safeLocalStorage.js';
 import { DEFAULT_THEME } from './theme.js';
-import { ThemeProvider, useTheme } from './ThemeContext.jsx';
+import { ThemeProvider, useTheme } from './ThemeContext';
 
 vi.mock('../utils/safeLocalStorage.js', () => ({
   default: {


### PR DESCRIPTION
## Summary
- drop `.tsx`/`.jsx` extensions from internal module imports
- configure ESLint resolver to handle extensionless module paths

## Testing
- `npm run lint`
- `npm test` (fails: ReferenceError: Cannot access 'saveToHistory' before initialization and other assertion errors)
- `npm run format:check`
- `npm run test:e2e` (fails: CannotFindBinaryPath for WebKitWebDriver)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1395f8d9883329bd82f9ce9ddef16