### PR TITLE
UX Stage 01: add Tailwind forms plugin

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -1,0 +1,8 @@
+# Forms Styling
+
+This project uses the [`@tailwindcss/forms`](https://github.com/tailwindlabs/tailwindcss-forms) plugin to provide a consistent baseline for form elements. The plugin resets default browser styles and maps controls to the design tokens defined in `tailwind.config.js`.
+
+- Inputs, selects, textareas, and checkboxes inherit typography and spacing from Tailwind utilities.
+- Additional component-level styling should rely on the existing design tokens for colors, radii, and motion.
+
+See `docs/ux-upgrade-plan.md` (version 0.2.0) for the broader context of form and button primitive upgrades.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@crabnebula/tauri-driver": "^2.0.5",
         "@eslint/js": "^9.33.0",
+        "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/postcss": "^4.0.7",
         "@tauri-apps/cli": "^2",
         "@testing-library/jest-dom": "6.7.0",
@@ -2540,6 +2541,19 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
+      "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.12",
@@ -9222,6 +9236,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@crabnebula/tauri-driver": "^2.0.5",
     "@eslint/js": "^9.33.0",
+    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/postcss": "^4.0.7",
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "6.7.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,8 @@
 /** @type {import('tailwindcss').Config} */
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const forms = require('@tailwindcss/forms');
+
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
@@ -22,5 +26,5 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [forms],
 };


### PR DESCRIPTION
## Summary
- add @tailwindcss/forms dev dependency and enable plugin in Tailwind config
- document baseline form styling

## Testing
- `npm run lint` *(warn: import order)*
- `npm test` *(fail: 16 failing tests)*
- `npm run format:check` *(fail: code style issues in .github/pull_request_template.md)*
- `npm run test:e2e` *(fail: missing glib-2.0 and WebKitWebDriver)*
- `npm run build`

Reference: [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) v0.2.0

------
https://chatgpt.com/codex/tasks/task_e_68a18384e9c48332b444d8a5a0b14305