### PR TITLE
fix: correct reset resources button closing tag

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -248,8 +248,8 @@ const CharacterStats = ({
         }}
       >
         🔄 Reset All Resources
-      </button>
-    </motion.div>
+      </Button>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- fix Reset All Resources button closing tag to use `<Button>` and correct container closing tag

## Testing
- `npm run lint` *(fails: Unable to resolve path to module '@typescript-eslint/eslint-plugin')*
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 13 files)*
- `npm run test:e2e` *(fails: failed to build app: gobject-2.0 not found; Can not find driver binary WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa962dfc28833288f77ba87295bb03