### PR TITLE
feat: use STR mod for Hack & Slash

### DIFF
--- a/src/components/DiceRollerModal.jsx
+++ b/src/components/DiceRollerModal.jsx
@@ -118,11 +118,12 @@ const DiceRollerModal = ({
                   Weapon ({equippedWeaponDamage})
                 </button>
                 <button
-                  onClick={() => rollDice('2d6+3', 'Hack & Slash')}
+                  onClick={() => rollDice(`2d6+${character.stats.STR.mod}`, 'Hack & Slash')}
                   className={`${styles.button} ${styles.purple} ${styles.small}`}
                   aria-label="Roll Hack & Slash"
                 >
-                  Hack & Slash
+                  Hack & Slash ({character.stats.STR.mod >= 0 ? '+' : ''}
+                  {character.stats.STR.mod})
                 </button>
                 <button
                   onClick={() => rollDice('d4', 'Upper Hand')}

--- a/src/components/DiceRollerModal.test.jsx
+++ b/src/components/DiceRollerModal.test.jsx
@@ -95,4 +95,31 @@ describe('DiceRollerModal', () => {
     expect(screen.getByText('Recent Rolls:')).toBeInTheDocument();
     expect(screen.getByText(/Previous roll: 10/)).toBeInTheDocument();
   });
+
+  it('uses STR modifier for Hack & Slash roll', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    const hackButton = screen.getByRole('button', { name: 'Roll Hack & Slash' });
+    fireEvent.click(hackButton);
+
+    expect(mockProps.rollDice).toHaveBeenCalledWith('2d6+1', 'Hack & Slash');
+  });
+
+  it('updates Hack & Slash modifier when STR mod changes', () => {
+    const { rerender } = render(<DiceRollerModal {...mockProps} />);
+
+    expect(screen.getByText(/Hack & Slash/)).toHaveTextContent('Hack & Slash (+1)');
+
+    rerender(
+      <DiceRollerModal
+        {...mockProps}
+        character={{
+          ...mockProps.character,
+          stats: { ...mockProps.character.stats, STR: { mod: 2 } },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Hack & Slash/)).toHaveTextContent('Hack & Slash (+2)');
+  });
 });


### PR DESCRIPTION
## Summary
- use character STR modifier for Hack & Slash rolls
- show current STR modifier in Hack & Slash button
- test Hack & Slash uses and updates STR modifier

## Testing
- `npm run lint`
- `npm test` *(fails: multiple test failures)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing WebKitWebDriver and mismatched Tauri packages)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc9305c008332903dfa1a434e6568