### PR TITLE
feat: add manual aid/interfere resolution

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,6 +102,7 @@ function App() {
     rollDice,
     rollModal,
     rollModalData,
+    resolveAidOrInterfere,
     aidModal,
     rollDie,
     clearRollHistory,
@@ -606,6 +607,7 @@ function App() {
         equippedWeaponDamage={equippedWeaponDamage}
         rollModal={rollModal}
         rollModalData={rollModalData}
+        resolveAidOrInterfere={resolveAidOrInterfere}
         aidModal={aidModal}
       />
 

--- a/src/components/DiceRollerModal.jsx
+++ b/src/components/DiceRollerModal.jsx
@@ -15,6 +15,7 @@ const DiceRollerModal = ({
   equippedWeaponDamage,
   rollModal,
   rollModalData,
+  resolveAidOrInterfere,
   aidModal,
 }) => {
   const [isRolling, setIsRolling] = useState(false);
@@ -224,6 +225,14 @@ const DiceRollerModal = ({
               {isRolling ? 'rolling…' : rollResult}
             </div>
 
+            <button
+              onClick={resolveAidOrInterfere}
+              className={`${styles.button} ${styles.purple} ${styles.small}`}
+              aria-label="Apply Aid or Interfere"
+            >
+              Apply Aid/Interfere
+            </button>
+
             {/* Roll History */}
             {rollHistory.length > 0 && (
               <div className={styles.history}>
@@ -267,6 +276,7 @@ DiceRollerModal.propTypes = {
     close: PropTypes.func.isRequired,
   }).isRequired,
   rollModalData: PropTypes.object.isRequired,
+  resolveAidOrInterfere: PropTypes.func.isRequired,
   aidModal: PropTypes.shape({
     isOpen: PropTypes.bool.isRequired,
     onConfirm: PropTypes.func.isRequired,

--- a/src/components/DiceRollerModal.test.jsx
+++ b/src/components/DiceRollerModal.test.jsx
@@ -31,6 +31,7 @@ describe('DiceRollerModal', () => {
       equippedWeaponDamage: 'd8',
       rollModal: { isOpen: false, close: vi.fn() },
       rollModalData: {},
+      resolveAidOrInterfere: vi.fn(),
       aidModal: { isOpen: false, onConfirm: vi.fn(), onCancel: vi.fn() },
     };
   });
@@ -87,6 +88,15 @@ describe('DiceRollerModal', () => {
     render(<DiceRollerModal {...mockProps} />);
 
     expect(screen.getByText('Roll result: 12')).toBeInTheDocument();
+  });
+
+  it('calls resolveAidOrInterfere when button is clicked', () => {
+    render(<DiceRollerModal {...mockProps} />);
+
+    const button = screen.getByRole('button', { name: 'Apply Aid/Interfere' });
+    fireEvent.click(button);
+
+    expect(mockProps.resolveAidOrInterfere).toHaveBeenCalledTimes(1);
   });
 
   it('displays roll history', () => {

--- a/src/hooks/useDiceRoller.help.test.jsx
+++ b/src/hooks/useDiceRoller.help.test.jsx
@@ -40,9 +40,12 @@ describe('useDiceRoller help modal cleanup', () => {
       wrapper,
     });
 
-    let rollPromise;
     act(() => {
-      rollPromise = result.current.rollDice('2d6', 'test');
+      result.current.rollDice('2d6', 'test');
+    });
+    let resolvePromise;
+    act(() => {
+      resolvePromise = result.current.resolveAidOrInterfere();
     });
 
     expect(aidModal.isOpen).toBe(true);
@@ -51,7 +54,7 @@ describe('useDiceRoller help modal cleanup', () => {
       unmount();
     });
 
-    await rollPromise;
+    await resolvePromise;
 
     expect(aidModal.close).toHaveBeenCalledTimes(1);
     expect(aidModal.isOpen).toBe(false);

--- a/src/hooks/useDiceRoller.test.jsx
+++ b/src/hooks/useDiceRoller.test.jsx
@@ -39,10 +39,7 @@ describe('useDiceRoller contexts', () => {
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter), { wrapper });
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999);
     await act(async () => {
-      const p = result.current.rollDice('2d6', desc);
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', desc);
     });
     randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe(expected);
@@ -54,10 +51,7 @@ describe('useDiceRoller contexts', () => {
     const randomSpy = vi.spyOn(Math, 'random');
     randomSpy.mockReturnValueOnce(0.35).mockReturnValueOnce(0.55);
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'HaCk');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', 'HaCk');
     });
     randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('Hit them, but they hit you back!');
@@ -69,10 +63,7 @@ describe('useDiceRoller contexts', () => {
     const randomSpy = vi.spyOn(Math, 'random');
     randomSpy.mockReturnValueOnce(0.35).mockReturnValueOnce(0.55);
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'upper hand');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', 'upper hand');
     });
     randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('Deal damage, but lose the upper hand!');
@@ -83,10 +74,7 @@ describe('useDiceRoller contexts', () => {
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter), { wrapper });
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'taunt');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', 'taunt');
     });
     randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('They ignore you completely');
@@ -97,10 +85,7 @@ describe('useDiceRoller contexts', () => {
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter), { wrapper });
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'upper hand');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', 'upper hand');
     });
     randomSpy.mockRestore();
     expect(result.current.rollModalData.context).toBe('Upper hand slips away completely!');
