### PR TITLE
fix(tauri): remove unused setup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,7 +79,6 @@ pub fn run() -> Result<(), tauri::Error> {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![write_file, read_file, get_os])
-        .setup(|_| Ok(()))
         .run(tauri::generate_context!())?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- avoid redundant Tauri setup so only the configured window is created

## Testing
- `npm run lint`
- `npm test` *(fails: ReferenceError in App tests and many others)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing `glib-2.0` system library and WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a166311cac8332b85376923511d725