### PR TITLE
UX Stage 01: centralize theme tokens

### DIFF
--- a/docs/tailwind-entry.md
+++ b/docs/tailwind-entry.md
@@ -1,3 +1,4 @@
 # Tailwind Entry
 
-The application loads Tailwind CSS layers from `src/styles/tailwind.css`, which is imported at the top of `src/main.tsx`.
+The application loads Tailwind CSS layers and design tokens from `src/styles/tailwind.css`.
+This file imports `theme.css` so the tokens load once and is included at the top of `src/main.tsx`.

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -14,7 +14,7 @@ without changing component markup.
 - `--radius` / `--radius-sm`: standard and small border radius
 - `--spacing-sm` / `--spacing-md` / `--spacing-lg`: spacing scale
 - `--shadow`: base shadow
-- `--glow-shadow`: accent glow shadow
+- `--glow-shadow`: accent glow color
 
 ## Tailwind Mapping
 
@@ -40,7 +40,7 @@ borderRadius: {
 },
 boxShadow: {
   DEFAULT: 'var(--shadow)',
-  glow: 'var(--glow-shadow)'
+  glow: '0 0 8px var(--glow-shadow)'
 }
 ```
 

--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,3 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-@import './styles/theme.css';
-
 /* Zimbo's Cyber-Barbarian Theme CSS */
 
 /* Reset and base styles */

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,6 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@import './theme.css';
 :root {
   --bg: 0 0% 0%; /* example HSL tokens */
   --fg: 0 0% 100%;
@@ -13,5 +14,5 @@
   --radius: 0.75rem;
   --radius-sm: 0.375rem;
   --shadow: 0 0 10px var(--panel-shadow);
-  --glow-shadow: 0 0 8px var(--glow-shadow);
+  --glow-shadow: hsl(var(--accent) / 0.35);
 }


### PR DESCRIPTION
## Summary
- remove Tailwind directives from App.css so it only holds custom styles
- centralize theme import in tailwind.css and fix `--glow-shadow` token
- document token and tailwind entry changes

## Testing
- `npm run lint`
- `npm test` *(fails: multiple unit tests)*
- `npm run format:check` *(warns `.github/pull_request_template.md`)*
- `npm run test:e2e` *(fails: missing glib/gobject and WebKitWebDriver)*
- `npm run build`

References [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) version 0.2.0.

------
https://chatgpt.com/codex/tasks/task_e_68a1885f8a648332bf629daa0c535b47