### PR TITLE
fix: remove duplicate window creation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,6 @@
 use directories::ProjectDirs;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
-use tauri::webview::WebviewWindowBuilder;
 
 fn resolve_app_path(path: &str) -> Result<PathBuf, String> {
     let relative = Path::new(path);
@@ -80,11 +79,7 @@ pub fn run() -> Result<(), tauri::Error> {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![write_file, read_file, get_os])
-        .setup(|app| {
-            WebviewWindowBuilder::from_config(app, app.config().app.windows.get(0).unwrap())?
-                .build()?;
-            Ok(())
-        })
+        .setup(|_| Ok(()))
         .run(tauri::generate_context!())?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- remove redundant window creation during setup so Tauri only opens the configured window

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError and other failing tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: icon file not found / WebDriver connection issues)*
- `npm run build`
- `npm run tauri build` *(fails: missing icon file)*

------
https://chatgpt.com/codex/tasks/task_e_68a15dd870588332b17de8782b1423c5