### PR TITLE
fix(tauri): expand CSP for dev resources

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; frame-ancestors 'self'"
+      "csp": "default-src 'self' http://localhost:1420 https://fonts.googleapis.com https://fonts.gstatic.com; script-src 'self' http://localhost:1420; frame-ancestors 'self';"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- allow Google Fonts and local dev scripts in Tauri CSP

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError and failing tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing gobject-2.0 / glib-2.0 system libs)*
- `npm run build`
- `npm run tauri dev` *(fails: gobject/glib libs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a16241f40083329b6ffb79a3e160d9