### PR TITLE
UX Stage 02: guard missing inventory notes handler

### DIFF
--- a/src/components/InventoryModal.jsx
+++ b/src/components/InventoryModal.jsx
@@ -12,7 +12,7 @@ const InventoryModal = ({
   onEquip,
   onConsume,
   onDrop,
-  onUpdateNotes,
+  onUpdateNotes = () => {},
   onClose,
 }) => {
   const transition = useMotionTransition(durations.md, easings.standard);
@@ -112,7 +112,7 @@ InventoryModal.propTypes = {
   onEquip: PropTypes.func.isRequired,
   onConsume: PropTypes.func.isRequired,
   onDrop: PropTypes.func.isRequired,
-  onUpdateNotes: PropTypes.func.isRequired,
+  onUpdateNotes: PropTypes.func,
   onClose: PropTypes.func.isRequired,
 };
 

--- a/src/components/InventoryModal.test.jsx
+++ b/src/components/InventoryModal.test.jsx
@@ -191,4 +191,21 @@ describe('InventoryModal', () => {
     await user.type(textarea, '!');
     expect(onUpdateNotes).toHaveBeenLastCalledWith(1, 'old!');
   });
+
+  it('handles missing onUpdateNotes without crashing', async () => {
+    const user = userEvent.setup();
+    const inventory = [{ id: 1, name: 'Sword', type: 'weapon' }];
+    render(
+      <InventoryModal
+        inventory={inventory}
+        onEquip={() => {}}
+        onConsume={() => {}}
+        onDrop={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const textarea = screen.getByPlaceholderText('Notes');
+    await user.type(textarea, 'hi');
+    expect(textarea.value).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- prevent `InventoryModal` from crashing when `handleUpdateNotes` is undefined
- cover missing notes handler case with test

## Testing
- `npm run lint`
- `npm test` *(fails: Unable to find element, etc.)*
- `npm run format:check`
- `npm run test:e2e` *(fails: glib-2.0 not found, CannotFindBinaryPath)*
- `npm run build`

Ref: [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) (v0.2.0)

------
https://chatgpt.com/codex/tasks/task_e_68a2838174f88332bb3b6dd45be8b618