### PR TITLE
UX Stage 01: move useUndo before callbacks

### DIFF
--- a/docs/undo.md
+++ b/docs/undo.md
@@ -1,0 +1,19 @@
+# Undo Hook Usage
+
+The `useUndo` hook manages the character's change history.
+
+## Usage
+
+Call `useUndo` before defining any callbacks that invoke `saveToHistory`.
+This ensures the `saveToHistory` function is available when callbacks are created.
+
+```jsx
+const { saveToHistory, undoLastAction } = useUndo(character, setCharacter, setRollResult);
+saveToHistoryRef.current = saveToHistory;
+```
+
+## Migration Notes
+
+If callbacks reference `saveToHistory`, reorder the `useUndo` call so it appears
+before those callbacks. This prevents `saveToHistory` from being `undefined` in
+closure scopes.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,9 @@ function App() {
     clearRollHistory,
   } = useDiceRoller(character, setCharacter, saveToHistoryRef);
 
+  const { saveToHistory, undoLastAction } = useUndo(character, setCharacter, setRollResult);
+  saveToHistoryRef.current = saveToHistory;
+
   const {
     totalArmor,
     equippedWeaponDamage,
@@ -137,9 +140,6 @@ function App() {
     window.addEventListener('resize', updateHeaderHeight);
     return () => window.removeEventListener('resize', updateHeaderHeight);
   }, []);
-
-  const { saveToHistory, undoLastAction } = useUndo(character, setCharacter, setRollResult);
-  saveToHistoryRef.current = saveToHistory;
 
   const {
     statusEffects,


### PR DESCRIPTION
## Summary
- order `useUndo` hook before callbacks using `saveToHistory`
- document `useUndo` usage and migration notes

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test` *(fails: Unable to find element text, missing deps, etc.)*
- `npm run test:e2e` *(fails: missing glib-2.0/gobject-2.0 libraries and driver binary)*
- `npm run build`

## Tokens
- n/a

## Feature Flags
- n/a

## Accessibility
- no change


------
https://chatgpt.com/codex/tasks/task_e_68a16d1cb4a483328dc7fa9fc080c3e1