### PR TITLE
fix: use modal tokens for stats colors

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import { motion } from 'framer-motion';
 import { useMotionTransition, useMotionVariants } from '../motion/reduced';
 import { durations, easings, fadeScale } from '../motion/tokens';
-import { resourceColors } from '../styles/colorMap.js';
 import Button from './common/Button';
 import ButtonGroup from './common/ButtonGroup';
 import styles from './CharacterStats.module.css';
@@ -198,7 +197,7 @@ const CharacterStats = ({
         <div key={key} className={styles.resourceRow}>
           <div className={styles.resourceHeader}>
             <span className={styles.resourceLabel}>{label}:</span>
-            <span className={styles.resourceValue} style={{ color: resourceColors[key] }}>
+            <span className={styles.resourceValue}>
               {character.resources[key]}/{max}
             </span>
           </div>
@@ -256,7 +255,7 @@ const CharacterStats = ({
       >
         🔄 Reset All Resources
       </Button>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -60,7 +60,7 @@
 
 .hpFill {
   height: 100%;
-  background: linear-gradient(90deg, var(--color-danger), var(--color-warning));
+  background: var(--color-accent);
   transition: width 0.3s ease;
 }
 
@@ -91,7 +91,7 @@
 
 .xpFill {
   height: 100%;
-  background: linear-gradient(90deg, var(--color-info-light), var(--color-accent));
+  background: var(--color-accent);
   transition: width 0.3s ease;
 }
 
@@ -134,8 +134,8 @@
 }
 
 .warningBox {
-  background: var(--overlay-warning);
-  border: 1px solid var(--color-warning);
+  background: var(--color-modal-bg-dark);
+  border: 1px solid var(--color-accent);
   border-radius: var(--hud-radius-sm);
   padding: var(--hud-spacing-sm);
   text-align: center;
@@ -143,11 +143,12 @@
 }
 
 .warningText {
-  color: var(--color-warning);
+  color: var(--color-accent);
   font-size: 0.8rem;
   font-weight: bold;
 }
 
 .resourceValue {
   font-weight: bold;
+  color: var(--color-accent);
 }


### PR DESCRIPTION
## Summary
- swap warning box and fill colors to modal/accent tokens
- drop resource-specific color mapping in CharacterStats

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 12 files. Run Prettier with --write to fix.)*
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ca4a5ac8332bd5b89887d940d36