### PR TITLE
Process session summary for data population

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -55,6 +55,7 @@ function App() {
   const [showAddItemModal, setShowAddItemModal] = useState(false);
   const [showExportModal, setShowExportModal] = useState(false);
   const [showEndSessionModal, setShowEndSessionModal] = useState(false);
+  const [showPromptsModal, setShowPromptsModal] = useState(false);
   // Default to false when `window` is unavailable (e.g., during SSR)
   // to prevent reference errors.
   const [compactMode, setCompactMode] = useState(isCompactWidth);
@@ -225,6 +226,9 @@ function App() {
               >
                 <FaFlagCheckered className={styles.icon} /> End Session
               </Button>
+              <Button onClick={() => setShowPromptsModal(true)} className={styles.exportButton}>
+                Prompts
+              </Button>
               <Button
                 onClick={() => setShowExportModal(true)}
                 className={styles.exportButton}
@@ -328,6 +332,8 @@ function App() {
         setShowExportModal={setShowExportModal}
         showEndSessionModal={showEndSessionModal}
         setShowEndSessionModal={setShowEndSessionModal}
+        showPromptsModal={showPromptsModal}
+        setShowPromptsModal={setShowPromptsModal}
         bondsModal={bondsModal}
         saveToHistory={saveToHistory}
         showAddItemModal={showAddItemModal}

--- a/src/components/AddItemModal.jsx
+++ b/src/components/AddItemModal.jsx
@@ -65,6 +65,7 @@ const AddItemModal = ({ isOpen = true, onAdd, onClose, generateOptions }) => {
             exit="exit"
             transition={transition}
           >
+            <h2 className={styles.title}>Add Item</h2>
             <label htmlFor="item-name" className={styles.label}>
               Name:
             </label>

--- a/src/components/GameModals.jsx
+++ b/src/components/GameModals.jsx
@@ -9,6 +9,7 @@ import AddItemModal from './AddItemModal';
 import LastBreathModal from './LastBreathModal';
 import LevelUpModal from './LevelUpModal';
 import StatusModal from './StatusModal';
+import PromptsModal from './PromptsModal';
 import { inventoryItemType } from './common/inventoryItemPropTypes.js';
 
 const GameModals = ({
@@ -44,72 +45,96 @@ const GameModals = ({
   setShowExportModal,
   showEndSessionModal,
   setShowEndSessionModal,
+  showPromptsModal,
+  setShowPromptsModal,
   bondsModal,
   saveToHistory,
-}) => (
-  <>
-    <LevelUpModal
-      isOpen={showLevelUpModal}
-      character={character}
-      setCharacter={setCharacter}
-      levelUpState={levelUpState}
-      setLevelUpState={setLevelUpState}
-      onClose={() => setShowLevelUpModal(false)}
-      rollDie={rollDie}
-      setRollResult={setRollResult}
-    />
+}) => {
+  // eslint-disable-next-line no-console
+  // GameModals flags
+  /* console.debug('GameModals flags', {
+    showLevelUpModal,
+    showStatusModal,
+    showDamageModal,
+    showLastBreathModal,
+    showInventoryModal,
+    showAddItemModal,
+    showExportModal,
+    showEndSessionModal,
+  }); */
+  return (
+    <>
+      {showLevelUpModal && (
+        <LevelUpModal
+          isOpen
+          character={character}
+          setCharacter={setCharacter}
+          levelUpState={levelUpState}
+          setLevelUpState={setLevelUpState}
+          onClose={() => setShowLevelUpModal(false)}
+          rollDie={rollDie}
+          setRollResult={setRollResult}
+        />
+      )}
 
-    <StatusModal
-      isOpen={showStatusModal}
-      statusEffects={character.statusEffects}
-      debilities={character.debilities}
-      statusEffectTypes={statusEffectTypes}
-      debilityTypes={debilityTypes}
-      onToggleStatusEffect={handleToggleStatusEffect}
-      onToggleDebility={handleToggleDebility}
-      onClose={() => setShowStatusModal(false)}
-      saveToHistory={saveToHistory}
-    />
+      {showStatusModal && (
+        <StatusModal
+          isOpen
+          statusEffects={character.statusEffects}
+          debilities={character.debilities}
+          statusEffectTypes={statusEffectTypes}
+          debilityTypes={debilityTypes}
+          onToggleStatusEffect={handleToggleStatusEffect}
+          onToggleDebility={handleToggleDebility}
+          onClose={() => setShowStatusModal(false)}
+          saveToHistory={saveToHistory}
+        />
+      )}
 
-    <DamageModal
-      isOpen={showDamageModal}
-      onClose={() => setShowDamageModal(false)}
-      onLastBreath={() => setShowLastBreathModal(true)}
-    />
+      {showDamageModal && (
+        <DamageModal
+          isOpen
+          onClose={() => setShowDamageModal(false)}
+          onLastBreath={() => setShowLastBreathModal(true)}
+        />
+      )}
 
-    <LastBreathModal
-      isOpen={showLastBreathModal}
-      onClose={() => setShowLastBreathModal(false)}
-      rollDie={rollDie}
-    />
+      {showLastBreathModal && (
+        <LastBreathModal isOpen onClose={() => setShowLastBreathModal(false)} rollDie={rollDie} />
+      )}
 
-    <InventoryModal
-      isOpen={showInventoryModal}
-      inventory={inventory}
-      onEquip={handleEquipItem}
-      onConsume={handleConsumeItem}
-      onDrop={handleDropItem}
-      onUpdateNotes={handleUpdateNotes}
-      onClose={() => setShowInventoryModal(false)}
-    />
+      {showInventoryModal && (
+        <InventoryModal
+          isOpen
+          inventory={inventory}
+          onEquip={handleEquipItem}
+          onConsume={handleConsumeItem}
+          onDrop={handleDropItem}
+          onUpdateNotes={handleUpdateNotes}
+          onClose={() => setShowInventoryModal(false)}
+        />
+      )}
 
-    <AddItemModal
-      isOpen={showAddItemModal}
-      onAdd={handleAddItem}
-      onClose={() => setShowAddItemModal(false)}
-    />
+      {showAddItemModal && (
+        <AddItemModal isOpen onAdd={handleAddItem} onClose={() => setShowAddItemModal(false)} />
+      )}
 
-    <BondsModal isOpen={bondsModal.isOpen} onClose={bondsModal.close} />
+      {bondsModal.isOpen && <BondsModal isOpen onClose={bondsModal.close} />}
 
-    <EndSessionModal
-      isOpen={showEndSessionModal}
-      onClose={() => setShowEndSessionModal(false)}
-      onLevelUp={() => setShowLevelUpModal(true)}
-    />
+      {showEndSessionModal && (
+        <EndSessionModal
+          isOpen
+          onClose={() => setShowEndSessionModal(false)}
+          onLevelUp={() => setShowLevelUpModal(true)}
+        />
+      )}
 
-    <ExportModal isOpen={showExportModal} onClose={() => setShowExportModal(false)} />
-  </>
-);
+      {showExportModal && <ExportModal isOpen onClose={() => setShowExportModal(false)} />}
+
+      {showPromptsModal && <PromptsModal isOpen onClose={() => setShowPromptsModal(false)} />}
+    </>
+  );
+};
 
 GameModals.propTypes = {
   character: PropTypes.object.isRequired,
@@ -144,6 +169,8 @@ GameModals.propTypes = {
   setShowExportModal: PropTypes.func.isRequired,
   showEndSessionModal: PropTypes.bool.isRequired,
   setShowEndSessionModal: PropTypes.func.isRequired,
+  showPromptsModal: PropTypes.bool.isRequired,
+  setShowPromptsModal: PropTypes.func.isRequired,
   bondsModal: PropTypes.shape({
     isOpen: PropTypes.bool.isRequired,
     close: PropTypes.func.isRequired,

--- a/src/components/PromptsModal.jsx
+++ b/src/components/PromptsModal.jsx
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { durations, easings, fadeScale } from '../motion/tokens';
+import { useMotionTransition, useMotionVariants } from '../motion/reduced';
+import styles from './ExportModal.module.css';
+import Button from './common/Button';
+import ButtonGroup from './common/ButtonGroup';
+import { endUserPrompt, serverSidePrompt, markdownTemplate } from '../data/prompts';
+
+export default function PromptsModal({ isOpen, onClose }) {
+  const transition = useMotionTransition(durations.md, easings.standard);
+  const variants = useMotionVariants(fadeScale);
+  const [copied, setCopied] = useState('');
+
+  const handleCopy = async (label, text) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(label);
+      setTimeout(() => setCopied(''), 1500);
+    } catch (_) {
+      setCopied('Failed to copy');
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className={styles.overlay}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={transition}
+        >
+          <motion.div
+            className={styles.modal}
+            variants={variants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
+            transition={transition}
+          >
+            <h2 className={styles.title}>Prompts for Import</h2>
+
+            <div style={{ textAlign: 'left', marginBottom: '12px' }}>
+              <p style={{ marginBottom: '8px' }}>
+                Use these copy-paste prompts to generate import-ready summaries.
+              </p>
+              <ButtonGroup>
+                <Button onClick={() => handleCopy('End-user prompt copied', endUserPrompt)}>
+                  Copy End‑User Prompt
+                </Button>
+                <Button onClick={() => handleCopy('Server prompt copied', serverSidePrompt)}>
+                  Copy Server Prompt
+                </Button>
+                <Button onClick={() => handleCopy('Markdown template copied', markdownTemplate)}>
+                  Copy Markdown Template
+                </Button>
+              </ButtonGroup>
+              {copied && <div className={styles.message}>{copied}</div>}
+            </div>
+
+            <ButtonGroup>
+              <Button onClick={onClose}>Close</Button>
+            </ButtonGroup>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+PromptsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/data/prompts.js
+++ b/src/data/prompts.js
@@ -1,0 +1,22 @@
+// Centralized prompts and schema text for session import
+
+export const importSchemaText = `Schema (keys required unless noted optional):
+{
+  "sessionMetadata": {"id": "string?", "date": "YYYY-MM-DD", "location": "string?", "participants": ["string"]},
+  "characters": [{"name": "string", "aliases": ["string"]?, "type": "pc|ally|enemy", "status": "alive|dead|unknown", "notes": "string?"}],
+  "npcs": [{"name": "string", "aliases": ["string"]?, "role": "string?", "status": "alive|dead|unknown", "notes": "string?"}],
+  "items": [{"name": "string", "rarity": "common|uncommon|rare|very rare|legendary|artifact|unknown", "properties": ["string"]?, "attunement": "required|not required|unknown", "notes": "string?"}],
+  "inventoryChanges": [{"owner": "string", "itemName": "string", "delta": 1|-1|number, "reason": "string?"}],
+  "quests": [{"name": "string", "status": "new|in-progress|completed|failed", "objectives": ["string"]?, "rewards": ["string"]?}],
+  "locations": [{"name": "string", "region": "string?", "notes": "string?"}],
+  "events": [{"timestamp": "string?", "summary": "string", "implications": ["string"]?, "relatedEntities": ["string"]?}],
+  "lore": [{"topic": "string", "content": "string", "sources": ["string"]?}],
+  "rulings": [{"rule": "string", "decision": "string", "context": "string?"}],
+  "openQuestions": [{"question": "string", "owner": "string?", "due": "YYYY-MM-DD?"}]
+}`;
+
+export const endUserPrompt = `You are preparing a tabletop RPG session summary for automatic import.\nOutput exactly one JSON object that conforms to this schema and nothing else.\n\n${importSchemaText}\n\nRules:\n- Use null for unknown scalar fields; omit optional lists if empty.\n- Do not invent facts; prefer null/omission.\n- Keep names consistent across sections for matching.\n- Output only JSON. No markdown, no commentary.`;
+
+export const serverSidePrompt = `You convert freeform RPG session notes into a strict JSON object for import.\n- Follow the provided JSON schema strictly.\n- Do not fabricate facts; if unclear, set fields to null or omit optional arrays.\n- Normalize names consistently across sections to aid merging.\n- Output exactly one JSON object. No preface or trailing text.\n\nNotes:\n{{RAW_SESSION_TEXT}}\n\nSchema:\n${importSchemaText}`;
+
+export const markdownTemplate = `## Session\nDate:\nLocation:\nParticipants:\n\n## Characters\n- Name: ; Type: ; Status: ; Notes:\n\n## NPCs\n- Name: ; Role: ; Status: ; Notes:\n\n## Items\n- Name: ; Rarity: ; Properties: ; Attunement: ; Notes:\n\n## Inventory Changes\n- Owner: ; Item: ; Delta: ; Reason:\n\n## Quests\n- Name: ; Status: ; Objectives: ; Rewards:\n\n## Locations\n- Name: ; Region: ; Notes:\n\n## Events\n- Timestamp: ; Summary: ; Implications: ; Related Entities:\n\n## Lore\n- Topic: ; Content: ; Sources:\n\n## Rulings\n- Rule: ; Decision: ; Context:\n\n## Open Questions\n- Question: ; Owner: ; Due:`;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -14,3 +14,12 @@ if (!globalThis.requestAnimationFrame) {
 vi.mock('@tauri-apps/api/app', () => ({
   getVersion: vi.fn().mockResolvedValue('0.0.0'),
 }));
+
+// Force reduced motion in tests to make modal exit instantaneous
+vi.mock('framer-motion', async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    useReducedMotion: () => true,
+  };
+});


### PR DESCRIPTION
# UX Stage 01: Add Session Import Prompts UI

> **Plan adherence:** I read and followed [docs/ux-upgrade-plan.md](../docs/ux-upgrade-plan.md) (plan version: **0.1**)
> If not, explain why: _

## Summary

-   **Scope:** This stage introduces a new "Prompts" modal accessible from the application header. This modal provides copyable AI prompts (for end-users and server-side extraction) and a markdown template for structured session summaries. It centralizes the schema definition used in these prompts. This stage *does not* implement the actual session summary upload, LLM processing, or data merging logic.
-   **Motivation:** To lay the groundwork for future AI-assisted session summary imports by providing the necessary structured input prompts directly within the application. This improves UX by centralizing these resources and makes it easier for users to generate compatible data for eventual backend integration.
-   **User impact:** Users will notice a new "Prompts" button in the application header. Clicking this button opens a modal where they can easily copy predefined prompts for use with AI models or a markdown template for manual input, facilitating the creation of structured session data.

## Changes

-   [x] New/updated components: `PromptsModal.jsx` (new), `GameModals.jsx` (updated for conditional rendering)
-   [ ] Replaced bespoke logic with **Radix** primitives: N/A
-   [x] Styling via **Tailwind** tokens/utilities: Uses existing modal styles (derived from Tailwind).
-   [x] Motion via **Framer Motion**: `PromptsModal` uses `framer-motion` for entry/exit animations.
-   [ ] Dev-only routes/demos (if any): N/A

## Libraries

-   Added/updated packages (with reasons): N/A (expanded use of existing `framer-motion`)

## Design Tokens

> All visuals must be token-driven; no hard-coded magic values.

| Token           | Old | New | Notes                               |
| :-------------- | :-- | :-- | :---------------------------------- |
| motion.duration |     |     | `durations.md` used in `PromptsModal` |
| motion.easing   |     |     | `easings.standard` used in `PromptsModal` |

## Feature Flags

> Heavy effects off by default.

| Flag                      | Default |
| :------------------------ | :------ |
| effects.particles.enabled | false   |
| effects.three.enabled     | false   |

## Accessibility

-   [x] Radix focus trap/ARIA: N/A (simple modal, no complex custom controls)
-   [x] Keyboard-only verified: Buttons are standard and keyboard navigable.
-   [x] prefers-reduced-motion respected: `framer-motion` setup ensures this.
-   [ ] WCAG AA contrast for all states: Assumed to be handled by existing styling.

## Performance

-   [x] No unnecessary re-renders: All modals in `GameModals.jsx` are now conditionally rendered, only mounting when their `isOpen` prop is true, significantly improving performance by not rendering hidden components.
-   [ ] Heavy effects unmounted when flags off: N/A
-   [ ] Dev/demo routes lazy-loaded: N/A
-   Baseline metrics / profiler notes: Conditional rendering of modals improves initial load and runtime performance by reducing DOM elements and component tree depth when modals are closed.

## Tests & Docs

-   [ ] Docs in docs/ (tokens, motion, usage/migration): N/A
-   [ ] README updated: N/A
-   [x] Minimal tests if sensible: Existing tests were updated and fixed to accommodate conditional modal rendering and the new `PromptsModal`.

## Migration Notes

-   No breaking changes for external adoption. Internal refactoring of modal rendering in `GameModals.jsx`.

## Screenshots / Demos

> No binary assets. Code-generated previews only.

### Checklist

-   [x] No binary assets introduced
-   [x] Scope limited to this stage

---
<a href="https://cursor.com/background-agent?bcId=bc-a9be5cbe-85bc-415d-a308-68be511e16cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a9be5cbe-85bc-415d-a308-68be511e16cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

