### PR TITLE
UX Stage 02: glass surfaces for UI primitives

### DIFF
--- a/docs/ui-primitives.md
+++ b/docs/ui-primitives.md
@@ -1,0 +1,8 @@
+# UI Primitives
+
+The project exposes simple building blocks that respect design tokens:
+
+- `Panel` and `Toolbar` render glass surfaces with `backdrop-blur-glass` applied.
+- `Card` accepts a `variant` prop (`solid` | `glass`) to switch surfaces while keeping tokenized spacing and radius.
+
+These utilities rely on Tailwind classes mapped to tokens. Use them as starting points for new components.

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
 
-export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'glass' | 'solid';
+}
 
-const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className = '', ...props }, ref) => (
-  <div
-    ref={ref}
-    className={['rounded bg-card text-fg shadow p-md', className].filter(Boolean).join(' ')}
-    {...props}
-  />
-));
+const variantClasses: Record<NonNullable<CardProps['variant']>, string> = {
+  glass: 'bg-glass border border-glass shadow-glass backdrop-blur-glass',
+  solid: 'bg-card text-fg shadow',
+};
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ variant = 'solid', className = '', ...props }, ref) => (
+    <div
+      ref={ref}
+      className={['rounded p-md', variantClasses[variant], className].filter(Boolean).join(' ')}
+      {...props}
+    />
+  ),
+);
 
 Card.displayName = 'Card';
 export default Card;

--- a/src/components/ui/Panel.tsx
+++ b/src/components/ui/Panel.tsx
@@ -5,7 +5,10 @@ export interface PanelProps extends React.HTMLAttributes<HTMLDivElement> {}
 const Panel = React.forwardRef<HTMLDivElement, PanelProps>(({ className = '', ...props }, ref) => (
   <div
     ref={ref}
-    className={['rounded bg-glass border border-glass shadow-glass p-md', className]
+    className={[
+      'rounded bg-glass border border-glass shadow-glass backdrop-blur-glass p-md',
+      className,
+    ]
       .filter(Boolean)
       .join(' ')}
     {...props}

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -7,7 +7,7 @@ const Toolbar = React.forwardRef<HTMLDivElement, ToolbarProps>(
     <div
       ref={ref}
       className={[
-        'flex items-center gap-sm rounded bg-glass border border-glass shadow-glass p-sm',
+        'flex items-center gap-sm rounded bg-glass border border-glass shadow-glass backdrop-blur-glass p-sm',
         className,
       ]
         .filter(Boolean)


### PR DESCRIPTION
# UX Stage 02: glass surfaces for UI primitives

> **Plan adherence:** I read and followed [docs/ux-upgrade-plan.md](../docs/ux-upgrade-plan.md) (plan version: **0.2.0**).
> If not, explain why: _

## Summary

- **Scope:** Add backdrop blur tokens to Panel and Toolbar; Card now supports `glass` or `solid` variants.
- **Motivation:** unify surface styling with tokenized classes.
- **User impact:** subtle glass blur surfaces; Card variants for flexible styling.

## Changes

- [x] New/updated components:
- [ ] Replaced bespoke logic with **Radix** primitives:
- [x] Styling via **Tailwind** tokens/utilities:
- [ ] Motion via **Framer Motion**:
- [ ] Dev-only routes/demos (if any):

## Libraries

- Added/updated packages (with reasons):
  - N/A

## Design Tokens

> All visuals must be token-driven; no hard-coded magic values.

| Token           | Old | New | Notes |
| --------------- | --- | --- | ----- |

## Feature Flags

> Heavy effects off by default.

| Flag                      | Default |
| ------------------------- | ------- |
| effects.particles.enabled | false   |
| effects.three.enabled     | false   |

## Accessibility

- [ ] Radix focus trap/ARIA
- [ ] Keyboard-only verified
- [ ] prefers-reduced-motion respected
- [ ] WCAG AA contrast for all states

## Performance

- [ ] No unnecessary re-renders
- [ ] Heavy effects unmounted when flags off
- [ ] Dev/demo routes lazy-loaded
- Baseline metrics / profiler notes:

## Tests & Docs

- [x] Docs in docs/ (tokens, motion, usage/migration)
- [ ] README updated
- [ ] Minimal tests if sensible

## Migration Notes

- Card variant prop defaults to `solid`; switch to `glass` as needed.

## Screenshots / Demos

> No binary assets. Code-generated previews only.

### Checklist

- [x] No binary assets introduced
- [x] Scope limited to this stage


------
https://chatgpt.com/codex/tasks/task_e_68a29a1159348332b236f93dfd86005c