### PR TITLE
UX Stage 01: share XP test utilities

### DIFF
--- a/tests/app.e2e.spec.ts
+++ b/tests/app.e2e.spec.ts
@@ -4,16 +4,12 @@ import { fileURLToPath } from 'url';
 import { waitTauriDriverReady } from '@crabnebula/tauri-driver';
 import { remote } from 'webdriverio';
 import { beforeAll, afterAll, test, expect } from 'vitest';
+import { parseXp, xpSelector, xpButtonSelector } from './utils';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let browser; // WebdriverIO.Browser
 let tauriDriver;
-
-const parseXp = (text: string): number => {
-  const match = /XP: (\d+)/.exec(text);
-  return match ? Number(match[1]) : 0;
-};
 
 beforeAll(async () => {
   const tauriDir = path.resolve(__dirname, '../src-tauri');
@@ -51,9 +47,9 @@ afterAll(async () => {
 });
 
 test('increments XP on button click', async () => {
-  const xpEl = await browser.$('div*=XP:');
+  const xpEl = await browser.$(xpSelector);
   const initialXp = parseXp(await xpEl.getText());
-  const xpButton = await browser.$('button=+1 XP');
+  const xpButton = await browser.$(xpButtonSelector);
   await xpButton.click();
   expect(parseXp(await xpEl.getText())).toBe(initialXp + 1);
 }, 120000);

--- a/tests/app.e2e.test.js
+++ b/tests/app.e2e.test.js
@@ -3,14 +3,10 @@ import path from 'path';
 import { waitTauriDriverReady } from '@crabnebula/tauri-driver';
 import { beforeAll, afterAll, test, expect } from 'vitest';
 import { remote } from 'webdriverio';
+import { parseXp, xpSelector, xpButtonSelector } from './utils.ts';
 
 let browser;
 let tauriDriver;
-
-const parseXp = (text) => {
-  const match = /XP: (\d+)/.exec(text);
-  return match ? Number(match[1]) : 0;
-};
 
 beforeAll(async () => {
   const tauriDir = path.resolve(__dirname, '../src-tauri');
@@ -49,10 +45,10 @@ afterAll(async () => {
 
 test('character flow with save and load', async () => {
   // wait for XP text to be available
-  const xpEl = await browser.$('div*=XP:');
+  const xpEl = await browser.$(xpSelector);
   const initialXpText = await xpEl.getText();
   const initialXp = parseXp(initialXpText);
-  const xpButton = await browser.$('button=+1 XP');
+  const xpButton = await browser.$(xpButtonSelector);
   await xpButton.click();
   expect(parseXp(await xpEl.getText())).toBe(initialXp + 1);
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,7 @@
+export const parseXp = (text: string): number => {
+  const match = /XP: (\d+)/.exec(text);
+  return match ? Number(match[1]) : 0;
+};
+
+export const xpSelector = 'div*=XP:';
+export const xpButtonSelector = 'button=+1 XP';


### PR DESCRIPTION
## Summary
- extract common XP helpers into `tests/utils.ts`
- reuse shared selectors and `parseXp` across e2e tests

## Testing
- `npm run lint`
- `npm test` *(fails: handleUpdateNotes is not defined; missing elements etc.)*
- `npm run format:check` *(warn: .github/pull_request_template.md)*
- `npm run test:e2e` *(fails: system library `glib-2.0` missing)*
- `npm run build`

Plan: [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) (version 0.2.0)

------
https://chatgpt.com/codex/tasks/task_e_68a23aa9cab48332952c45e2e42c7cb5