### PR TITLE
UX Stage 01: prioritize theme import in Tailwind

### DIFF
--- a/docs/tailwind-entry.md
+++ b/docs/tailwind-entry.md
@@ -1,4 +1,5 @@
 # Tailwind Entry
 
 The application loads Tailwind CSS layers and design tokens from `src/styles/tailwind.css`.
-This file imports `theme.css` so the tokens load once and is included at the top of `src/main.tsx`.
+
+This file first imports `theme.css` so the tokens load before Tailwind's layers. No `:root` overrides live here; `theme.css` defines the cosmic-v2 palette.

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,23 +1,5 @@
+@import './theme.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-@import './theme.css';
-:root {
-  --bg: 0 0% 0%; /* example HSL tokens */
-  --fg: 0 0% 100%;
-  --accent: 160 60% 50%;
-  /* add muted, card, and other tokens */
-  --muted: 240 4% 16%;
-  --muted-foreground: 240 5% 64%;
-  --card: 240 4% 10%;
-  --card-foreground: 240 4% 90%;
-  --radius: 0.75rem;
-  --radius-sm: 0.375rem;
-  --shadow: 0 0 10px var(--panel-shadow);
-  --glow-shadow: hsl(var(--accent) / 0.35);
-  --glass-bg: 0 0% 100%;
-  --glass-border: 0 0% 100%;
-  --shadow-glass: 0 8px 32px rgba(0, 0, 0, 0.3);
-  --color-neon: 166 85% 70%;
-  --shadow-neon: 0 0 10px hsl(var(--color-neon));
-}


### PR DESCRIPTION
## Summary
- load `theme.css` before Tailwind layers
- drop placeholder `:root` overrides to expose cosmic-v2 tokens

## Testing
- `npm run lint`
- `npm test` *(fails: 4 failed, 188 passed | see logs)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system library gobject-2.0 / WebKitWebDriver)*
- `npm run build`

Plan: [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) v0.2.0

------
https://chatgpt.com/codex/tasks/task_e_68a290206e9c8332beb730ba29925f6f