### PR TITLE
feat: add spell management panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import EquipmentPanel from './components/EquipmentPanel';
 import FloatingDiceButton from './components/FloatingDiceButton';
 import GameModals from './components/GameModals';
 import InventoryPanel from './components/InventoryPanel';
+import SpellsPanel from './components/SpellsPanel';
 import PrintableSheet from './components/PrintableSheet.jsx';
 import SessionNotes from './components/SessionNotes';
 import Settings from './components/Settings';
@@ -449,6 +450,15 @@ function App() {
           {/* Equipment Panel */}
           <div className={`${styles.tile} ${styles.equipment}`}>
             <EquipmentPanel character={character} setCharacter={setCharacter} />
+          </div>
+
+          {/* Spells Panel */}
+          <div className={`${styles.tile} ${styles.spells}`}>
+            <SpellsPanel
+              character={character}
+              setCharacter={setCharacter}
+              saveToHistory={saveToHistory}
+            />
           </div>
 
           {/* Inventory Panel */}

--- a/src/components/CharacterStats.jsx
+++ b/src/components/CharacterStats.jsx
@@ -247,6 +247,7 @@ const CharacterStats = ({
               rations: 5,
               advGear: 5,
             },
+            spells: prev.spells.map((s) => ({ ...s, expended: false })),
           }));
           setSessionNotes('');
           clearRollHistory();

--- a/src/components/CharacterStats.test.jsx
+++ b/src/components/CharacterStats.test.jsx
@@ -25,6 +25,7 @@ function makeCharacter(overrides = {}) {
       rations: 1,
       advGear: 1,
     },
+    spells: [],
     ...overrides,
   };
 }

