### PR TITLE
UX Stage 02: add test ids for e2e stability

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -211,6 +211,7 @@ function App() {
               <Button
                 onClick={() => setShowInventoryModal(true)}
                 className={styles.inventoryButton}
+                data-testid="open-inventory"
               >
                 <FaBoxOpen className={styles.icon} /> Inventory
               </Button>
@@ -224,7 +225,11 @@ function App() {
               >
                 <FaFlagCheckered className={styles.icon} /> End Session
               </Button>
-              <Button onClick={() => setShowExportModal(true)} className={styles.exportButton}>
+              <Button
+                onClick={() => setShowExportModal(true)}
+                className={styles.exportButton}
+                data-testid="open-export"
+              >
                 <FaSatellite className={styles.icon} /> Export/Save
               </Button>
               <Settings />

--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -85,7 +85,7 @@ const CharacterStats = ({
           style={{ width: `${(character.xp / character.xpNeeded) * 100}%` }}
         />
       </div>
-      <div className={styles.centerText}>
+      <div className={styles.centerText} data-testid="xp-display">
         XP: {character.xp}/{character.xpNeeded} (Level {character.level})
       </div>
       <div className={styles.controls}>
@@ -98,6 +98,7 @@ const CharacterStats = ({
             }))
           }
           className={styles.button}
+          data-testid="increment-xp"
         >
           +1 XP
         </button>

--- a/src/components/ExportModal.jsx
+++ b/src/components/ExportModal.jsx
@@ -75,9 +75,15 @@ export default function ExportModal({ isOpen, onClose }) {
             />
             {message && <div className={styles.message}>{message}</div>}
             <ButtonGroup>
-              <Button onClick={handleSave}>Save</Button>
-              <Button onClick={handleLoad}>Load</Button>
-              <Button onClick={onClose}>Close</Button>
+              <Button onClick={handleSave} data-testid="save-character">
+                Save
+              </Button>
+              <Button onClick={handleLoad} data-testid="load-character">
+                Load
+              </Button>
+              <Button onClick={onClose} data-testid="close-export">
+                Close
+              </Button>
             </ButtonGroup>
           </motion.div>
         </motion.div>

--- a/src/components/InventoryModal.jsx
+++ b/src/components/InventoryModal.jsx
@@ -66,7 +66,11 @@ const InventoryModal = ({
                     </div>
                     <div className={styles.inventoryItemActions}>
                       {'equipped' in item && (
-                        <button className={styles.inventoryButton} onClick={() => onEquip(item.id)}>
+                        <button
+                          className={styles.inventoryButton}
+                          onClick={() => onEquip(item.id)}
+                          data-testid="equip-toggle"
+                        >
                           {item.equipped ? 'Unequip' : 'Equip'}
                         </button>
                       )}
@@ -87,7 +91,11 @@ const InventoryModal = ({
               </ul>
             )}
             <div className={styles.inventoryClose}>
-              <button className={styles.inventoryButton} onClick={onClose}>
+              <button
+                className={styles.inventoryButton}
+                onClick={onClose}
+                data-testid="close-inventory"
+              >
                 Close
               </button>
             </div>

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -9,7 +9,12 @@ const Settings = () => {
   return (
     <div>
       <label htmlFor="theme-select">Theme:</label>{' '}
-      <select id="theme-select" value={theme} onChange={(e) => setTheme(e.target.value)}>
+      <select
+        id="theme-select"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value)}
+        data-testid="theme-select"
+      >
         {themes.map((t) => (
           <option key={t} value={t}>
             {t.replace('-', ' ')}

--- a/tests/app.e2e.spec.ts
+++ b/tests/app.e2e.spec.ts
@@ -51,9 +51,9 @@ afterAll(async () => {
 });
 
 test('increments XP on button click', async () => {
-  const xpEl = await browser.$('div*=XP:');
+  const xpEl = await browser.$('[data-testid="xp-display"]');
   const initialXp = parseXp(await xpEl.getText());
-  const xpButton = await browser.$('button=+1 XP');
+  const xpButton = await browser.$('[data-testid="increment-xp"]');
   await xpButton.click();
   expect(parseXp(await xpEl.getText())).toBe(initialXp + 1);
 }, 120000);

--- a/tests/app.e2e.test.js
+++ b/tests/app.e2e.test.js
@@ -49,47 +49,47 @@ afterAll(async () => {
 
 test('character flow with save and load', async () => {
   // wait for XP text to be available
-  const xpEl = await browser.$('div*=XP:');
+  const xpEl = await browser.$('[data-testid="xp-display"]');
   const initialXpText = await xpEl.getText();
   const initialXp = parseXp(initialXpText);
-  const xpButton = await browser.$('button=+1 XP');
+  const xpButton = await browser.$('[data-testid="increment-xp"]');
   await xpButton.click();
   expect(parseXp(await xpEl.getText())).toBe(initialXp + 1);
 
   // Inventory modal
-  const inventoryButton = await browser.$('button=Inventory');
+  const inventoryButton = await browser.$('[data-testid="open-inventory"]');
   await inventoryButton.click();
   await expect(await browser.$('h2*=Inventory').isExisting()).resolves.toBe(true);
   await expect(await browser.$('div=Phases through time occasionally').isExisting()).resolves.toBe(
     true,
   );
-  const unequipBtn = await browser.$('button=Unequip');
-  await unequipBtn.click();
-  await expect(await browser.$('button=Equip').isExisting()).resolves.toBe(true);
-  await (await browser.$('button=Close')).click();
+  const equipToggle = await browser.$('[data-testid="equip-toggle"]');
+  await equipToggle.click();
+  await expect(await equipToggle.getText()).resolves.toBe('Equip');
+  await (await browser.$('[data-testid="close-inventory"]')).click();
 
   // Settings
-  const themeSelect = await browser.$('#theme-select');
+  const themeSelect = await browser.$('[data-testid="theme-select"]');
   await themeSelect.selectByVisibleText('classic');
   expect(await browser.$('html').getAttribute('data-theme')).toBe('classic');
 
   // Save character
-  const exportButton = await browser.$('button=Export/Save');
+  const exportButton = await browser.$('[data-testid="open-export"]');
   await exportButton.click();
-  const saveButton = await browser.$('button=Save');
+  const saveButton = await browser.$('[data-testid="save-character"]');
   await saveButton.click();
   await expect(await browser.$('div=Character saved!').isExisting()).resolves.toBe(true);
-  await (await browser.$('button=Close')).click();
+  await (await browser.$('[data-testid="close-export"]')).click();
 
   // change XP then load
   await xpButton.click();
   expect(parseXp(await xpEl.getText())).toBe(initialXp + 2);
 
   await exportButton.click();
-  const loadButton = await browser.$('button=Load');
+  const loadButton = await browser.$('[data-testid="load-character"]');
   await loadButton.click();
   await expect(await browser.$('div=Character loaded!').isExisting()).resolves.toBe(true);
-  await (await browser.$('button=Close')).click();
+  await (await browser.$('[data-testid="close-export"]')).click();
 
   expect(parseXp(await xpEl.getText())).toBe(initialXp + 1);
 }, 120000);


### PR DESCRIPTION
## Summary
- add `data-testid` hooks to key interactive elements
- switch e2e tests to query by `data-testid`

## Testing
- `npm run lint`
- `npm test` *(fails: 27 tests failed)*
- `npm run format:check` *(fails: .github/pull_request_template.md)*
- `npm run test:e2e` *(fails: missing system libraries)*
- `npm run build`

Reference: [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) (plan version: 0.2.0)


------
https://chatgpt.com/codex/tasks/task_e_68a23ab247ac8332a60f9ae8b4b4b885