### PR TITLE
feat(theme): add Arwes theme

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -436,6 +436,25 @@ describe('Theme switching', () => {
       expect(document.documentElement.getAttribute('data-theme')).toBe('moebius');
     });
   });
+
+  it('updates the theme attribute when selecting arwes', () => {
+    render(
+      <ThemeProvider>
+        <SettingsProvider initialAutoXpOnMiss={true}>
+          <Settings />
+        </SettingsProvider>
+      </ThemeProvider>,
+    );
+
+    const select = screen.getByLabelText(/Theme:/i);
+
+    return waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe('cosmic-v2');
+    }).then(() => {
+      fireEvent.change(select, { target: { value: 'arwes' } });
+      expect(document.documentElement.getAttribute('data-theme')).toBe('arwes');
+    });
+  });
 });
 
 describe('App header', () => {

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -8,6 +8,9 @@ const Settings = () => {
   const themeLabels = {
     legacy: 'Legacy',
     'cosmic-v2': 'Cosmic v2',
+    classic: 'Classic',
+    moebius: 'Moebius',
+    arwes: 'Arwes Space',
   };
 
   return (

--- a/src/state/ThemeContext.test.jsx
+++ b/src/state/ThemeContext.test.jsx
@@ -49,10 +49,10 @@ describe('ThemeContext', () => {
     safeLocalStorage.getItem.mockImplementation((key, fallback) => fallback);
     const { result } = renderHook(() => useTheme(), { wrapper });
     act(() => {
-      result.current.setTheme('classic');
+      result.current.setTheme('arwes');
     });
-    expect(setAttributeMock).toHaveBeenCalledWith('data-theme', 'classic');
-    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('theme', 'classic');
+    expect(setAttributeMock).toHaveBeenCalledWith('data-theme', 'arwes');
+    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('theme', 'arwes');
   });
 
   it('persists theme changes and loads stored theme', () => {

--- a/src/state/theme.js
+++ b/src/state/theme.js
@@ -1,3 +1,3 @@
-export const THEMES = ['legacy', 'cosmic-v2', 'classic', 'moebius'];
+export const THEMES = ['legacy', 'cosmic-v2', 'classic', 'moebius', 'arwes'];
 
 export const DEFAULT_THEME = 'cosmic-v2';

--- a/tests/app.e2e.spec.ts
+++ b/tests/app.e2e.spec.ts
@@ -70,8 +70,8 @@ test('character flow with save and load', async () => {
 
   // Settings
   const themeSelect = await browser.$('#theme-select');
-  await themeSelect.selectByVisibleText('classic');
-  expect(await browser.$('html').getAttribute('data-theme')).toBe('classic');
+  await themeSelect.selectByVisibleText('Arwes Space');
+  expect(await browser.$('html').getAttribute('data-theme')).toBe('arwes');
 
   // Save character
   const exportButton = await browser.$('button=Export/Save');


### PR DESCRIPTION
## Summary
- add Arwes theme option and keep cosmic-v2 as default
- label all themes in settings including Arwes Space
- test theme switching for Arwes, unit and e2e

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check` (warn: Code style issues found in 6 files)
- `npm run test:e2e` (fail: The system library `glib-2.0` required by crate `glib-sys` was not found)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaab6ad5a88332bbe96da203551994