### PR TITLE
UX Stage 01: Add CSP directives for Tauri

### DIFF
--- a/docs/csp.md
+++ b/docs/csp.md
@@ -1,0 +1,11 @@
+# Content Security Policy
+
+Version: 0.1.0
+
+This project uses a restrictive Content Security Policy for the Tauri backend. The policy allows only local assets by default and explicitly permits fonts from `https://fonts.gstatic.com`.
+
+## Migration Notes
+
+- Ensure any external fonts are served from `fonts.gstatic.com`.
+- Inline styles are allowed to simplify style injection during the UX upgrade.
+- No additional tokens were introduced in this change.

--- a/docs/ux-upgrade-plan.md
+++ b/docs/ux-upgrade-plan.md
@@ -1,9 +1,9 @@
-
 # UX Upgrade Plan
 
 Version: 0.1.0
 
 This plan outlines the staged approach for upgrading the project's UX. Each PR should reference this document and note the plan version.
+
 # UX Modernization Plan
 
 ## Current UI Gaps

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' http://localhost:1420 https://fonts.googleapis.com https://fonts.gstatic.com; script-src 'self' http://localhost:1420; frame-ancestors 'self';"
+      "csp": "default-src 'self' blob:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com;"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- enforce restrictive CSP for Tauri backend so only local assets and fonts from gstatic load
- document CSP policy and migration notes

## Testing
- `npm run lint`
- `npm test` *(fails: 13 failing tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing glib-2.0 and hook timeouts)*
- `npm run build`
- `npm run tauri build` *(fails: missing glib-2.0)*

## Tokens
- none

## Feature Flags
- none

## Accessibility Notes
- no user-facing changes

## Screenshots
- N/A

Reference: [UX Upgrade Plan v0.1.0](docs/ux-upgrade-plan.md)

------
https://chatgpt.com/codex/tasks/task_e_68a176ae34a08332981984a6d4c03b7f