### PR TITLE
UX Stage 01: glass blur token

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -15,6 +15,7 @@ without changing component markup.
 - `--shadow-neon`: neon glow
 - `--glass-bg` / `--glass-border`: translucent panel surfaces
 - `--shadow-glass`: depth for glass backdrops
+- `--glass-blur`: blur radius for glass backdrops
 - `--radius` / `--radius-sm`: standard and small border radius
 - `--spacing-sm` / `--spacing-md` / `--spacing-lg`: spacing scale
 - `--shadow`: base shadow
@@ -49,6 +50,9 @@ boxShadow: {
   glow: '0 0 8px var(--glow-shadow)',
   glass: 'var(--shadow-glass)',
   neon: 'var(--shadow-neon)'
+},
+backdropBlur: {
+  glass: 'var(--glass-blur)'
 }
 ```
 

--- a/src/App.css
+++ b/src/App.css
@@ -117,8 +117,7 @@ select:focus-visible {
 
 /* Modal Backdrop Blur */
 .modal-backdrop {
-  -webkit-backdrop-filter: blur(5px);
-  backdrop-filter: blur(5px);
+  @apply backdrop-blur-glass;
 }
 
 /* Responsive Design */
@@ -148,8 +147,7 @@ select:focus-visible {
 
 .glass-panel {
   background: var(--panel-bg);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  @apply backdrop-blur-glass;
   border-radius: var(--hud-radius);
   border: 1px solid var(--panel-border);
 }

--- a/src/components/AidInterfereModal.module.css
+++ b/src/components/AidInterfereModal.module.css
@@ -5,8 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
-  -webkit-backdrop-filter: blur(5px);
-  backdrop-filter: blur(5px);
+  @apply backdrop-blur-glass;
   z-index: 1000;
   display: flex;
   align-items: center;

--- a/src/components/CharacterAvatar.module.css
+++ b/src/components/CharacterAvatar.module.css
@@ -1,7 +1,6 @@
 .avatarContainer {
   background: var(--panel-bg);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  @apply backdrop-blur-glass;
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);
   border: 1px solid var(--panel-border);

--- a/src/components/CharacterHUD/Portrait.module.css
+++ b/src/components/CharacterHUD/Portrait.module.css
@@ -1,7 +1,6 @@
 .avatarContainer {
   background: var(--panel-bg);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  @apply backdrop-blur-glass;
   border-radius: 12px;
   padding: var(--hud-spacing);
   border: 1px solid var(--panel-border);

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -1,7 +1,6 @@
 .panel {
   background: var(--panel-bg);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  @apply backdrop-blur-glass;
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);
   border: 1px solid var(--panel-border);

--- a/src/components/DiceRoller.module.css
+++ b/src/components/DiceRoller.module.css
@@ -1,7 +1,6 @@
 .panel {
   background: var(--panel-bg);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  @apply backdrop-blur-glass;
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);
   border: 1px solid var(--panel-border);

--- a/src/components/LastBreathModal.module.css
+++ b/src/components/LastBreathModal.module.css
@@ -5,8 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
-  -webkit-backdrop-filter: blur(5px);
-  backdrop-filter: blur(5px);
+  @apply backdrop-blur-glass;
   z-index: 1000;
   display: flex;
   align-items: center;

--- a/src/components/LevelUpModal.module.css
+++ b/src/components/LevelUpModal.module.css
@@ -5,8 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.9);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
+  @apply backdrop-blur-glass;
   z-index: 1000;
   display: flex;
   align-items: center;

--- a/src/components/RollModal.module.css
+++ b/src/components/RollModal.module.css
@@ -5,8 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
-  -webkit-backdrop-filter: blur(5px);
-  backdrop-filter: blur(5px);
+  @apply backdrop-blur-glass;
   z-index: 1000;
   display: flex;
   align-items: center;

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -1,7 +1,6 @@
 .panel {
   background: var(--panel-bg);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  @apply backdrop-blur-glass;
   border-radius: var(--hud-radius);
   padding: var(--hud-spacing);
   border: 1px solid var(--panel-border);
@@ -102,8 +101,7 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.8);
-  -webkit-backdrop-filter: blur(5px);
-  backdrop-filter: blur(5px);
+  @apply backdrop-blur-glass;
   z-index: 1000;
   display: flex;
   align-items: center;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -122,6 +122,7 @@
   --panel-shadow: rgba(0, 0, 0, 0.3);
   --glass-bg: var(--panel-bg);
   --glass-border: var(--panel-border);
+  --glass-blur: 8px;
   --shadow-glass: 0 8px 32px var(--panel-shadow);
   --shadow-neon: 0 0 10px var(--color-neon);
   --color-bg-primary: var(--panel-bg);
@@ -178,6 +179,7 @@
 :root[data-theme='cosmic-v2'] {
   --glass-bg: hsla(0, 0%, 100%, 0.06);
   --glass-border: hsla(0, 0%, 100%, 0.15);
+  --glass-blur: 12px;
   --shadow-glass: 0 8px 32px rgba(0, 0, 0, 0.4);
   --color-neon: #64f1e1;
   --shadow-neon: 0 0 12px var(--color-neon);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,9 @@ export default {
         glass: 'var(--shadow-glass)',
         neon: 'var(--shadow-neon)',
       },
+      backdropBlur: {
+        glass: 'var(--glass-blur)',
+      },
     },
   },
   plugins: [forms],


### PR DESCRIPTION
## Summary
- add `--glass-blur` variable with tailwind `backdrop-blur-glass`
- document glass blur design token
- refactor overlays and panels to use `backdrop-blur-glass`

## Testing
- `npm run lint`
- `npm test` *(fails: 15 failing tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: cannot find driver binary / glib-2.0.pc)*
- `npm run build`

References:
- [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) v0.2.0

------
https://chatgpt.com/codex/tasks/task_e_68a29a113d1483329a59324c13de0b47