### PR TITLE
UX Stage 02: centralize e2e setup

### DIFF
--- a/tests/app.e2e.spec.ts
+++ b/tests/app.e2e.spec.ts
@@ -1,54 +1,9 @@
-import { spawn, spawnSync } from 'child_process';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { waitTauriDriverReady } from '@crabnebula/tauri-driver';
-import { remote } from 'webdriverio';
-import { beforeAll, afterAll, test, expect } from 'vitest';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-let browser; // WebdriverIO.Browser
-let tauriDriver;
+import { test, expect } from 'vitest';
 
 const parseXp = (text: string): number => {
   const match = /XP: (\d+)/.exec(text);
   return match ? Number(match[1]) : 0;
 };
-
-beforeAll(async () => {
-  const tauriDir = path.resolve(__dirname, '../src-tauri');
-  spawnSync('npx', ['tauri', 'build', '--debug'], {
-    cwd: tauriDir,
-    stdio: 'inherit',
-  });
-
-  tauriDriver = spawn('npx', ['tauri-driver'], {
-    stdio: 'inherit',
-    shell: true,
-  });
-  await waitTauriDriverReady();
-
-  const appPath = path.resolve(tauriDir, 'target/debug/zimbo-panel');
-  browser = await remote({
-    hostname: '127.0.0.1',
-    port: 4444,
-    capabilities: {
-      'tauri:options': {
-        application: appPath,
-      },
-    },
-    logLevel: 'error',
-  });
-}, 120000);
-
-afterAll(async () => {
-  if (browser) {
-    await browser.deleteSession();
-  }
-  if (tauriDriver) {
-    tauriDriver.kill();
-  }
-});
 
 test('increments XP on button click', async () => {
   const xpEl = await browser.$('div*=XP:');

--- a/tests/app.e2e.test.js
+++ b/tests/app.e2e.test.js
@@ -1,51 +1,9 @@
-import { spawn, spawnSync } from 'child_process';
-import path from 'path';
-import { waitTauriDriverReady } from '@crabnebula/tauri-driver';
-import { beforeAll, afterAll, test, expect } from 'vitest';
-import { remote } from 'webdriverio';
-
-let browser;
-let tauriDriver;
+import { test, expect } from 'vitest';
 
 const parseXp = (text) => {
   const match = /XP: (\d+)/.exec(text);
   return match ? Number(match[1]) : 0;
 };
-
-beforeAll(async () => {
-  const tauriDir = path.resolve(__dirname, '../src-tauri');
-  spawnSync('npx', ['tauri', 'build', '--debug'], {
-    cwd: tauriDir,
-    stdio: 'inherit',
-  });
-
-  tauriDriver = spawn('npx', ['tauri-driver'], {
-    stdio: 'inherit',
-    shell: true,
-  });
-  await waitTauriDriverReady();
-
-  const appPath = path.resolve(tauriDir, 'target/debug/zimbo-panel');
-  browser = await remote({
-    hostname: '127.0.0.1',
-    port: 4444,
-    capabilities: {
-      'tauri:options': {
-        application: appPath,
-      },
-    },
-    logLevel: 'error',
-  });
-});
-
-afterAll(async () => {
-  if (browser) {
-    await browser.deleteSession();
-  }
-  if (tauriDriver) {
-    tauriDriver.kill();
-  }
-});
 
 test('character flow with save and load', async () => {
   // wait for XP text to be available

--- a/tests/e2e.setup.ts
+++ b/tests/e2e.setup.ts
@@ -1,0 +1,56 @@
+import { spawn, spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { waitTauriDriverReady } from '@crabnebula/tauri-driver';
+import { remote, type Browser } from 'webdriverio';
+import { beforeAll } from 'vitest';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var browser: Browser;
+  // eslint-disable-next-line no-var
+  var __E2E_BROWSER_PROMISE__: Promise<Browser> | undefined;
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const tauriDir = path.resolve(__dirname, '../src-tauri');
+
+if (!globalThis.__E2E_BROWSER_PROMISE__) {
+  globalThis.__E2E_BROWSER_PROMISE__ = (async () => {
+    spawnSync('npx', ['tauri', 'build', '--debug'], {
+      cwd: tauriDir,
+      stdio: 'inherit',
+    });
+
+    const tauriDriver = spawn('npx', ['tauri-driver'], {
+      stdio: 'inherit',
+      shell: true,
+    });
+    await waitTauriDriverReady();
+
+    const appPath = path.resolve(tauriDir, 'target/debug/zimbo-panel');
+    const browser = await remote({
+      hostname: '127.0.0.1',
+      port: 4444,
+      capabilities: {
+        'tauri:options': {
+          application: appPath,
+        },
+      },
+      logLevel: 'error',
+    });
+
+    process.once('exit', async () => {
+      await browser.deleteSession();
+      tauriDriver.kill();
+    });
+
+    return browser;
+  })();
+}
+
+beforeAll(async () => {
+  globalThis.browser = await globalThis.__E2E_BROWSER_PROMISE__;
+}, 120000);
+
+export {};

--- a/vitest.e2e.config.js
+++ b/vitest.e2e.config.js
@@ -4,5 +4,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: ['tests/**/*.e2e.test.js', 'tests/**/*.e2e.spec.ts'],
+    setupFiles: ['tests/e2e.setup.ts'],
+    threads: {
+      singleThread: true,
+    },
   },
 });


### PR DESCRIPTION
## Summary
- centralize tauri build/driver startup in shared Vitest setup
- run e2e tests in a single thread with shared browser
- streamline individual tests to use global driver

## Testing
- `npm run lint`
- `npm test` *(fails: handleUpdateNotes is not defined)*
- `npm run format:check` *(fails: Code style issues found in the above file. Run Prettier with --write to fix.)*
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*
- `npm run build`

Reference: [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) (v0.2.0)

------
https://chatgpt.com/codex/tasks/task_e_68a23aa8ef288332ac9b0c63f1bd87ee