### PR TITLE
UX Stage 02: move dev primitives preview to components

### DIFF
--- a/src/components/dev/DevPrimitivesPreview.tsx
+++ b/src/components/dev/DevPrimitivesPreview.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Dialog, Tooltip, DropdownMenu, Separator, Slider } from '../components/ui/primitives.js';
+import { Dialog, Tooltip, DropdownMenu, Separator, Slider } from '../ui/primitives';
 
-export default function DevComponents() {
-  const [open, setOpen] = React.useState(false);
+export default function DevPrimitivesPreview() {
+  const [open, setOpen] = React.useState<boolean>(false);
 
   return (
     <div className="min-h-screen bg-bg p-md text-fg space-y-md">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import DevPrimitivesPreview from './components/dev/DevPrimitivesPreview';
 import ErrorBoundary from './components/ErrorBoundary';
-import DevComponents from './dev/DevComponents';
 import { CharacterProvider } from './state/CharacterContext';
 import { SettingsProvider } from './state/SettingsContext';
 import { ThemeProvider } from './state/ThemeContext';
@@ -17,7 +17,7 @@ if (import.meta.env.DEV && window.location.pathname === '/dev/components') {
   ReactDOM.createRoot(rootElement).render(
     <React.StrictMode>
       <ThemeProvider>
-        <DevComponents />
+        <DevPrimitivesPreview />
       </ThemeProvider>
     </React.StrictMode>,
   );


### PR DESCRIPTION
## Summary
- move DevComponents into `src/components/dev` and convert to TypeScript
- update main entry to load new DevPrimitivesPreview

## Testing
- `npm run lint` *(fails: 0 errors, 2 warnings)*
- `npm test` *(fails: multiple failing tests)*
- `npm run format:check` *(fails: code style issues in .github/pull_request_template.md)*
- `npm run test:e2e` *(fails: compilation aborted)*
- `npm run build`

Reference: [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) v0.2.0

------
https://chatgpt.com/codex/tasks/task_e_68a1837ac56483328c4d35e619dd8273