### PR TITLE
feat(button): add neon border glow

### DIFF
--- a/src/components/common/Button.module.css
+++ b/src/components/common/Button.module.css
@@ -1,6 +1,6 @@
 .button {
   background: linear-gradient(45deg, var(--color-neon), var(--color-neon-dark));
-  border: none;
+  border: 2px solid var(--color-neon);
   border-radius: var(--hud-radius-sm);
   color: var(--color-white);
   font-size: var(--font-size-body);
@@ -9,22 +9,25 @@
   min-height: calc(var(--space-md) * 2 + 1.2em);
   cursor: pointer;
   font-weight: bold;
-  transition: var(--hud-transition);
+  transition:
+    box-shadow var(--hud-transition),
+    filter var(--hud-transition);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 5px;
+  box-shadow: 0 0 0 0 var(--color-neon);
 }
 
 .button:hover {
   filter: brightness(1.1);
-  box-shadow: var(--shadow-neon);
+  box-shadow: 0 0 8px 2px var(--color-neon);
 }
 
 .button:focus-visible {
   outline: 2px solid var(--color-neon);
   outline-offset: 2px;
-  box-shadow: var(--shadow-neon);
+  box-shadow: 0 0 8px 2px var(--color-neon);
 }
 
 .button:disabled {


### PR DESCRIPTION
## Summary
- animate button glow using `--hud-transition`
- draw button borders and shadows from `--color-neon`

## Testing
- `npm run format:check` *(fails: Code style issues found in 6 files. Run Prettier with --write to fix.)*
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: missing WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaab6cee148332a7939e2b7911e6c5