### PR TITLE
feat: add animated space background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -10,7 +10,9 @@
 body {
   font-family: var(--font-body);
   font-size: var(--font-size-body);
-  background: linear-gradient(135deg, var(--color-bg-start), var(--color-bg-end));
+  background-image: var(--space-bg-image);
+  background-repeat: repeat;
+  animation: spaceScroll 60s linear infinite;
   color: var(--color-text);
   overflow-x: hidden;
 }
@@ -30,6 +32,15 @@ h1 {
 }
 
 /* Animations */
+@keyframes spaceScroll {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 10000px 10000px;
+  }
+}
+
 @keyframes pulse {
   0%,
   100% {
@@ -147,7 +158,7 @@ select:focus-visible {
 }
 
 .glass-panel {
-  background: var(--panel-bg);
+  background: var(--glass-bg);
   backdrop-filter: blur(var(--glass-blur));
   -webkit-backdrop-filter: blur(var(--glass-blur));
   border-radius: var(--hud-radius);
@@ -236,4 +247,19 @@ select:focus-visible {
     var(--critical-failure-end)
   ) !important;
   animation: pulse 0.5s ease-in-out 3;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body {
+    animation: none;
+  }
+
+  .loading-shimmer,
+  .status-critical,
+  .level-up-celebration,
+  .dice-rolling,
+  .critical-hit,
+  .critical-failure {
+    animation: none !important;
+  }
 }

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -1,6 +1,8 @@
 .container {
   min-height: 100vh;
-  background: linear-gradient(135deg, var(--color-bg-start), var(--color-bg-end));
+  background-image: var(--space-bg-image);
+  background-repeat: repeat;
+  animation: spaceScroll 60s linear infinite;
   color: var(--color-text);
   padding: var(--hud-spacing);
   font-family: var(--font-body);
@@ -23,7 +25,8 @@
   margin-bottom: var(--space-md);
   padding: var(--hud-spacing);
   border-radius: 15px;
-  border: 2px solid var(--color-accent);
+  background: var(--glass-bg);
+  border: 1px solid var(--panel-border);
   box-shadow: 0 0 20px var(--glow-shadow);
   transition: var(--hud-transition-slow);
 }
@@ -226,4 +229,17 @@
 
 :global(.invisible-overlay)::before {
   background: radial-gradient(circle at 50% 50%, var(--overlay-invisible) 0%, transparent 70%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .container {
+    animation: none;
+  }
+
+  .statusEffectIcon,
+  :global(.burning-overlay)::before,
+  :global(.shocked-overlay)::before,
+  :global(.blessed-overlay)::before {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- animate app background using `--space-bg-image`
- style panels with `--glass-bg` and `--panel-border`
- add reduced-motion fallbacks to disable background and other animations

## Testing
- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaab6bd5188332a0d5fdfcaf7fc9ed