### PR TITLE
fix: remove invalid security header

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,10 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; frame-ancestors 'self'",
-      "headers": {
-        "X-Frame-Options": "DENY"
-      }
+      "csp": "default-src 'self'; script-src 'self'; frame-ancestors 'self'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- remove unsupported security headers from Tauri config

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError: Cannot access 'saveToHistory' before initialization)*
- `npm run format:check`
- `npm run test:e2e` *(fails: system library `glib-2.0` not found / WebKitWebDriver missing)*
- `npm run build`
- `npm run tauri dev` *(fails: gobject-2.0 and related libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a15b48f454833280f4f5a22e8010cf