### PR TITLE
refactor: use shared buttons in CharacterStats

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 import { resourceColors } from '../styles/colorMap.js';
+import Button from './common/Button';
+import ButtonGroup from './common/ButtonGroup';
 import styles from './CharacterStats.module.css';
 
 const CharacterStats = ({
@@ -44,8 +46,8 @@ const CharacterStats = ({
       <div className={styles.centerText}>
         HP: {character.hp}/{character.maxHp} | Armor: {totalArmor}
       </div>
-      <div className={styles.controls}>
-        <button
+      <ButtonGroup className={styles.controls}>
+        <Button
           onClick={() => {
             saveToHistory('HP Change');
             setCharacter((prev) => ({
@@ -53,11 +55,10 @@ const CharacterStats = ({
               hp: Math.min(prev.maxHp, prev.hp + 1),
             }));
           }}
-          className={styles.button}
         >
           +1 HP
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() => {
             saveToHistory('HP Change');
             setCharacter((prev) => ({
@@ -65,11 +66,10 @@ const CharacterStats = ({
               hp: Math.max(0, prev.hp - 1),
             }));
           }}
-          className={`${styles.button} ${styles.buttonRed}`}
         >
           -1 HP
-        </button>
-      </div>
+        </Button>
+      </ButtonGroup>
       {/* eslint-disable-next-line jsx-a11y/tabindex-no-positive */}
       <div
         className={styles.xpBarContainer}
@@ -88,8 +88,8 @@ const CharacterStats = ({
       <div className={styles.centerText} data-testid="xp-display">
         XP: {character.xp}/{character.xpNeeded} (Level {character.level})
       </div>
-      <div className={styles.controls}>
-        <button
+      <ButtonGroup className={styles.controls}>
+        <Button
           onClick={() =>
             setCharacter((prev) => ({
               ...prev,
@@ -97,12 +97,11 @@ const CharacterStats = ({
               xpNeeded: prev.level + 7,
             }))
           }
-          className={styles.button}
           data-testid="increment-xp"
         >
           +1 XP
-        </button>
-        <button
+        </Button>
+        <Button
           onClick={() =>
             setCharacter((prev) => ({
               ...prev,
@@ -110,30 +109,19 @@ const CharacterStats = ({
               xpNeeded: prev.level + 7,
             }))
           }
-          className={`${styles.button} ${styles.buttonRed}`}
         >
           -1 XP
-        </button>
-      </div>
+        </Button>
+      </ButtonGroup>
       {import.meta.env.DEV && (
-        <button
-          onClick={() => setShowLevelUpModal(true)}
-          className={`${styles.button} ${styles.devButton}`}
-        >
-          Open Level Up Test Modal
-        </button>
+        <Button onClick={() => setShowLevelUpModal(true)}>Open Level Up Test Modal</Button>
       )}
       {character.xp >= character.xpNeeded && (
-        <button
-          onClick={() => setShowLevelUpModal(true)}
-          className={`${styles.button} ${styles.levelUpButton}`}
-        >
-          🎉 LEVEL UP AVAILABLE!
-        </button>
+        <Button onClick={() => setShowLevelUpModal(true)}>🎉 LEVEL UP AVAILABLE!</Button>
       )}
       <div className={styles.chronoContainer}>
-        <div className={`${styles.centerText} ${styles.chronoRow}`}>
-          <button
+        <ButtonGroup className={`${styles.centerText} ${styles.chronoRow}`}>
+          <Button
             aria-label="Decrease Chrono-Retcon"
             onClick={() =>
               setCharacter((prev) => ({
@@ -144,12 +132,11 @@ const CharacterStats = ({
                 },
               }))
             }
-            className={styles.minusButton}
           >
             -1
-          </button>
+          </Button>
           <span>Chrono-Retcon Uses: {character.resources.chronoUses}</span>
-          <button
+          <Button
             aria-label="Increase Chrono-Retcon"
             onClick={() =>
               setCharacter((prev) => ({
@@ -160,12 +147,11 @@ const CharacterStats = ({
                 },
               }))
             }
-            className={styles.plusButton}
           >
             +1
-          </button>
-        </div>
-        <button
+          </Button>
+        </ButtonGroup>
+        <Button
           onClick={() => {
             if (character.resources.chronoUses > 0) {
               setCharacter((prev) => ({
@@ -183,10 +169,9 @@ const CharacterStats = ({
             }
           }}
           disabled={character.resources.chronoUses === 0}
-          className={styles.chronoButton}
         >
           ⏰ Use Chrono-Retcon
-        </button>
+        </Button>
       </div>
       {[
         { key: 'coin', label: 'Coin', max: 999 },
@@ -202,8 +187,8 @@ const CharacterStats = ({
               {character.resources[key]}/{max}
             </span>
           </div>
-          <div className={styles.resourceButtons}>
-            <button
+          <ButtonGroup className={styles.resourceButtons}>
+            <Button
               onClick={() =>
                 setCharacter((prev) => ({
                   ...prev,
@@ -213,11 +198,10 @@ const CharacterStats = ({
                   },
                 }))
               }
-              className={styles.minusButton}
             >
               -1
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={() =>
                 setCharacter((prev) => ({
                   ...prev,
@@ -227,11 +211,10 @@ const CharacterStats = ({
                   },
                 }))
               }
-              className={styles.plusButton}
             >
               +1
-            </button>
-          </div>
+            </Button>
+          </ButtonGroup>
         </div>
       ))}
       {character.resources.paradoxPoints >= 3 && (
@@ -239,7 +222,7 @@ const CharacterStats = ({
           <div className={styles.warningText}>⚠️ REALITY UNSTABLE! ⚠️</div>
         </div>
       )}
-      <button
+      <Button
         onClick={() => {
           setCharacter((prev) => ({
             ...prev,
@@ -255,10 +238,9 @@ const CharacterStats = ({
           clearRollHistory();
           setRollResult('🔄 All resources restored!');
         }}
-        className={styles.resetButton}
       >
         🔄 Reset All Resources
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -76,27 +76,6 @@
   margin-top: var(--space-md);
 }
 
-.button {
-  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: var(--color-white);
-  padding: var(--space-sm) 15px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: var(--hud-transition);
-  margin: var(--space-sm);
-}
-
-.button:focus-visible {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
-}
-
-.buttonRed {
-  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
-}
-
 .xpBarContainer {
   width: 100%;
   height: 20px;
@@ -144,30 +123,6 @@
   gap: 5px;
 }
 
-.minusButton {
-  background: linear-gradient(45deg, var(--color-danger), var(--color-danger-dark));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: var(--color-white);
-  padding: 5px 10px;
-  cursor: pointer;
-  margin: 0;
-  font-size: var(--font-size-sm);
-  flex: 1;
-}
-
-.plusButton {
-  background: linear-gradient(45deg, var(--color-accent), var(--color-accent-dark));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: var(--color-white);
-  padding: 5px 10px;
-  cursor: pointer;
-  margin: 0;
-  font-size: var(--font-size-sm);
-  flex: 1;
-}
-
 .chronoContainer {
   margin-top: var(--space-md);
 }
@@ -177,24 +132,6 @@
   justify-content: center;
   align-items: center;
   gap: 5px;
-}
-
-.chronoButton {
-  background: linear-gradient(45deg, var(--color-success), var(--color-success-dark));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: var(--color-white);
-  padding: var(--space-sm) 15px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: var(--hud-transition);
-  width: 100%;
-}
-
-.chronoButton:disabled {
-  background: linear-gradient(45deg, var(--color-gray), var(--color-gray-dark));
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .warningBox {
@@ -210,34 +147,6 @@
   color: var(--color-warning);
   font-size: 0.8rem;
   font-weight: bold;
-}
-
-.resetButton {
-  background: linear-gradient(45deg, var(--color-info-light), var(--color-accent));
-  border: none;
-  border-radius: var(--hud-radius-sm);
-  color: var(--color-white);
-  padding: 10px 20px;
-  cursor: pointer;
-  font-weight: bold;
-  transition: var(--hud-transition);
-  width: 100%;
-  margin-top: var(--space-md);
-}
-
-.devButton {
-  background: linear-gradient(45deg, var(--color-purple-dark), var(--color-purple));
-  width: 100%;
-  margin-top: var(--space-md);
-}
-
-.levelUpButton {
-  background: linear-gradient(45deg, var(--color-warning-light), var(--color-warning));
-  width: 100%;
-  margin-top: var(--space-md);
-  padding: 15px;
-  font-size: 16px;
-  animation: pulse 2s infinite;
 }
 
 .resourceValue {


### PR DESCRIPTION
## Summary
- refactor CharacterStats to use reusable Button and ButtonGroup components
- clean up module styles by removing unused button-specific classes

## Testing
- `npm run lint` *(fails: Unable to resolve path to module '@typescript-eslint/eslint-plugin')*
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 13 files)*
- `npm run test:e2e` *(fails: The system library `glib-2.0` was not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa906e323c8332ae8fa79b9fa93db3