### PR TITLE
UX Stage 01: guard compact mode on SSR

### DIFF
--- a/docs/compact-mode.md
+++ b/docs/compact-mode.md
@@ -1,0 +1,15 @@
+# Compact Mode
+
+Token: `screen.sm` = `768px`
+
+The `compactMode` state triggers a single-column layout for small screens. It now uses a safe initializer that falls back to `false` when `window` is unavailable, preventing server-side rendering errors.
+
+## Usage
+
+- `isCompactWidth` checks `window.innerWidth` against `screen.sm`.
+- `compactMode` uses `isCompactWidth` as its state initializer.
+
+## Migration Notes
+
+- Replace direct width checks with `isCompactWidth`.
+- No action required for consumers; behavior is backward compatible.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import { useCharacter } from './state/CharacterContext';
 import { useSettings } from './state/SettingsContext';
 import styles from './styles/AppStyles.module.css';
 import safeLocalStorage from './utils/safeLocalStorage.js';
+import { isCompactWidth } from './utils/responsive.js';
 
 const PerformanceHud =
   import.meta.env.DEV && import.meta.env.VITE_SHOW_PERFORMANCE_HUD === 'true'
@@ -54,7 +55,9 @@ function App() {
   const [showAddItemModal, setShowAddItemModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showEndSessionModal, setShowEndSessionModal] = useState(false);
-  const [compactMode, setCompactMode] = useState(() => window.innerWidth < 768);
+  // Default to false when `window` is unavailable (e.g., during SSR)
+  // to prevent reference errors.
+  const [compactMode, setCompactMode] = useState(isCompactWidth);
   const [hudMounted, setHudMounted] = useState(false);
 
   const getDefaultLevelUpState = () => ({

--- a/src/utils/responsive.js
+++ b/src/utils/responsive.js
@@ -1,0 +1,3 @@
+export const SCREEN_SM = 768; // token: screen.sm
+
+export const isCompactWidth = () => typeof window !== 'undefined' && window.innerWidth < SCREEN_SM;

--- a/src/utils/responsive.test.js
+++ b/src/utils/responsive.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { isCompactWidth, SCREEN_SM } from './responsive';
+
+describe('isCompactWidth', () => {
+  it('returns false when window is undefined', () => {
+    const originalWindow = globalThis.window;
+    vi.stubGlobal('window', undefined);
+    expect(isCompactWidth()).toBe(false);
+    vi.stubGlobal('window', originalWindow);
+  });
+
+  it('detects compact widths', () => {
+    const originalWindow = globalThis.window;
+    vi.stubGlobal('window', { innerWidth: SCREEN_SM - 1 });
+    expect(isCompactWidth()).toBe(true);
+    vi.stubGlobal('window', originalWindow);
+  });
+});


### PR DESCRIPTION
## Summary
- guard `compactMode` initialization against missing `window`
- add `isCompactWidth` utility and document `screen.sm` token

## Testing
- `npm run lint`
- `npm test` *(fails: Unable to find an element with the text: /generate with ai/i, etc.)*
- `npm run format:check`
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm run build`

---
Plan: [UX Upgrade Plan v0.1.0](docs/ux-upgrade-plan.md)
Tokens: `screen.sm`
Feature Flags: n/a
A11y: avoids SSR `window` reference errors
Screenshots: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a176ac1e08833299a985065d7733c0