### PR TITLE
feat: add alignment field and editing

### DIFF
--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -29,6 +29,18 @@ const CharacterStats = ({
       transition={transition}
     >
       <h3 className={styles.title}>⚡ Stats &amp; Health</h3>
+      <div className={styles.alignmentRow}>
+        <label htmlFor="alignment-input" className={styles.alignmentLabel}>
+          Alignment/Drive:
+        </label>
+        <input
+          id="alignment-input"
+          type="text"
+          value={character.alignment ?? ''}
+          onChange={(e) => setCharacter((prev) => ({ ...prev, alignment: e.target.value }))}
+          className={styles.alignmentInput}
+        />
+      </div>
       <div className={styles.statsGrid}>
         {Object.entries(character.stats).map(([stat, data]) => (
           <div key={stat} className={styles.statItem}>
@@ -268,6 +280,7 @@ CharacterStats.propTypes = {
     xpNeeded: PropTypes.number.isRequired,
     level: PropTypes.number.isRequired,
     resources: PropTypes.object.isRequired,
+    alignment: PropTypes.string,
   }).isRequired,
   setCharacter: PropTypes.func.isRequired,
   saveToHistory: PropTypes.func.isRequired,

--- a/src/components/CharacterStats.module.css
+++ b/src/components/CharacterStats.module.css
@@ -43,6 +43,19 @@
   color: var(--color-accent);
 }
 
+.alignmentRow {
+  margin-bottom: var(--space-md);
+}
+
+.alignmentLabel {
+  font-weight: bold;
+  margin-right: var(--space-sm);
+}
+
+.alignmentInput {
+  width: 100%;
+}
+
 .hpBarContainer {
   width: 100%;
   height: 25px;

--- a/src/components/CharacterStats.test.jsx
+++ b/src/components/CharacterStats.test.jsx
@@ -18,6 +18,7 @@ function makeCharacter(overrides = {}) {
     xpNeeded: 10,
     level: 1,
     levelUpPending: false,
+    alignment: 'Neutral',
     resources: {
       chronoUses: 0,
       paradoxPoints: 0,
@@ -102,5 +103,18 @@ describe('CharacterStats', () => {
     updateFn = setCharacter.mock.calls[setCharacter.mock.calls.length - 1][0];
     state = updateFn(state);
     expect(state.resources.chronoUses).toBe(0);
+  });
+
+  it('updates alignment when edited', async () => {
+    const user = userEvent.setup();
+    const setCharacter = vi.fn();
+    const character = makeCharacter({ alignment: 'Neutral' });
+    renderComponent({ character, setCharacter });
+
+    const input = screen.getByLabelText(/alignment\/drive/i);
+    await user.clear(input);
+    await user.type(input, 'Chaotic');
+
+    expect(setCharacter).toHaveBeenCalled();
   });
 });

--- a/src/components/EndSessionModal.jsx
+++ b/src/components/EndSessionModal.jsx
@@ -147,7 +147,9 @@ export default function EndSessionModal({ isOpen, onClose }) {
                   checked={answers.alignment}
                   onChange={() => toggleAnswer('alignment')}
                 />{' '}
-                Did you fulfill your alignment/drive?
+                {`Did you fulfill your alignment/drive${
+                  character.alignment ? ` (${character.alignment})` : ''
+                }?`}
               </label>
             </div>
 

--- a/src/components/EndSessionModal.test.jsx
+++ b/src/components/EndSessionModal.test.jsx
@@ -80,6 +80,23 @@ describe('EndSessionModal', () => {
     });
   });
 
+  it('shows stored alignment in the checkbox label', () => {
+    const onClose = vi.fn();
+    const initial = {
+      xp: 0,
+      level: 1,
+      xpNeeded: 8,
+      bonds: [],
+      inventory: [],
+      resources: {},
+      statusEffects: [],
+      debilities: [],
+      alignment: 'Protect the timeline',
+    };
+    renderWithCharacter(<EndSessionModal isOpen onClose={onClose} />, initial);
+    expect(screen.getByLabelText(/Protect the timeline/i)).toBeInTheDocument();
+  });
+
   it('uses xpNeeded to trigger level up', async () => {
     const user = userEvent.setup();
     const onLevelUp = vi.fn();

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -27,6 +27,7 @@ export const INITIAL_CHARACTER_DATA = {
   armor: 0,
   secondaryResource: 0,
   maxSecondaryResource: 0,
+  alignment: 'Protect the timeline from paradoxes',
 
   // Attributes
   stats: {


### PR DESCRIPTION
## Summary
- track character alignment in initial state
- edit and display alignment in stats panel
- show stored alignment during end of session

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test` *(fails: Command palette test, AddItemModal test, and others)*
- `npx vitest run src/components/CharacterStats.test.jsx`
- `npm run test:e2e` *(fails: cannot find WebKitWebDriver; Tauri package mismatch)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc951428883328e5b491783d9f707