### PR TITLE
Move dice roller to a pop-up

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ import {
 } from 'react-icons/fa6';
 import CharacterStats from './components/CharacterStats';
 import DiceRoller from './components/DiceRoller';
+import FloatingDiceButton from './components/FloatingDiceButton';
+import DiceRollerModal from './components/DiceRollerModal';
 import GameModals from './components/GameModals';
 import InventoryPanel from './components/InventoryPanel';
 import SessionNotes from './components/SessionNotes';
@@ -68,6 +70,7 @@ function App() {
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const [showVersionsModal, setShowVersionsModal] = useState(false);
   const [showPrint, setShowPrint] = useState(false);
+  const [showDiceRollerModal, setShowDiceRollerModal] = useState(false);
   const [versions, setVersions] = useState(() => {
     try {
       const raw = localStorage.getItem('characterVersions');
@@ -363,20 +366,6 @@ function App() {
             />
           </div>
 
-          {/* Dice Roller Panel (component-based, main branch design) */}
-          <div className={styles.dice}>
-            <DiceRoller
-              character={character}
-              rollDice={rollDice}
-              rollResult={rollResult}
-              rollHistory={rollHistory}
-              equippedWeaponDamage={equippedWeaponDamage}
-              rollModal={rollModal}
-              rollModalData={rollModalData}
-              aidModal={aidModal}
-            />
-          </div>
-
           {/* Quick Inventory Panel */}
           <div className={styles.inventory}>
             <InventoryPanel
@@ -456,6 +445,11 @@ function App() {
           },
           { id: 'open-bonds', label: 'Open Bonds', action: () => bondsModal.open() },
           {
+            id: 'open-dice-roller',
+            label: 'Open Dice Roller',
+            action: () => setShowDiceRollerModal(true),
+          },
+          {
             id: 'open-end-session',
             label: 'End Session',
             action: () => setShowEndSessionModal(true),
@@ -510,6 +504,26 @@ function App() {
           </div>
         </div>
       )}
+      {/* Floating Dice Button */}
+      <FloatingDiceButton
+        onClick={() => setShowDiceRollerModal(true)}
+        isOpen={showDiceRollerModal}
+      />
+
+      {/* Dice Roller Modal */}
+      <DiceRollerModal
+        isOpen={showDiceRollerModal}
+        onClose={() => setShowDiceRollerModal(false)}
+        character={character}
+        rollDice={rollDice}
+        rollResult={rollResult}
+        rollHistory={rollHistory}
+        equippedWeaponDamage={equippedWeaponDamage}
+        rollModal={rollModal}
+        rollModalData={rollModalData}
+        aidModal={aidModal}
+      />
+
       {PerformanceHud && (
         <Suspense fallback={null}>
           <PerformanceHud />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -98,6 +98,12 @@ describe('XP gain on miss', () => {
       </Wrapper>,
     );
 
+    // First open the dice roller modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    act(() => {
+      fireEvent.click(diceButton);
+    });
+
     const button = screen.getByRole('button', { name: 'Roll INT Check' });
 
     act(() => {
@@ -120,6 +126,12 @@ describe('XP gain on miss', () => {
         <App />
       </Wrapper>,
     );
+
+    // First open the dice roller modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    act(() => {
+      fireEvent.click(diceButton);
+    });
 
     const button = screen.getByRole('button', { name: 'Roll INT Check' });
     act(() => {

--- a/src/components/DiceRollerModal.jsx
+++ b/src/components/DiceRollerModal.jsx
@@ -1,0 +1,277 @@
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import styles from './DiceRollerModal.module.css';
+import RollModal from './RollModal';
+import AidInterfereModal from './AidInterfereModal';
+import safeLocalStorage from '../utils/safeLocalStorage.js';
+
+const DiceRollerModal = ({
+  isOpen,
+  onClose,
+  character,
+  rollDice,
+  rollResult,
+  rollHistory,
+  equippedWeaponDamage,
+  rollModal,
+  rollModalData,
+  aidModal,
+}) => {
+  const [isRolling, setIsRolling] = useState(false);
+  const [animate, setAnimate] = useState(false);
+  const [presets, setPresets] = useState(() => {
+    const saved = safeLocalStorage.getItem('rollPresets');
+    if (!saved) return [];
+    try {
+      const parsed = JSON.parse(saved);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  });
+  const [presetName, setPresetName] = useState('');
+  const [presetFormula, setPresetFormula] = useState('');
+
+  const handleRoll = (expr, label) => {
+    setIsRolling(true);
+    if (label !== undefined) {
+      rollDice(expr, label);
+    } else {
+      rollDice(expr);
+    }
+    setTimeout(() => {
+      setIsRolling(false);
+      setAnimate(true);
+    }, 350);
+  };
+
+  useEffect(() => {
+    if (presets.length > 0) {
+      safeLocalStorage.setItem('rollPresets', JSON.stringify(presets));
+    } else {
+      safeLocalStorage.removeItem('rollPresets');
+    }
+  }, [presets]);
+
+  const addPreset = () => {
+    const name = presetName.trim();
+    const formula = presetFormula.trim();
+    if (!name || !/^\d*d\d+(?:[+-]\d+)?$/i.test(formula)) return;
+    setPresets((prev) => {
+      const next = [...prev.filter((p) => p.name !== name), { name, formula }];
+      return next.slice(0, 12);
+    });
+    setPresetName('');
+    setPresetFormula('');
+  };
+
+  const removePreset = (name) => {
+    setPresets((prev) => prev.filter((p) => p.name !== name));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div className={styles.overlay} onClick={onClose} role="presentation">
+        <div
+          className={styles.modal}
+          onClick={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className={styles.header}>
+            <h3 className={styles.title}>🎲 Dice Roller</h3>
+            <button className={styles.closeButton} onClick={onClose} aria-label="Close dice roller">
+              ×
+            </button>
+          </div>
+
+          <div className={styles.content}>
+            {/* Stat Check Buttons */}
+            <div className={styles.section}>
+              <h4 className={styles.subtitle}>Stat Checks</h4>
+              <div className={styles.statGrid}>
+                {Object.entries(character.stats).map(([stat, data]) => (
+                  <button
+                    key={stat}
+                    onClick={() => handleRoll(`2d6+${data.mod}`, `${stat} Check`)}
+                    className={`${styles.button} ${styles.purple} ${styles.small}`}
+                    aria-label={`Roll ${stat} Check`}
+                  >
+                    {stat} ({data.mod >= 0 ? '+' : ''}
+                    {data.mod})
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Combat Rolls */}
+            <div className={styles.section}>
+              <h4 className={styles.subtitle}>Combat Rolls</h4>
+              <div className={styles.combatGrid}>
+                <button
+                  onClick={() => rollDice(equippedWeaponDamage, 'Weapon Damage')}
+                  className={`${styles.button} ${styles.red} ${styles.small}`}
+                  aria-label={`Roll weapon damage ${equippedWeaponDamage}`}
+                >
+                  Weapon ({equippedWeaponDamage})
+                </button>
+                <button
+                  onClick={() => rollDice('2d6+3', 'Hack & Slash')}
+                  className={`${styles.button} ${styles.purple} ${styles.small}`}
+                  aria-label="Roll Hack & Slash"
+                >
+                  Hack & Slash
+                </button>
+                <button
+                  onClick={() => rollDice('d4', 'Upper Hand')}
+                  className={`${styles.button} ${styles.orange} ${styles.small}`}
+                  aria-label="Roll Upper Hand d4"
+                >
+                  Upper Hand d4
+                </button>
+                <button
+                  onClick={() => rollDice('2d6-1', 'Taunt')}
+                  className={`${styles.button} ${styles.amber} ${styles.small}`}
+                  aria-label="Roll Taunt Enemy"
+                >
+                  Taunt Enemy
+                </button>
+                <button
+                  onClick={() => rollDice('2d6', 'Aid/Interfere')}
+                  className={`${styles.button} ${styles.purple} ${styles.small}`}
+                  aria-label="Roll Aid or Interfere"
+                >
+                  Aid/Interfere
+                </button>
+              </div>
+            </div>
+
+            {/* Basic Dice */}
+            <div className={styles.section}>
+              <h4 className={styles.subtitle}>Basic Dice</h4>
+              <div className={styles.basicGrid}>
+                {[4, 6, 8, 10, 12, 20].map((sides) => (
+                  <button
+                    key={sides}
+                    onClick={() => handleRoll(`d${sides}`)}
+                    className={`${styles.button} ${styles.cyan} ${styles.tiny}`}
+                    aria-label={`Roll d${sides}`}
+                  >
+                    {`d${sides}`}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Roll Presets */}
+            <div className={styles.section}>
+              <h4 className={styles.subtitle}>Roll Presets</h4>
+              {presets.length > 0 && (
+                <div className={styles.combatGrid}>
+                  {presets.map((p) => (
+                    <div key={p.name} className={styles.presetItem}>
+                      <button
+                        onClick={() => handleRoll(p.formula, p.name)}
+                        className={`${styles.button} ${styles.purple} ${styles.small}`}
+                        aria-label={`Roll preset ${p.name}`}
+                      >
+                        {p.name}
+                      </button>
+                      <button
+                        className={`${styles.button} ${styles.tiny}`}
+                        aria-label={`Remove preset ${p.name}`}
+                        onClick={() => removePreset(p.name)}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className={styles.presetForm}>
+                <input
+                  placeholder="Name (e.g., Volley)"
+                  value={presetName}
+                  onChange={(e) => setPresetName(e.target.value)}
+                  className={styles.input}
+                  aria-label="Preset name"
+                />
+                <input
+                  placeholder="Formula (e.g., 2d6+DEX)"
+                  value={presetFormula}
+                  onChange={(e) => setPresetFormula(e.target.value)}
+                  className={styles.input}
+                  aria-label="Preset formula"
+                />
+                <button
+                  onClick={addPreset}
+                  className={`${styles.button} ${styles.green} ${styles.small}`}
+                  aria-label="Add preset"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+
+            {/* Roll Result Display */}
+            <div
+              className={`${styles.resultBox} ${animate ? styles.pop : ''}`}
+              onAnimationEnd={() => setAnimate(false)}
+              aria-live="polite"
+            >
+              {isRolling ? 'rolling…' : rollResult}
+            </div>
+
+            {/* Roll History */}
+            {rollHistory.length > 0 && (
+              <div className={styles.history}>
+                <div className={styles.historyTitle}>Recent Rolls:</div>
+                {rollHistory.slice(0, 3).map((roll) => (
+                  <div key={roll.timestamp} className={styles.historyItem}>
+                    <span className={styles.historyTime}>
+                      {new Date(roll.timestamp).toLocaleTimeString()}
+                    </span>
+                    {' - '}
+                    {roll.result}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <RollModal isOpen={rollModal.isOpen} data={rollModalData} onClose={rollModal.close} />
+      <AidInterfereModal
+        isOpen={aidModal.isOpen}
+        onConfirm={aidModal.onConfirm}
+        onCancel={aidModal.onCancel}
+      />
+    </>
+  );
+};
+
+DiceRollerModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  character: PropTypes.shape({
+    stats: PropTypes.object.isRequired,
+  }).isRequired,
+  rollDice: PropTypes.func.isRequired,
+  rollResult: PropTypes.string.isRequired,
+  rollHistory: PropTypes.arrayOf(PropTypes.object).isRequired,
+  equippedWeaponDamage: PropTypes.string.isRequired,
+  rollModal: PropTypes.shape({
+    isOpen: PropTypes.bool.isRequired,
+    close: PropTypes.func.isRequired,
+  }).isRequired,
+  rollModalData: PropTypes.object.isRequired,
+  aidModal: PropTypes.shape({
+    isOpen: PropTypes.bool.isRequired,
+    onConfirm: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+export default DiceRollerModal;

--- a/src/components/DiceRollerModal.module.css
+++ b/src/components/DiceRollerModal.module.css
@@ -1,0 +1,281 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  padding: 20px;
+}
+
+.modal {
+  background: var(--panel-bg);
+  backdrop-filter: blur(10px);
+  border-radius: var(--hud-radius);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 16px 64px var(--panel-shadow);
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--hud-spacing);
+  border-bottom: 1px solid var(--panel-border);
+  background: rgba(var(--color-accent-rgb), 0.1);
+}
+
+.title {
+  color: var(--color-accent);
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: var(--color-gray-400);
+  font-size: 24px;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.closeButton:hover {
+  color: var(--color-accent);
+  background: rgba(var(--color-accent-rgb), 0.1);
+}
+
+.content {
+  padding: var(--hud-spacing);
+  overflow-y: auto;
+  flex: 1;
+}
+
+.section {
+  margin-bottom: var(--space-md);
+}
+
+.subtitle {
+  color: var(--color-accent);
+  margin-bottom: var(--space-md);
+  font-size: 1rem;
+}
+
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 5px;
+}
+
+.combatGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 5px;
+}
+
+.basicGrid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 5px;
+}
+
+.button {
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
+  border: none;
+  border-radius: var(--hud-radius-sm);
+  color: var(--color-white);
+  padding: var(--space-sm) 15px;
+  cursor: pointer;
+  font-weight: bold;
+  transition: var(--hud-transition);
+  margin: var(--space-sm);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.small {
+  padding: var(--space-sm) 6px;
+  margin: 2px;
+  font-size: 11px;
+}
+
+.tiny {
+  padding: var(--space-sm) 4px;
+  margin: 2px;
+  font-size: 11px;
+}
+
+.red {
+  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
+}
+
+.purple {
+  background: linear-gradient(45deg, var(--color-purple), var(--color-purple-dark));
+}
+
+.orange {
+  background: linear-gradient(45deg, var(--color-warning), var(--color-warning-dark));
+}
+
+.amber {
+  background: linear-gradient(45deg, var(--color-warning-light), var(--color-warning));
+}
+
+.cyan {
+  background: linear-gradient(45deg, var(--color-info), var(--color-info-dark));
+}
+
+.green {
+  background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
+}
+
+.presetItem {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.presetForm {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.input {
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--hud-radius-sm);
+  padding: var(--space-sm);
+  color: var(--color-text);
+  font-size: 12px;
+  flex: 1;
+  min-width: 120px;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.resultBox {
+  background: rgba(var(--color-accent-rgb), 0.2);
+  padding: var(--hud-spacing-sm);
+  border-radius: var(--hud-radius-sm);
+  text-align: center;
+  font-weight: bold;
+  min-height: 40px;
+  min-width: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: var(--space-md) 0;
+}
+
+.history {
+  margin-top: var(--space-md);
+  font-size: 0.8rem;
+}
+
+.historyTitle {
+  color: var(--color-accent);
+  margin-bottom: var(--space-md);
+}
+
+.historyItem {
+  color: var(--color-gray-400);
+  margin-bottom: 2px;
+}
+
+.historyTime {
+  color: var(--color-accent);
+}
+
+@keyframes resultPop {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.pop {
+  animation: resultPop 0.3s ease;
+}
+
+@keyframes criticalShake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-2px);
+  }
+  75% {
+    transform: translateX(2px);
+  }
+}
+
+.critical {
+  animation: criticalShake 0.4s ease-in-out;
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    padding: 10px;
+  }
+
+  .modal {
+    max-height: 95vh;
+  }
+
+  .content {
+    padding: var(--space-md);
+  }
+
+  .statGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .combatGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .basicGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .presetForm {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .input {
+    min-width: auto;
+  }
+}

--- a/src/components/DiceRollerModal.test.jsx
+++ b/src/components/DiceRollerModal.test.jsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import DiceRollerModal from './DiceRollerModal';
+
+// Mock the child components
+vi.mock('./RollModal', () => ({
+  default: ({ isOpen }) => (isOpen ? <div data-testid="roll-modal">Roll Modal</div> : null),
+}));
+
+vi.mock('./AidInterfereModal', () => ({
+  default: ({ isOpen }) => (isOpen ? <div data-testid="aid-modal">Aid Modal</div> : null),
+}));
+
+describe('DiceRollerModal', () => {
+  let mockProps;
+
+  beforeEach(() => {
+    mockProps = {
+      isOpen: true,
+      onClose: vi.fn(),
+      character: {
+        stats: {
+          STR: { mod: 1 },
+          DEX: { mod: 2 },
+          CON: { mod: 0 },
+        },
+      },
+      rollDice: vi.fn(),
+      rollResult: 'Roll result: 12',
+      rollHistory: [{ timestamp: Date.now(), result: 'Previous roll: 10' }],
+      equippedWeaponDamage: 'd8',
+      rollModal: { isOpen: false, close: vi.fn() },
+      rollModalData: {},
+      aidModal: { isOpen: false, onConfirm: vi.fn(), onCancel: vi.fn() },
+    };
+  });
+
+  it('renders when isOpen is true', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    expect(screen.getByText('🎲 Dice Roller')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close dice roller' })).toBeInTheDocument();
+  });
+
+  it('does not render when isOpen is false', () => {
+    render(<DiceRollerModal {...mockProps} isOpen={false} />);
+
+    expect(screen.queryByText('🎲 Dice Roller')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    const closeButton = screen.getByRole('button', { name: 'Close dice roller' });
+    fireEvent.click(closeButton);
+
+    expect(mockProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when overlay is clicked', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    const overlay = screen.getByRole('presentation');
+    fireEvent.click(overlay);
+
+    expect(mockProps.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose when modal content is clicked', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    const modal = screen.getByRole('dialog');
+    fireEvent.click(modal);
+
+    expect(mockProps.onClose).not.toHaveBeenCalled();
+  });
+
+  it('displays stat check buttons', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    expect(screen.getByRole('button', { name: 'Roll STR Check' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll DEX Check' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Roll CON Check' })).toBeInTheDocument();
+  });
+
+  it('displays roll result', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    expect(screen.getByText('Roll result: 12')).toBeInTheDocument();
+  });
+
+  it('displays roll history', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    expect(screen.getByText('Recent Rolls:')).toBeInTheDocument();
+    expect(screen.getByText(/Previous roll: 10/)).toBeInTheDocument();
+  });
+});

--- a/src/components/FloatingDiceButton.jsx
+++ b/src/components/FloatingDiceButton.jsx
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styles from './FloatingDiceButton.module.css';
+
+const FloatingDiceButton = ({ onClick, isOpen }) => {
+  return (
+    <button
+      className={`${styles.floatingButton} ${isOpen ? styles.active : ''}`}
+      onClick={onClick}
+      aria-label="Open dice roller"
+      title="Dice Roller"
+    >
+      <span className={styles.diceIcon}>🎲</span>
+    </button>
+  );
+};
+
+FloatingDiceButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+};
+
+export default FloatingDiceButton;

--- a/src/components/FloatingDiceButton.module.css
+++ b/src/components/FloatingDiceButton.module.css
@@ -1,0 +1,50 @@
+.floatingButton {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
+  border: 2px solid var(--panel-border);
+  box-shadow: 0 8px 32px var(--panel-shadow);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease;
+  z-index: 1000;
+  backdrop-filter: blur(10px);
+}
+
+.floatingButton:hover {
+  transform: scale(1.1);
+  box-shadow: 0 12px 40px var(--panel-shadow);
+}
+
+.floatingButton:active {
+  transform: scale(0.95);
+}
+
+.floatingButton.active {
+  background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
+  transform: scale(1.1);
+}
+
+.diceIcon {
+  font-size: 24px;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.3));
+}
+
+@media (max-width: 768px) {
+  .floatingButton {
+    bottom: 15px;
+    right: 15px;
+    width: 50px;
+    height: 50px;
+  }
+
+  .diceIcon {
+    font-size: 20px;
+  }
+}

--- a/src/components/FloatingDiceButton.test.jsx
+++ b/src/components/FloatingDiceButton.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import FloatingDiceButton from './FloatingDiceButton';
+
+describe('FloatingDiceButton', () => {
+  it('renders with dice icon', () => {
+    const mockOnClick = vi.fn();
+    render(<FloatingDiceButton onClick={mockOnClick} isOpen={false} />);
+
+    expect(screen.getByRole('button', { name: 'Open dice roller' })).toBeInTheDocument();
+    expect(screen.getByText('🎲')).toBeInTheDocument();
+  });
+
+  it('calls onClick when clicked', () => {
+    const mockOnClick = vi.fn();
+    render(<FloatingDiceButton onClick={mockOnClick} isOpen={false} />);
+
+    const button = screen.getByRole('button', { name: 'Open dice roller' });
+    fireEvent.click(button);
+
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies active class when isOpen is true', () => {
+    const mockOnClick = vi.fn();
+    render(<FloatingDiceButton onClick={mockOnClick} isOpen={true} />);
+
+    const button = screen.getByRole('button', { name: 'Open dice roller' });
+    expect(button.className).toContain('active');
+  });
+
+  it('has correct accessibility attributes', () => {
+    const mockOnClick = vi.fn();
+    render(<FloatingDiceButton onClick={mockOnClick} isOpen={false} />);
+
+    const button = screen.getByRole('button', { name: 'Open dice roller' });
+    expect(button).toHaveAttribute('aria-label', 'Open dice roller');
+    expect(button).toHaveAttribute('title', 'Dice Roller');
+  });
+});

--- a/src/components/FloatingDiceIntegration.test.jsx
+++ b/src/components/FloatingDiceIntegration.test.jsx
@@ -1,0 +1,236 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import App from '../App';
+import { CharacterProvider } from '../state/CharacterContext';
+import { SettingsProvider } from '../state/SettingsContext';
+import { ThemeProvider } from '../state/ThemeContext';
+
+// Mock Math.random for predictable dice rolls
+const mockMath = Object.create(global.Math);
+mockMath.random = () => 0.5; // This will give us predictable results
+global.Math = mockMath;
+
+// Mock localStorage
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+global.localStorage = localStorageMock;
+
+// Mock safeLocalStorage
+vi.mock('../utils/safeLocalStorage.js', () => ({
+  default: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+describe('Floating Dice Integration', () => {
+  const user = userEvent.setup();
+
+  const renderApp = () => {
+    return render(
+      <ThemeProvider>
+        <SettingsProvider>
+          <CharacterProvider>
+            <App />
+          </CharacterProvider>
+        </SettingsProvider>
+      </ThemeProvider>,
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorageMock.getItem.mockReturnValue(null);
+  });
+
+  it('renders floating dice button on the page', async () => {
+    renderApp();
+
+    expect(screen.getByRole('button', { name: 'Open dice roller' })).toBeInTheDocument();
+    expect(screen.getByText('🎲')).toBeInTheDocument();
+  });
+
+  it('opens dice roller modal when floating button is clicked', async () => {
+    renderApp();
+
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    await user.click(diceButton);
+
+    // Modal should be open
+    expect(screen.getByText('🎲 Dice Roller')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close dice roller' })).toBeInTheDocument();
+  });
+
+  it('closes dice roller modal when close button is clicked', async () => {
+    renderApp();
+
+    // Open modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    await user.click(diceButton);
+
+    // Verify modal is open
+    expect(screen.getByText('🎲 Dice Roller')).toBeInTheDocument();
+
+    // Close modal
+    const closeButton = screen.getByRole('button', { name: 'Close dice roller' });
+    await user.click(closeButton);
+
+    // Verify modal is closed
+    expect(screen.queryByText('🎲 Dice Roller')).not.toBeInTheDocument();
+  });
+
+  it('closes dice roller modal when clicking outside', async () => {
+    renderApp();
+
+    // Open modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    await user.click(diceButton);
+
+    // Verify modal is open
+    expect(screen.getByText('🎲 Dice Roller')).toBeInTheDocument();
+
+    // Click outside (on the overlay)
+    const overlay = screen.getByRole('presentation');
+    await user.click(overlay);
+
+    // Verify modal is closed
+    expect(screen.queryByText('🎲 Dice Roller')).not.toBeInTheDocument();
+  });
+
+  it('can roll dice from the modal', async () => {
+    renderApp();
+
+    // Open modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    await user.click(diceButton);
+
+    // Roll a d6
+    const d6Button = screen.getByRole('button', { name: 'Roll d6' });
+    await user.click(d6Button);
+
+    // Should show rolling state briefly, then result
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    // Should show a roll result (the exact number depends on the mock)
+    expect(screen.getAllByText(/d6: \d+ = \d+/)).toHaveLength(3); // Result box, history, and roll modal
+  });
+
+  it('can roll combat actions from the modal', async () => {
+    renderApp();
+
+    // Open modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    await user.click(diceButton);
+
+    // Roll Hack & Slash
+    const hackButton = screen.getByRole('button', { name: 'Roll Hack & Slash' });
+    await user.click(hackButton);
+
+    // Should show rolling state briefly, then result
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    // Should show a roll result
+    expect(screen.getByText(/Hack & Slash/)).toBeInTheDocument();
+  });
+
+  it('can add and use roll presets', async () => {
+    renderApp();
+
+    // Open modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    await user.click(diceButton);
+
+    // Add a preset
+    const nameInput = screen.getByRole('textbox', { name: 'Preset name' });
+    const formulaInput = screen.getByRole('textbox', { name: 'Preset formula' });
+    const addButton = screen.getByRole('button', { name: 'Add preset' });
+
+    await user.type(nameInput, 'Test Roll');
+    await user.type(formulaInput, '2d6+1');
+    await user.click(addButton);
+
+    // Should now have a preset button
+    const presetButton = screen.getByRole('button', { name: 'Roll preset Test Roll' });
+    expect(presetButton).toBeInTheDocument();
+
+    // Use the preset
+    await user.click(presetButton);
+
+    // Should show rolling state briefly, then result
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    // Should show a roll result
+    expect(screen.getByText(/Test Roll/)).toBeInTheDocument();
+  });
+
+  it('can be opened via command palette', async () => {
+    renderApp();
+
+    // Open command palette with Ctrl+K
+    await user.keyboard('{Control>}k{/Control}');
+
+    // Should show command palette
+    expect(screen.getByText('Open Dice Roller')).toBeInTheDocument();
+
+    // Click on the dice roller command
+    const diceCommand = screen.getByText('Open Dice Roller');
+    await user.click(diceCommand);
+
+    // Modal should be open
+    expect(screen.getByText('🎲 Dice Roller')).toBeInTheDocument();
+  });
+
+  it('shows roll history in the modal', async () => {
+    renderApp();
+
+    // Open modal
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+    await user.click(diceButton);
+
+    // Roll a few dice to generate history
+    const d6Button = screen.getByRole('button', { name: 'Roll d6' });
+    await user.click(d6Button);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    // Should show roll history
+    expect(screen.getByText('Recent Rolls:')).toBeInTheDocument();
+  });
+
+  it('floating button shows active state when modal is open', async () => {
+    renderApp();
+
+    const diceButton = screen.getByRole('button', { name: 'Open dice roller' });
+
+    // Button should not be active initially
+    expect(diceButton.className).not.toContain('active');
+
+    // Open modal
+    await user.click(diceButton);
+
+    // Button should be active when modal is open
+    expect(diceButton.className).toContain('active');
+
+    // Close modal
+    const closeButton = screen.getByRole('button', { name: 'Close dice roller' });
+    await user.click(closeButton);
+
+    // Button should not be active again
+    expect(diceButton.className).not.toContain('active');
+  });
+});

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -85,7 +85,6 @@
   grid-template-areas:
     'hud'
     'stats'
-    'dice'
     'inventory'
     'notes';
 }
@@ -96,10 +95,6 @@
 
 .stats {
   grid-area: stats;
-}
-
-.dice {
-  grid-area: dice;
 }
 
 .inventory {


### PR DESCRIPTION
# UX Stage 01: Implement Floating Dice Roller Modal

> **Plan adherence:** I read and followed [docs/ux-upgrade-plan.md](../docs/ux-upgrade-plan.md) (plan version: **1.0**).

## Summary

- **Scope:** This stage refactors the existing `DiceRoller` component from a fixed panel within the main application grid into a modal that is triggered by a new floating action button. It removes the dedicated grid area for the dice roller and introduces new `FloatingDiceButton` and `DiceRollerModal` components. A command palette entry for the dice roller is also added.
- **Motivation:** The previous dice roller occupied significant screen real estate even when not actively used. This change addresses user feedback by making the dice roller accessible on-demand, improving overall screen efficiency and user experience.
- **User impact:** The dice roller is no longer permanently visible on the screen. Users can access it by clicking a new floating dice button located in the bottom-right corner or by using the command palette (Ctrl+K, then "Open Dice Roller").

## Changes

- [x] New/updated components: `FloatingDiceButton.jsx`, `DiceRollerModal.jsx`
- [ ] Replaced bespoke logic with **Radix** primitives: N/A (custom implementation)
- [ ] Styling via **Tailwind** tokens/utilities: N/A (custom CSS modules)
- [ ] Motion via **Framer Motion**: N/A (custom CSS animations)
- [ ] Dev-only routes/demos (if any): No

## Libraries

- Added/updated packages (with reasons): None.

## Design Tokens

> All visuals must be token-driven; no hard-coded magic values.

| Token           | Old | New | Notes                               |
| --------------- | --- | --- | ----------------------------------- |
| color.accent    |     | X   | Used for button backgrounds, titles |
| color.danger    |     | X   | Used for specific button backgrounds|
| color.purple    |     | X   | Used for specific button backgrounds|
| color.warning   |     | X   | Used for specific button backgrounds|
| color.info      |     | X   | Used for specific button backgrounds|
| color.success   |     | X   | Used for specific button backgrounds|
| color.gray      |     | X   | Used for close button, history text |
| radius.md       |     | X   | `var(--hud-radius)` for modal/panel |
| radius.sm       |     | X   | `var(--hud-radius-sm)` for buttons/inputs |
| shadow.glow     |     | X   | `var(--panel-shadow)` for modal/button shadow |
| motion.duration |     | X   | `var(--hud-transition)` for button hover/active |
| spacing.md      |     | X   | `var(--space-md)` for section margins |
| spacing.sm      |     | X   | `var(--space-sm)` for padding |

## Feature Flags

> Heavy effects off by default.

| Flag                      | Default |
| ------------------------- | ------- |
| effects.particles.enabled | false   |
| effects.three.enabled     | false   |
| (None introduced)         |         |

## Accessibility

- [x] Radix focus trap/ARIA: ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-label`) added for modal and buttons.
- [ ] Keyboard-only verified
- [ ] prefers-reduced-motion respected
- [ ] WCAG AA contrast for all states

## Performance

- [ ] No unnecessary re-renders
- [ ] Heavy effects unmounted when flags off: N/A
- [ ] Dev/demo routes lazy-loaded: N/A
- Baseline metrics / profiler notes: N/A

## Tests & Docs

- [ ] Docs in docs/ (tokens, motion, usage/migration)
- [ ] README updated
- [x] Minimal tests if sensible: Existing tests updated, new unit tests added for `FloatingDiceButton` and `DiceRollerModal`. All tests passing.

## Migration Notes

- The `DiceRoller` component is no longer rendered directly in `App.jsx` within the CSS grid.
- The `dice` grid area has been removed from `AppStyles.module.css`.
- Developers should now use the `FloatingDiceButton` to trigger the `DiceRollerModal`.

## Screenshots / Demos

> No binary assets. Code-generated previews only.

### Checklist

- [x] No binary assets introduced
- [x] Scope limited to this stage

---
<a href="https://cursor.com/background-agent?bcId=bc-b3045efa-e4b7-42e2-ace0-b720d2cb2048">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3045efa-e4b7-42e2-ace0-b720d2cb2048">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

