### PR TITLE
feat(ui): add hud panel style

### DIFF
--- a/src/components/ui/Panel.tsx
+++ b/src/components/ui/Panel.tsx
@@ -3,20 +3,7 @@ import React from 'react';
 export interface PanelProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 const Panel = React.forwardRef<HTMLDivElement, PanelProps>(({ className = '', ...props }, ref) => (
-  <div
-    ref={ref}
-    className={['panel', className].filter(Boolean).join(' ')}
-    style={{
-      background: 'transparent',
-      border: 'none',
-      borderRadius: '0',
-      padding: 'var(--hud-spacing, 1.25rem)',
-      boxShadow: 'none',
-      backdropFilter: 'none',
-      WebkitBackdropFilter: 'none',
-    }}
-    {...props}
-  />
+  <div ref={ref} className={['hud-panel', className].filter(Boolean).join(' ')} {...props} />
 ));
 
 Panel.displayName = 'Panel';

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -463,152 +463,38 @@
 
 .hud {
   grid-area: hud;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.hud::before {
-  display: none;
-}
-
-.hud::after {
-  display: none;
 }
 
 .hud:hover {
   transform: translateY(-1px);
 }
 
-.hud:hover::before {
-  display: none;
-}
-
-.hud:hover::after {
-  display: none;
-}
-
 .stats {
   grid-area: stats;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.stats::before {
-  display: none;
-}
-
-.stats::after {
-  display: none;
 }
 
 .stats:hover {
   transform: translateY(-1px);
 }
 
-.stats:hover::before {
-  display: none;
-}
-
-.stats:hover::after {
-  display: none;
-}
-
 .inventory {
   grid-area: inventory;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
 }
 
 .equipment {
   grid-area: equipment;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.inventory::before {
-  display: none;
-}
-
-.inventory::after {
-  display: none;
 }
 
 .inventory:hover {
   transform: translateY(-1px);
 }
 
-.inventory:hover::before {
-  display: none;
-}
-
-.inventory:hover::after {
-  display: none;
-}
-
 .notes {
   grid-area: notes;
-  background: transparent;
-  -webkit-backdrop-filter: none;
-  backdrop-filter: none;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  transition: var(--hud-transition);
-  position: relative;
-  overflow: visible;
-  padding: var(--hud-spacing);
-}
-
-.notes::before {
-  display: none;
-}
-
-.notes::after {
-  display: none;
 }
 
 .notes:hover {
   transform: translateY(-1px);
-}
-
-.notes:hover::before {
-  display: none;
-}
-
-.notes:hover::after {
-  display: none;
 }
 
 @media (max-width: 1199px) {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -52,6 +52,10 @@
   --hud-spacing: 1.25rem;
   --hud-transition: all 300ms ease-in-out;
 
+  /* HUD frame colors */
+  --hud-frame-orange: #ff8a00;
+  --hud-frame-cyan: #00ffff;
+
   /* Legacy compatibility */
   --fg: var(--color-text);
   --bg: var(--color-bg-start);
@@ -364,6 +368,49 @@ body::after {
 }
 
 /* Typography */
+
+/* HUD panel with animated gradient frame */
+.hud-panel {
+  position: relative;
+  padding: var(--hud-spacing);
+  border-radius: var(--hud-radius);
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 8px 32px var(--panel-shadow);
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  backdrop-filter: blur(var(--glass-blur));
+  overflow: hidden;
+  transition: var(--hud-transition);
+}
+
+.hud-panel::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  background: linear-gradient(
+    135deg,
+    var(--hud-frame-orange),
+    var(--hud-frame-cyan),
+    var(--hud-frame-orange)
+  );
+  background-size: 300% 300%;
+  filter: blur(8px);
+  z-index: -1;
+  animation: hud-frame-glow 8s linear infinite;
+}
+
+@keyframes hud-frame-glow {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Summary
- add `.hud-panel` with animated gradient frame
- expose `--hud-frame-orange` and `--hud-frame-cyan` variables
- apply `hud-panel` in Panel component and update app styles

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test` *(fails: Command palette, Theme switching, AddItemModal)*
- `npm run test:e2e` *(fails: missing WebKitWebDriver and Tauri version mismatch)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab92cc26e08332b60e6d2214fc8e25