### PR TITLE
UX Stage 02: motion system

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -11,6 +11,8 @@ without changing component markup.
 - `--accent`: primary accent color
 - `--muted` / `--muted-foreground`: muted surfaces and their text color
 - `--card` / `--card-foreground`: card surfaces and their text color
+- `--color-neon` / `--color-neon-dark`: neon accent pair
+- `--shadow-neon`: neon glow
 - `--radius` / `--radius-sm`: standard and small border radius
 - `--spacing-sm` / `--spacing-md` / `--spacing-lg`: spacing scale
 - `--shadow`: base shadow
@@ -45,3 +47,18 @@ boxShadow: {
 ```
 
 Use these utilities in components to stay aligned with the design system.
+
+## Motion Tokens
+
+JavaScript animations use centralized timing and easing presets defined in
+`src/motion/tokens.ts`:
+
+- `durations.xs` `120ms`
+- `durations.sm` `160ms`
+- `durations.md` `220ms`
+- `durations.lg` `320ms`
+- `easings.standard` cubic-bezier(0.4, 0, 0.2, 1)
+- `easings.emphasized` cubic-bezier(0.2, 0, 0, 1)
+- `spring` preset for interactive elements
+
+Always reference these tokens instead of hardcoding values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "framer-motion": "^11.18.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0"
@@ -7170,6 +7171,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9326,6 +9354,21 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "framer-motion": "^11.18.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0"

--- a/src/components/ExportModal.jsx
+++ b/src/components/ExportModal.jsx
@@ -3,22 +3,25 @@ import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import { FaSatellite } from 'react-icons/fa6';
 import { useCharacter } from '../state/CharacterContext';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { durations, easings, fadeScale } from '../motion/tokens';
 import styles from './ExportModal.module.css';
 import Button from './common/Button';
 import ButtonGroup from './common/ButtonGroup';
-import useModalTransition from './common/useModalTransition.js';
 
 export default function ExportModal({ isOpen, onClose }) {
   const { character, addCharacter, selectedId } = useCharacter();
   const [fileName, setFileName] = useState(`character-${selectedId}.json`);
   const [message, setMessage] = useState('');
-  const [isVisible, isActive] = useModalTransition(isOpen);
+  const reduce = useReducedMotion();
+  const transition = reduce ? { duration: 0 } : { duration: durations.md, ease: easings.standard };
+  const variants = reduce
+    ? { hidden: { opacity: 0 }, visible: { opacity: 1 }, exit: { opacity: 0 } }
+    : fadeScale;
 
   useEffect(() => {
     setFileName(`character-${selectedId}.json`);
   }, [selectedId]);
-
-  if (!isVisible) return null;
 
   const handleSave = async () => {
     try {
@@ -45,28 +48,43 @@ export default function ExportModal({ isOpen, onClose }) {
   };
 
   return (
-    <div className={styles.overlay}>
-      <div
-        className={`${styles.modal} ${styles.modalEnter} ${isActive ? styles.modalEnterActive : ''}`}
-      >
-        <h2 className={styles.title}>
-          <FaSatellite style={{ marginRight: '4px' }} /> Export / Import
-        </h2>
-        <input
-          type="text"
-          value={fileName}
-          onChange={(e) => setFileName(e.target.value)}
-          placeholder="filename.json"
-          className={styles.input}
-        />
-        {message && <div className={styles.message}>{message}</div>}
-        <ButtonGroup>
-          <Button onClick={handleSave}>Save</Button>
-          <Button onClick={handleLoad}>Load</Button>
-          <Button onClick={onClose}>Close</Button>
-        </ButtonGroup>
-      </div>
-    </div>
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className={styles.overlay}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={transition}
+        >
+          <motion.div
+            className={styles.modal}
+            variants={variants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            transition={transition}
+          >
+            <h2 className={styles.title}>
+              <FaSatellite style={{ marginRight: '4px' }} /> Export / Import
+            </h2>
+            <input
+              type="text"
+              value={fileName}
+              onChange={(e) => setFileName(e.target.value)}
+              placeholder="filename.json"
+              className={styles.input}
+            />
+            {message && <div className={styles.message}>{message}</div>}
+            <ButtonGroup>
+              <Button onClick={handleSave}>Save</Button>
+              <Button onClick={handleLoad}>Load</Button>
+              <Button onClick={onClose}>Close</Button>
+            </ButtonGroup>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }
 

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,12 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { spring } from '../../motion/tokens';
 import styles from './Button.module.css';
 
 export default function Button({ className = '', type = 'button', children, ...props }) {
+  const reduce = useReducedMotion();
+  const hover = reduce ? undefined : { scale: 1.02 };
+  const tap = reduce ? undefined : { scale: 0.98 };
+  const transition = reduce ? { duration: 0 } : spring;
+
   return (
-    <button type={type} className={`${styles.button} ${className}`} {...props}>
+    <motion.button
+      type={type}
+      className={`${styles.button} ${className}`}
+      whileHover={hover}
+      whileTap={tap}
+      transition={transition}
+      {...props}
+    >
       {children}
-    </button>
+    </motion.button>
   );
 }
 

--- a/src/components/common/Button.module.css
+++ b/src/components/common/Button.module.css
@@ -18,11 +18,13 @@
 
 .button:hover {
   filter: brightness(1.1);
+  box-shadow: var(--shadow-neon);
 }
 
 .button:focus-visible {
-  outline: 2px solid var(--color-accent);
+  outline: 2px solid var(--color-neon);
   outline-offset: 2px;
+  box-shadow: var(--shadow-neon);
 }
 
 .button:disabled {

--- a/src/components/dev/DevPrimitivesPreview.tsx
+++ b/src/components/dev/DevPrimitivesPreview.tsx
@@ -1,8 +1,16 @@
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import React from 'react';
+import { durations, easings, fadeScale } from '../../motion/tokens';
 import { Dialog, Tooltip, DropdownMenu, Separator, Slider } from '../ui/primitives';
 
 export default function DevPrimitivesPreview() {
   const [open, setOpen] = React.useState<boolean>(false);
+  const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
+  const reduce = useReducedMotion();
+  const transition = reduce ? { duration: 0 } : { duration: durations.sm, ease: easings.standard };
+  const variants = reduce
+    ? { hidden: { opacity: 0 }, visible: { opacity: 1 }, exit: { opacity: 0 } }
+    : fadeScale;
 
   return (
     <div className="min-h-screen bg-bg p-md text-fg space-y-md">
@@ -19,25 +27,53 @@ export default function DevPrimitivesPreview() {
         <Dialog.Trigger asChild>
           <button className="rounded bg-accent px-md py-sm text-bg">Open Dialog</button>
         </Dialog.Trigger>
-        <Dialog.Content className="rounded bg-bg p-md shadow">
-          <Dialog.Title className="mb-sm">Dialog Title</Dialog.Title>
-          <Dialog.Description className="mb-md">This is a Radix dialog.</Dialog.Description>
-          <button onClick={() => setOpen(false)} className="rounded bg-accent px-md py-sm text-bg">
-            Close
-          </button>
-        </Dialog.Content>
+        <AnimatePresence>
+          {open && (
+            <Dialog.Content asChild forceMount>
+              <motion.div
+                variants={variants}
+                initial="hidden"
+                animate="visible"
+                exit="exit"
+                transition={transition}
+                className="rounded bg-bg p-md shadow"
+              >
+                <Dialog.Title className="mb-sm">Dialog Title</Dialog.Title>
+                <Dialog.Description className="mb-md">This is a Radix dialog.</Dialog.Description>
+                <button
+                  onClick={() => setOpen(false)}
+                  className="rounded bg-accent px-md py-sm text-bg"
+                >
+                  Close
+                </button>
+              </motion.div>
+            </Dialog.Content>
+          )}
+        </AnimatePresence>
       </Dialog.Root>
 
-      <DropdownMenu.Root>
+      <DropdownMenu.Root open={menuOpen} onOpenChange={setMenuOpen}>
         <DropdownMenu.Trigger asChild>
           <button className="rounded bg-accent px-md py-sm text-bg">Menu</button>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content className="rounded bg-bg p-sm shadow text-fg">
-          <DropdownMenu.Item className="px-md py-sm">Item 1</DropdownMenu.Item>
-          <DropdownMenu.Item className="px-md py-sm">Item 2</DropdownMenu.Item>
-          <Separator className="my-sm h-px bg-accent" />
-          <DropdownMenu.Item className="px-md py-sm">Item 3</DropdownMenu.Item>
-        </DropdownMenu.Content>
+        <AnimatePresence>
+          {menuOpen && (
+            <DropdownMenu.Content asChild forceMount className="rounded bg-bg p-sm shadow text-fg">
+              <motion.div
+                variants={variants}
+                initial="hidden"
+                animate="visible"
+                exit="exit"
+                transition={transition}
+              >
+                <DropdownMenu.Item className="px-md py-sm">Item 1</DropdownMenu.Item>
+                <DropdownMenu.Item className="px-md py-sm">Item 2</DropdownMenu.Item>
+                <Separator className="my-sm h-px bg-accent" />
+                <DropdownMenu.Item className="px-md py-sm">Item 3</DropdownMenu.Item>
+              </motion.div>
+            </DropdownMenu.Content>
+          )}
+        </AnimatePresence>
       </DropdownMenu.Root>
 
       <div className="w-64">

--- a/src/motion/tokens.ts
+++ b/src/motion/tokens.ts
@@ -1,0 +1,23 @@
+export const durations = {
+  xs: 0.12,
+  sm: 0.16,
+  md: 0.22,
+  lg: 0.32,
+} as const;
+
+export const easings = {
+  standard: [0.4, 0, 0.2, 1] as const,
+  emphasized: [0.2, 0, 0, 1] as const,
+} as const;
+
+export const spring = {
+  type: 'spring',
+  stiffness: 300,
+  damping: 30,
+};
+
+export const fadeScale = {
+  hidden: { opacity: 0, scale: 0.96 },
+  visible: { opacity: 1, scale: 1 },
+  exit: { opacity: 0, scale: 0.96 },
+};

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -43,7 +43,9 @@
 
   --color-accent: #5fd1c1;
   --color-accent-dark: #3fa39e;
-  --color-accent-darker: #2b6c65;
+  --color-neon: #64f1e1;
+  --color-neon-dark: #2bc7b4;
+  --shadow-neon: 0 0 10px var(--color-neon);
   --color-accent-rgb: 95, 209, 193;
 
   /* base neutrals */
@@ -189,7 +191,9 @@
 
   --color-accent: #0066cc;
   --color-accent-dark: #004a99;
-  --color-accent-darker: #003366;
+  --color-neon: #64f1e1;
+  --color-neon-dark: #2bc7b4;
+  --shadow-neon: 0 0 10px var(--color-neon);
   --color-accent-rgb: 0, 102, 204;
 
   /* base neutrals */
@@ -337,7 +341,9 @@
 
   --color-accent: #1e827c;
   --color-accent-dark: #155b58;
-  --color-accent-darker: #0d423e;
+  --color-neon: #64f1e1;
+  --color-neon-dark: #2bc7b4;
+  --shadow-neon: 0 0 10px var(--color-neon);
   --color-accent-rgb: 30, 130, 124;
 
   --color-info: #d2666f;


### PR DESCRIPTION
## Summary
- add motion tokens and Framer Motion utilities
- animate dialogs and menus via AnimatePresence
- introduce micro-interactions and neon focus states
- respect `prefers-reduced-motion`

## Testing
- `npm run lint`
- `npm test` *(fails: 6 files, 16 tests failed)*
- `npm run format:check` *(warns about .github/pull_request_template.md)*
- `npm run test:e2e` *(fails: missing glib-2.0 and driver binary)*
- `npm run build`

References [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) v0.2.0

------
https://chatgpt.com/codex/tasks/task_e_68a1e540e8a48332acfc976341172ddf