### PR TITLE
feat: derive load capacity from class base load

### DIFF
--- a/src/components/InventoryPanel.test.jsx
+++ b/src/components/InventoryPanel.test.jsx
@@ -6,6 +6,8 @@ import InventoryPanel from './InventoryPanel.jsx';
 
 const characterTemplate = {
   inventory: [],
+  baseLoad: 0,
+  stats: { STR: { mod: 0 } },
 };
 
 function setup(custom = {}) {
@@ -27,7 +29,7 @@ function setup(custom = {}) {
 describe('InventoryPanel', () => {
   it('calls setShowAddItemModal when Add Item clicked', async () => {
     const user = userEvent.setup();
-    const { setShowAddItemModal } = setup({ inventory: [], maxLoad: 12 });
+    const { setShowAddItemModal } = setup({ inventory: [], baseLoad: 12 });
     await user.click(screen.getByText(/add item/i));
     expect(setShowAddItemModal).toHaveBeenCalledWith(true);
   });

--- a/src/data/classData.js
+++ b/src/data/classData.js
@@ -1,0 +1,13 @@
+export const CLASS_DATA = {
+  Barbarian: { baseLoad: 8 },
+  Bard: { baseLoad: 9 },
+  Cleric: { baseLoad: 10 },
+  Druid: { baseLoad: 6 },
+  Fighter: { baseLoad: 12 },
+  Paladin: { baseLoad: 12 },
+  Ranger: { baseLoad: 11 },
+  Thief: { baseLoad: 9 },
+  Wizard: { baseLoad: 7 },
+};
+
+export default CLASS_DATA;

--- a/src/hooks/useInventory.js
+++ b/src/hooks/useInventory.js
@@ -122,7 +122,7 @@ export default function useInventory(character, setCharacter) {
     [setCharacter],
   );
 
-  const maxLoad = character.maxLoad ?? 12;
+  const maxLoad = (character.baseLoad || 0) + (character.stats?.STR?.mod || 0);
 
   return {
     totalArmor,

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -13,6 +13,7 @@ import {
   FaBrain,
   FaFaceFrownOpen,
 } from 'react-icons/fa6';
+import { CLASS_DATA } from '../data/classData.js';
 
 export const RULEBOOK = 'Dungeon World';
 
@@ -27,6 +28,8 @@ export const INITIAL_CHARACTER_DATA = {
   armor: 0,
   secondaryResource: 0,
   maxSecondaryResource: 0,
+  class: 'Fighter',
+  baseLoad: CLASS_DATA.Fighter.baseLoad,
 
   // Attributes
   stats: {


### PR DESCRIPTION
## Summary
- add per-class base loads and track class on character
- compute max load from base load plus STR modifier
- update inventory tests for new load calculation

## Testing
- `npm test` *(fails: TestingLibraryElementError, Theme switching assertion, AddItemModal assertion)*
- `npm run lint`
- `npm run format:check`
- `npm run test:e2e` *(fails: Hook timed out, missing WebKitWebDriver, version mismatches)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc94cd3288332ad66ed170d918dbc