### PR TITLE
refactor: use Tauri fs helpers

### DIFF
--- a/src/utils/fileStorage.js
+++ b/src/utils/fileStorage.js
@@ -1,7 +1,8 @@
 export async function saveFile(name, contents) {
   if (window.__TAURI__) {
-    const { invoke } = await import('@tauri-apps/api/core');
-    return invoke('write_file', { path: name, contents });
+    const module = '@tauri-apps/api/' + 'fs';
+    const { writeTextFile } = await import(/* @vite-ignore */ module);
+    return writeTextFile(name, contents);
   }
 
   try {
@@ -22,8 +23,9 @@ export async function saveFile(name, contents) {
 
 export async function loadFile(name) {
   if (window.__TAURI__) {
-    const { invoke } = await import('@tauri-apps/api/core');
-    return invoke('read_file', { path: name });
+    const module = '@tauri-apps/api/' + 'fs';
+    const { readTextFile } = await import(/* @vite-ignore */ module);
+    return readTextFile(name);
   }
 
   try {

--- a/src/utils/fileStorage.test.js
+++ b/src/utils/fileStorage.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { saveFile, loadFile } from './fileStorage.js';
 
-vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
+vi.mock('@tauri-apps/api/fs', () => ({
+  writeTextFile: vi.fn(),
+  readTextFile: vi.fn(),
 }));
 
 afterEach(() => {
@@ -11,22 +12,21 @@ afterEach(() => {
 });
 
 describe('fileStorage tauri integration', () => {
-  it('calls invoke to save file when Tauri is available', async () => {
+  it('writes file when Tauri is available', async () => {
     window.__TAURI__ = {};
-    const { invoke } = await import('@tauri-apps/api/core');
+    const module = '@tauri-apps/api/' + 'fs';
+    const { writeTextFile } = await import(/* @vite-ignore */ module);
     await saveFile('test.json', '{"a":1}');
-    expect(invoke).toHaveBeenCalledWith('write_file', {
-      path: 'test.json',
-      contents: '{"a":1}',
-    });
+    expect(writeTextFile).toHaveBeenCalledWith('test.json', '{"a":1}');
   });
 
-  it('calls invoke to load file when Tauri is available', async () => {
+  it('reads file when Tauri is available', async () => {
     window.__TAURI__ = {};
-    const { invoke } = await import('@tauri-apps/api/core');
-    invoke.mockResolvedValueOnce('content');
+    const module = '@tauri-apps/api/' + 'fs';
+    const { readTextFile } = await import(/* @vite-ignore */ module);
+    readTextFile.mockResolvedValueOnce('content');
     await expect(loadFile('test.json')).resolves.toBe('content');
-    expect(invoke).toHaveBeenCalledWith('read_file', { path: 'test.json' });
+    expect(readTextFile).toHaveBeenCalledWith('test.json');
   });
 });
 


### PR DESCRIPTION
## Summary
- replace invoke-based file access with `@tauri-apps/api` fs helpers
- update storage tests for new Tauri fs API

## Testing
- `npm run lint`
- `npm test` *(fails: 7 failed, 175 passed, 4 skipped)*
- `npm run format:check` *(warns: tests/app.e2e.spec.ts needs formatting)*
- `npm run test:e2e` *(fails: missing system libraries and WebKitWebDriver)*
- `npm run build`

Ref: docs/ux-upgrade-plan.md v0.2.0

------
https://chatgpt.com/codex/tasks/task_e_68a27430a0a48332b553adea45c1d33c