### PR TITLE
refactor: use Panel for session notes

### DIFF
--- a/src/components/SessionNotes.jsx
+++ b/src/components/SessionNotes.jsx
@@ -11,6 +11,7 @@ import {
   FaLaptop,
   FaMobileScreen,
 } from 'react-icons/fa6';
+import Panel from './ui/Panel';
 import styles from './SessionNotes.module.css';
 
 const NOTES_FILE = 'session_notes.txt';
@@ -71,9 +72,9 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
 
   return (
     <>
-      <div
-        className={`${styles.panel} ${
-          compactMode ? styles.panelCompact : styles.panelExpanded
+      <Panel
+        className={`${styles.container} ${
+          compactMode ? styles.collapsed : styles.expanded
         } ${compactMode ? '' : styles.fullWidth}`}
       >
         <h3 className={styles.title}>
@@ -150,7 +151,7 @@ const SessionNotes = ({ sessionNotes, setSessionNotes, compactMode, setCompactMo
             {compactMode ? <FaLaptop /> : <FaMobileScreen />} {compactMode ? 'Expand' : 'Compact'}
           </button>
         </div>
-      </div>
+      </Panel>
       <ClearNotesModal
         isOpen={clearModal.isOpen}
         onConfirm={handleConfirmClear}

--- a/src/components/SessionNotes.module.css
+++ b/src/components/SessionNotes.module.css
@@ -1,11 +1,4 @@
-.panel {
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  padding: var(--hud-spacing);
-  border: none;
-  box-shadow: none;
+.container {
   overflow: visible;
   transition:
     max-height 0.3s ease,
@@ -98,19 +91,19 @@
   grid-column: 1 / -1;
 }
 
-.panelCompact {
+.collapsed {
   max-height: 0;
   opacity: 0;
 }
 
-.panelExpanded {
+.expanded {
   max-height: calc(100vh - var(--header-height) - 2 * var(--space-lg));
   overflow: auto;
   opacity: 1;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .panel {
+  .container {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- wrap session notes in shared Panel component
- simplify styles and add collapsed/expanded classes

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test` *(fails: Command palette, Theme switching, AddItemModal tests)*
- `npm run test:e2e` *(fails: CannotFindBinaryPath, Tauri package version mismatch)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab92cd2a708332b52fccaa6c572f03