### PR TITLE
fix: center character stats panel

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -256,7 +256,7 @@ const CharacterStats = ({
       >
         🔄 Reset All Resources
       </Button>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -3,6 +3,9 @@
   border: 2px solid var(--color-accent);
   border-radius: 15px;
   padding: var(--hud-spacing);
+  text-align: center;
+  max-width: 300px;
+  margin: 0 auto;
 }
 
 .title {


### PR DESCRIPTION
## Summary
- center CharacterStats modal and limit its width
- fix mismatched closing tag in CharacterStats component

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 12 files. Run Prettier with --write to fix.)*
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found; driver binary WebKitWebDriver missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ca09db883328d307c2e66f43bf0