### PR TITLE
feat: adopt bento grid layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -429,12 +429,12 @@ function App() {
         {/* Main Grid Layout */}
         <div className={styles.grid}>
           {/* Avatar Panel */}
-          <div className={styles.hud}>
+          <div className={`${styles.tile} ${styles.hud}`}>
             <CharacterHUD onMountChange={setHudMounted} />
           </div>
 
           {/* Stats Panel */}
-          <div className={styles.stats}>
+          <div className={`${styles.tile} ${styles.stats}`}>
             <CharacterStats
               character={character}
               setCharacter={setCharacter}
@@ -446,9 +446,8 @@ function App() {
               clearRollHistory={clearRollHistory}
             />
           </div>
-
           {/* Equipment and Inventory Panels */}
-          <div className={styles.inventory}>
+          <div className={`${styles.tile} ${styles.inventory}`}>
             <EquipmentPanel character={character} setCharacter={setCharacter} />
             <InventoryPanel
               character={character}
@@ -459,7 +458,7 @@ function App() {
           </div>
 
           {/* Session Notes Panel */}
-          <div className={styles.notes}>
+          <div className={`${styles.tile} ${styles.notes}`}>
             <SessionNotes
               sessionNotes={sessionNotes}
               setSessionNotes={setSessionNotes}

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -453,174 +453,52 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-auto-rows: minmax(200px, auto);
+  grid-auto-flow: dense;
   gap: var(--hud-spacing);
   margin-bottom: var(--hud-spacing);
-  grid-template-areas:
-    'hud stats inventory'
-    'notes notes notes';
+}
+
+.tile {
+  background: transparent;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  border-radius: 0;
+  border: none;
+  box-shadow: none;
+  transition: var(--hud-transition);
+  position: relative;
+  overflow: visible;
+  padding: var(--hud-spacing);
+}
+
+.tile::before,
+.tile::after,
+.tile:hover::before,
+.tile:hover::after {
+  display: none;
+}
+
+.tile:hover {
+  transform: translateY(-1px);
 }
 
 .hud {
-  grid-area: hud;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.hud::before {
-  display: none;
-}
-
-.hud::after {
-  display: none;
-}
-
-.hud:hover {
-  transform: translateY(-1px);
-}
-
-.hud:hover::before {
-  display: none;
-}
-
-.hud:hover::after {
-  display: none;
+  grid-column: span 2;
+  grid-row: span 2;
 }
 
 .stats {
-  grid-area: stats;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.stats::before {
-  display: none;
-}
-
-.stats::after {
-  display: none;
-}
-
-.stats:hover {
-  transform: translateY(-1px);
-}
-
-.stats:hover::before {
-  display: none;
-}
-
-.stats:hover::after {
-  display: none;
+  grid-row: span 2;
 }
 
 .inventory {
-  grid-area: inventory;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.equipment {
-  grid-area: equipment;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.inventory::before {
-  display: none;
-}
-
-.inventory::after {
-  display: none;
-}
-
-.inventory:hover {
-  transform: translateY(-1px);
-}
-
-.inventory:hover::before {
-  display: none;
-}
-
-.inventory:hover::after {
-  display: none;
+  grid-row: span 2;
 }
 
 .notes {
-  grid-area: notes;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.notes::before {
-  display: none;
-}
-
-.notes::after {
-  display: none;
-}
-
-.notes:hover {
-  transform: translateY(-1px);
-}
-
-.notes:hover::before {
-  display: none;
-}
-
-.notes:hover::after {
-  display: none;
-}
-
-@media (max-width: 1199px) {
-  .grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (max-width: 767px) {
-  .grid {
-    grid-template-columns: 1fr;
-  }
+  grid-column: span 3;
 }
 
 /* Button Styles - Updated to match about page */


### PR DESCRIPTION
## Summary
- switch grid to bento-style auto-fill layout
- span HUD, stats, inventory, and notes panels for varied sizes
- update App.jsx to use shared tile class

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run test:e2e` *(fails: CannotFindBinaryPath)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab92ce7e948332b0d715e418b9057d