### PR TITLE
refactor: simplify CharacterStats layout

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -135,7 +135,7 @@ const CharacterStats = ({
         <Button onClick={() => setShowLevelUpModal(true)}>🎉 LEVEL UP AVAILABLE!</Button>
       )}
       <div className={styles.chronoContainer}>
-        <ButtonGroup className={`${styles.centerText} ${styles.chronoRow}`}>
+        <ButtonGroup>
           <Button
             aria-label="Decrease Chrono-Retcon"
             onClick={() =>
@@ -202,7 +202,7 @@ const CharacterStats = ({
               {character.resources[key]}/{max}
             </span>
           </div>
-          <ButtonGroup className={styles.resourceButtons}>
+          <ButtonGroup>
             <Button
               onClick={() =>
                 setCharacter((prev) => ({
@@ -256,7 +256,7 @@ const CharacterStats = ({
       >
         🔄 Reset All Resources
       </Button>
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -117,20 +117,8 @@
   font-size: 0.9rem;
 }
 
-.resourceButtons {
-  display: flex;
-  gap: 5px;
-}
-
 .chronoContainer {
   margin-top: var(--space-md);
-}
-
-.chronoRow {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 5px;
 }
 
 .warningBox {


### PR DESCRIPTION
## Summary
- rely on ButtonGroup for Chrono-Retcon controls instead of custom classes
- drop resource ButtonGroup styling and remove related CSS

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check` *(fails: Code style issues found in 12 files)*
- `npx prettier src/components/CharacterStats.jsx src/components/CharacterStats.module.css --check`
- `npm run test:e2e` *(fails: missing glib-2.0 and WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ca759608332a2f647faf4ef9908