--- a/src/components/LevelUpModal.jsx
+++ b/src/components/LevelUpModal.jsx
@@ -149,6 +149,7 @@ const LevelUpModal = ({
       xpNeeded: levelUpState.newLevel + 7,
       selectedMoves: [...prev.selectedMoves, levelUpState.selectedMove],
       levelUpPending: false,
+      spells: prev.spells.map((s) => ({ ...s, expended: false })),
       actionHistory: [
         ...prev.actionHistory.slice(-4), // Keep last 4 actions
         {

--- a/src/components/LevelUpModal.test.jsx
+++ b/src/components/LevelUpModal.test.jsx
@@ -26,6 +26,7 @@ describe('LevelUpModal advanced moves', () => {
         CHA: { score: 10, mod: 0 },
       },
       selectedMoves: [],
+      spells: [],
     };
 
     const levelUpState = {
@@ -72,6 +73,7 @@ describe('LevelUpModal XP calculation', () => {
       selectedMoves: [],
       actionHistory: [],
       levelUpPending: true,
+      spells: [],
     };
 
     const levelUpState = {
@@ -125,6 +127,7 @@ describe('LevelUpModal stat modifier', () => {
       selectedMoves: [],
       actionHistory: [],
       levelUpPending: true,
+      spells: [],
     };
 
     const levelUpState = {
@@ -270,6 +273,7 @@ describe('LevelUpModal visibility and closing', () => {
       xpNeeded: 8,
       resources: { chronoUses: 0 },
       selectedMoves: [],
+      spells: [],
     };
 
     const levelUpState = {

--- a/src/components/SpellsPanel.jsx
+++ b/src/components/SpellsPanel.jsx
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { FaWandMagicSparkles } from 'react-icons/fa6';
+import Panel from './ui/Panel';
+
+function SpellsPanel({ character, setCharacter, saveToHistory }) {
+  const togglePrepared = (id) => {
+    saveToHistory('Spell Preparation');
+    setCharacter((prev) => ({
+      ...prev,
+      spells: prev.spells.map((s) => (s.id === id ? { ...s, prepared: !s.prepared } : s)),
+    }));
+  };
+
+  const castSpell = (id) => {
+    saveToHistory('Cast Spell');
+    setCharacter((prev) => ({
+      ...prev,
+      spells: prev.spells.map((s) => (s.id === id ? { ...s, expended: true } : s)),
+    }));
+  };
+
+  return (
+    <Panel>
+      <h3
+        style={{
+          color: 'var(--color-accent)',
+          marginBottom: 'var(--space-md)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          fontSize: '1.125rem',
+        }}
+      >
+        <FaWandMagicSparkles /> Spells
+      </h3>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+        {character.spells.map((spell) => (
+          <li
+            key={spell.id}
+            style={{
+              borderLeft: '4px solid var(--color-accent)',
+              padding: 'var(--space-sm)',
+              marginBottom: 'var(--space-sm)',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <label>
+              <input
+                type="checkbox"
+                checked={spell.prepared}
+                onChange={() => togglePrepared(spell.id)}
+              />{' '}
+              {spell.name}
+            </label>
+            <button
+              onClick={() => castSpell(spell.id)}
+              disabled={!spell.prepared || spell.expended}
+            >
+              {spell.expended ? 'Expended' : 'Cast'}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}
+
+SpellsPanel.propTypes = {
+  character: PropTypes.shape({
+    spells: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired,
+        prepared: PropTypes.bool.isRequired,
+        expended: PropTypes.bool.isRequired,
+      }),
+    ).isRequired,
+  }).isRequired,
+  setCharacter: PropTypes.func.isRequired,
+  saveToHistory: PropTypes.func.isRequired,
+};
+
+export default SpellsPanel;

--- a/src/components/SpellsPanel.test.jsx
+++ b/src/components/SpellsPanel.test.jsx
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { vi } from 'vitest';
+import SpellsPanel from './SpellsPanel';
+
+function makeCharacter(overrides = {}) {
+  return {
+    spells: [{ id: 1, name: 'Fireball', prepared: false, expended: false }],
+    ...overrides,
+  };
+}
+
+describe('SpellsPanel', () => {
+  it('toggles preparation', async () => {
+    const user = userEvent.setup();
+    const setCharacter = vi.fn();
+    render(
+      <SpellsPanel
+        character={makeCharacter()}
+        setCharacter={setCharacter}
+        saveToHistory={vi.fn()}
+      />,
+    );
+    const checkbox = screen.getByLabelText('Fireball');
+    await user.click(checkbox);
+    const updateFn = setCharacter.mock.calls[0][0];
+    const state = updateFn(makeCharacter());
+    expect(state.spells[0].prepared).toBe(true);
+  });
+
+  it('casts a prepared spell', async () => {
+    const user = userEvent.setup();
+    const setCharacter = vi.fn();
+    const character = makeCharacter({
+      spells: [{ id: 1, name: 'Fireball', prepared: true, expended: false }],
+    });
+    render(
+      <SpellsPanel character={character} setCharacter={setCharacter} saveToHistory={vi.fn()} />,
+    );
+    const button = screen.getByRole('button', { name: 'Cast' });
+    await user.click(button);
+    const updateFn = setCharacter.mock.calls[0][0];
+    const state = updateFn(character);
+    expect(state.spells[0].expended).toBe(true);
+  });
+
+  it('disables cast when not prepared', () => {
+    const setCharacter = vi.fn();
+    render(
+      <SpellsPanel
+        character={makeCharacter()}
+        setCharacter={setCharacter}
+        saveToHistory={vi.fn()}
+      />,
+    );
+    const button = screen.getByRole('button', { name: 'Cast' });
+    expect(button).toBeDisabled();
+  });
+});

--- a/src/state/character.js
+++ b/src/state/character.js
@@ -48,6 +48,12 @@ export const INITIAL_CHARACTER_DATA = {
     advGear: 5, // Rope, torches, chalk, etc.
   },
 
+  // Spells
+  spells: [
+    { id: 1, name: 'Magic Missile', prepared: false, expended: false },
+    { id: 2, name: 'Fireball', prepared: false, expended: false },
+  ],
+
   // Character Relationships
   bonds: [
     { name: 'Sar', relationship: 'I will teach Sar about the future', resolved: false },

--- a/src/styles/AppStyles.module.css
+++ b/src/styles/AppStyles.module.css
@@ -408,9 +408,10 @@
   display: grid;
   grid-template-areas:
     'hud stats equipment'
+    'hud spells inventory'
     'hud notes inventory';
   grid-template-columns: 320px 1fr 320px;
-  grid-template-rows: auto auto;
+  grid-template-rows: auto auto auto;
   gap: var(--hud-spacing);
   margin-bottom: var(--hud-spacing);
 }
@@ -444,6 +445,14 @@
   grid-area: equipment;
 }
 
+.spells {
+  grid-area: spells;
+}
+
+.spells:hover {
+  transform: translateY(-1px);
+}
+
 .inventory:hover {
   transform: translateY(-1px);
 }
@@ -460,10 +469,11 @@
   .grid {
     grid-template-areas:
       'hud stats'
-      'equipment inventory'
+      'spells equipment'
+      'inventory inventory'
       'notes notes';
     grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto auto auto;
+    grid-template-rows: auto auto auto auto;
   }
 }
 
@@ -473,10 +483,11 @@
       'hud'
       'stats'
       'equipment'
+      'spells'
       'inventory'
       'notes';
     grid-template-columns: 1fr;
-    grid-template-rows: repeat(5, auto);
+    grid-template-rows: repeat(6, auto);
   }
 }
 


### PR DESCRIPTION
## Summary
- track spell preparation and expended status in character state
- add spells panel to manage and cast spells
- reset spell slots on rest and level-up

## Testing
- `npm run lint`
- `npm test` *(fails: multiple existing tests fail)*
- `npm run format:check`
- `npm run test:e2e` *(fails: missing WebKitWebDriver)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abc95cb3c083329b37009885ea8a7e