### PR TITLE
UX Stage 02: remove deprecated themes

### DIFF
--- a/docs/hud-theme.md
+++ b/docs/hud-theme.md
@@ -4,20 +4,20 @@ The heads-up display (HUD) uses a small set of CSS custom properties to keep spa
 radius and animation speeds consistent across components. These tokens live in
 [`src/styles/theme.css`](../src/styles/theme.css) and can be overridden per theme.
 
-| Token                   | Description                                    | Default                    | Classic                    | Moebius                      |
-| ----------------------- | ---------------------------------------------- | -------------------------- | -------------------------- | ---------------------------- |
-| `--hud-radius`          | Corner rounding for panels and containers      | `0.75rem`                  | `0.5rem`                   | `0.75rem`                    |
-| `--hud-radius-sm`       | Corner rounding for buttons and small elements | `0.375rem`                 | `0.25rem`                  | `0.375rem`                   |
-| `--hud-spacing`         | Standard padding for panels                    | `1.25rem`                  | `1rem`                     | `1.5rem`                     |
-| `--hud-spacing-sm`      | Compact padding for inner elements             | `0.625rem`                 | `0.5rem`                   | `0.75rem`                    |
-| `--hud-transition-fast` | Quick animations                               | `all 150ms ease-in-out`    | `all 100ms ease-in-out`    | `all 200ms ease-in-out`      |
-| `--hud-transition`      | Default animations                             | `all 300ms ease-in-out`    | `all 250ms ease-in-out`    | `all 350ms ease-in-out`      |
-| `--hud-transition-slow` | Emphasized animations                          | `all 500ms ease-in-out`    | `all 400ms ease-in-out`    | `all 600ms ease-in-out`      |
-| `--font-heading`        | Typeface used for headings                     | `'Montserrat', sans-serif` | `'Georgia', serif`         | `'Trebuchet MS', sans-serif` |
-| `--font-body`           | Typeface used for body text                    | `'Inter', sans-serif`      | `'Times New Roman', serif` | `'Verdana', sans-serif`      |
-| `--space-sm`            | General small spacing                          | `0.5rem`                   | `0.5rem`                   | `0.75rem`                    |
-| `--space-md`            | General medium spacing                         | `1rem`                     | `1rem`                     | `1.5rem`                     |
-| `--space-lg`            | General large spacing                          | `1.5rem`                   | `1.5rem`                   | `2.25rem`                    |
+| Token                   | Description                                    | Default (cosmic-v2 & legacy) |
+| ----------------------- | ---------------------------------------------- | ---------------------------- |
+| `--hud-radius`          | Corner rounding for panels and containers      | `0.75rem`                    |
+| `--hud-radius-sm`       | Corner rounding for buttons and small elements | `0.375rem`                   |
+| `--hud-spacing`         | Standard padding for panels                    | `1.25rem`                    |
+| `--hud-spacing-sm`      | Compact padding for inner elements             | `0.625rem`                   |
+| `--hud-transition-fast` | Quick animations                               | `all 150ms ease-in-out`      |
+| `--hud-transition`      | Default animations                             | `all 300ms ease-in-out`      |
+| `--hud-transition-slow` | Emphasized animations                          | `all 500ms ease-in-out`      |
+| `--font-heading`        | Typeface used for headings                     | `'Montserrat', sans-serif`   |
+| `--font-body`           | Typeface used for body text                    | `'Inter', sans-serif`        |
+| `--space-sm`            | General small spacing                          | `0.5rem`                     |
+| `--space-md`            | General medium spacing                         | `1rem`                       |
+| `--space-lg`            | General large spacing                          | `1.5rem`                     |
 
 Use these tokens within HUD components to guarantee visual consistency:
 
@@ -29,6 +29,5 @@ Use these tokens within HUD components to guarantee visual consistency:
 }
 ```
 
-Light themes such as `classic` and `moebius` override the tokens to provide
-subtle differences in spacing and motion. Custom themes can do the same by
-redefining these variables under their own `[data-theme]` selector.
+Both the default `cosmic-v2` and `legacy` themes share these values. Custom themes can override
+the variables under their own `[data-theme]` selector.

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -2,7 +2,8 @@
 
 These tokens are exposed via CSS variables and mapped into Tailwind for
 utility classes. Themes may override any variable to adjust appearance
-without changing component markup.
+without changing component markup. Currently available themes are `legacy`
+and `cosmic-v2`.
 
 ## CSS Variables
 

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -5,6 +5,10 @@ import { useSettings } from '../state/SettingsContext';
 const Settings = () => {
   const { theme, setTheme, themes } = useTheme();
   const { autoXpOnMiss, setAutoXpOnMiss, showDiagnostics, setShowDiagnostics } = useSettings();
+  const themeLabels = {
+    legacy: 'Legacy',
+    'cosmic-v2': 'Cosmic v2',
+  };
 
   return (
     <div>
@@ -17,7 +21,7 @@ const Settings = () => {
       >
         {themes.map((t) => (
           <option key={t} value={t}>
-            {t.replace('-', ' ')}
+            {themeLabels[t] || t}
           </option>
         ))}
       </select>

--- a/src/state/theme.js
+++ b/src/state/theme.js
@@ -1,3 +1,3 @@
-export const THEMES = ['legacy', 'classic', 'moebius', 'cosmic-v2'];
+export const THEMES = ['legacy', 'cosmic-v2'];
 
 export const DEFAULT_THEME = 'cosmic-v2';


### PR DESCRIPTION
## Summary
- limit theme options to `legacy` and `cosmic-v2`
- label themes in Settings for clarity
- clean up HUD and token docs

## Testing
- `npm run lint`
- `npm test` *(fails: 17 failing tests)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing system deps & driver)*
- `npm run build`

References [docs/ux-upgrade-plan.md](docs/ux-upgrade-plan.md) v0.2.0.

------
https://chatgpt.com/codex/tasks/task_e_68a29a1688c8833289dfe20a2d32b4c7