### PR TITLE
UX Stage 01: add design tokens

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -9,9 +9,12 @@ without changing component markup.
 - `--fg`: foreground text color
 - `--bg`: background color
 - `--accent`: primary accent color
+- `--muted`: muted foreground color
+- `--card`: card background color
 - `--radius` / `--radius-sm`: standard and small border radius
 - `--spacing-sm` / `--spacing-md` / `--spacing-lg`: spacing scale
 - `--shadow`: base shadow
+- `--glow-shadow`: glow shadow
 
 ## Tailwind Mapping
 
@@ -20,9 +23,11 @@ Tailwind reads the variables and exposes them as semantic utilities:
 ```js
 // tailwind.config.js
 colors: {
-  fg: 'var(--fg)',
-  bg: 'var(--bg)',
-  accent: 'var(--accent)'
+  fg: 'hsl(var(--fg) / <alpha-value>)',
+  bg: 'hsl(var(--bg) / <alpha-value>)',
+  accent: 'hsl(var(--accent) / <alpha-value>)',
+  muted: 'hsl(var(--muted) / <alpha-value>)',
+  card: 'hsl(var(--card) / <alpha-value>)'
 },
 spacing: {
   sm: 'var(--spacing-sm)',
@@ -34,7 +39,8 @@ borderRadius: {
   sm: 'var(--radius-sm)'
 },
 boxShadow: {
-  DEFAULT: 'var(--shadow)'
+  DEFAULT: 'var(--shadow)',
+  glow: '0 0 8px var(--glow-shadow)'
 }
 ```
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,9 +4,11 @@ export default {
   theme: {
     extend: {
       colors: {
-        fg: 'var(--fg)',
-        bg: 'var(--bg)',
-        accent: 'var(--accent)',
+        fg: 'hsl(var(--fg) / <alpha-value>)',
+        bg: 'hsl(var(--bg) / <alpha-value>)',
+        accent: 'hsl(var(--accent) / <alpha-value>)',
+        muted: 'hsl(var(--muted) / <alpha-value>)',
+        card: 'hsl(var(--card) / <alpha-value>)',
       },
       spacing: {
         sm: 'var(--spacing-sm)',
@@ -19,6 +21,7 @@ export default {
       },
       boxShadow: {
         DEFAULT: 'var(--shadow)',
+        glow: '0 0 8px var(--glow-shadow)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend Tailwind colors with fg/bg/accent/muted/card tokens
- add glow box shadow token
- document new color and shadow tokens

## Testing
- `npm run lint` *(fails: import order warning)*
- `npm test` *(fails: 16 failing tests)*
- `npm run format:check` *(fails: code style issues in .github/pull_request_template.md)*
- `npm run test:e2e` *(fails: system library `glib-2.0` missing, cannot find driver path)*
- `npm run build`

## Plan
- References [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) version 0.2.0

------
https://chatgpt.com/codex/tasks/task_e_68a1838397ec8332947e1882377c6732