### PR TITLE
style: replace panel with inline modal for stats

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -13,7 +13,7 @@ const CharacterStats = ({
   clearRollHistory,
 }) => {
   return (
-    <div className={styles.panel}>
+    <div className={styles.modal}>
       <h3 className={styles.title}>⚡ Stats &amp; Health</h3>
       <div className={styles.statsGrid}>
         {Object.entries(character.stats).map(([stat, data]) => (

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -1,10 +1,8 @@
-.panel {
-  background: var(--panel-bg);
-  @apply backdrop-blur-glass;
-  border-radius: var(--hud-radius);
+.modal {
+  background: var(--color-modal-bg);
+  border: 2px solid var(--color-accent);
+  border-radius: 15px;
   padding: var(--hud-spacing);
-  border: 1px solid var(--panel-border);
-  box-shadow: 0 8px 32px var(--panel-shadow);
 }
 
 .title {


### PR DESCRIPTION
## Summary
- style CharacterStats with modal container instead of panel
- introduce matching `.modal` styles for stats module

## Testing
- `npm run lint -- --ignore-pattern eslint.config.js --ignore-pattern src/components/dev`
- `npm test`
- `npx prettier --check src/components/CharacterStats.jsx src/components/CharacterStats.module.css`
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found; can not find driver binary WebKitWebDriver in the PATH)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa90683bd88332bb7b9638bf1f2c3f