@@ -111,10 +96,7 @@ describe('useDiceRoller contexts', () => {
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter), { wrapper });
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     await act(async () => {
-      const p = result.current.rollDice('d4', 'test');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('d4', 'test');
     });
     randomSpy.mockRestore();
     expect(result.current.rollResult).toBe('d4: 1 = 1');
@@ -125,10 +107,7 @@ describe('useDiceRoller contexts', () => {
     const { result } = renderHook(() => useDiceRoller(baseCharacter, setCharacter), { wrapper });
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999);
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'Upper Hand');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', 'Upper Hand');
     });
     randomSpy.mockRestore();
     expect(result.current.rollModalData.description).toBe('Upper Hand');
@@ -152,7 +131,10 @@ describe('useDiceRoller aid/interfere', () => {
       wrapper,
     });
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'test');
+      await result.current.rollDice('2d6', 'test');
+    });
+    await act(async () => {
+      const p = result.current.resolveAidOrInterfere();
       await Promise.resolve();
       result.current.aidModal.onConfirm({ action: 'aid', bond: 2 });
       await p;
@@ -180,7 +162,10 @@ describe('useDiceRoller aid/interfere', () => {
       { wrapper },
     );
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'test');
+      await result.current.rollDice('2d6', 'test');
+    });
+    await act(async () => {
+      const p = result.current.resolveAidOrInterfere();
       await Promise.resolve();
       result.current.aidModal.onConfirm({ action: 'aid', bond: 2 });
       await p;
@@ -225,19 +210,13 @@ describe('useDiceRoller mixed-case status modifiers', () => {
 
     randomSpy.mockReturnValueOnce(0.4).mockReturnValueOnce(0.4);
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'dEx test');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', 'dEx test');
     });
     expect(result.current.rollModalData.result).toMatch(/Shocked \(-2 DEX\)/);
 
     randomSpy.mockReturnValueOnce(0.25);
     await act(async () => {
-      const p = result.current.rollDice('d4', 'DaMaGe roll');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('d4', 'DaMaGe roll');
     });
     randomSpy.mockRestore();
     expect(result.current.rollModalData.result).toMatch(/Weakened \(-1 damage\)/);
@@ -288,10 +267,7 @@ describe('useDiceRoller XP on miss handling', () => {
     });
     const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     await act(async () => {
-      const p = result.current.rollDice('2d6', 'test');
-      await Promise.resolve();
-      result.current.aidModal.onCancel();
-      await p;
+      await result.current.rollDice('2d6', 'test');
     });
     randomSpy.mockRestore();
     expect(setCharacter).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- remove automatic Aid/Interfere logic from dice roller hook
- add Apply Aid/Interfere button to dice roller modal
- update dice roller tests for manual Aid/Interfere interaction

## Testing
- `npm run lint`
- `npm test` *(fails: Theme switching > updates the theme attribute when selecting arwes)*
- `npm run format:check`
- `npm run test:e2e` *(fails: version mismatched Tauri packages)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc948da5883328eb97a6f4791df60