### PR TITLE
UX Stage 01: remove dev server MIME override

### DIFF
--- a/docs/dev-server-mime-types.md
+++ b/docs/dev-server-mime-types.md
@@ -1,0 +1,11 @@
+# Dev Server MIME Types
+
+The development server now lets Vite determine `Content-Type` headers automatically. This ensures JavaScript modules are served with the correct MIME type and prevents browser warnings.
+
+## Migration Notes
+
+- Remove any manual `Content-Type` overrides from `vite.config.js`.
+
+## Tokens
+
+- None affected.

--- a/docs/ux-upgrade-plan.md
+++ b/docs/ux-upgrade-plan.md
@@ -1,0 +1,5 @@
+# UX Upgrade Plan
+
+Version: 0.1.0
+
+This plan outlines the staged approach for upgrading the project's UX. Each PR should reference this document and note the plan version.

--- a/vite.config.js
+++ b/vite.config.js
@@ -45,7 +45,6 @@ export default defineConfig(async () => ({
       : undefined,
     headers: {
       'X-Frame-Options': 'DENY',
-      'Content-Type': 'text/html; charset=utf-8',
       'Cache-Control': 'no-store',
       Expires: '0',
     },


### PR DESCRIPTION
## Scope
- Remove hardcoded `Content-Type` header so Vite automatically sets MIME types.

## Tokens
- None

## Feature Flags
- None

## Accessibility
- No user-facing impact; module scripts receive correct MIME types.

## Screenshots
- N/A

## Testing
- `npm run lint`
- `npm test` *(fails: see log)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system libraries / WebKit driver)*
- `npm run build`

Plan: docs/ux-upgrade-plan.md v0.1.0


------
https://chatgpt.com/codex/tasks/task_e_68a171c6232c83328a249e7a9f3dce42